### PR TITLE
Default `nodes' invocation for Algo path finders

### DIFF
--- a/lib/neo4j/algo/algo.rb
+++ b/lib/neo4j/algo/algo.rb
@@ -162,14 +162,14 @@ module Neo4j
       self
     end
 
-    # Specifies that nodes should be returned from as result (this is default)
+    # Specifies that nodes should be returned from as result
     # See also #rels
     def nodes
       @path_finder_method = :nodes
       self
     end
 
-    # Specifies that relationships should be returned from as result (this is default)
+    # Specifies that relationships should be returned from as result
     # See also #nodes
     #
     def rels
@@ -184,8 +184,8 @@ module Neo4j
     end
 
     def each(&block) #:nodoc:
-      if @single
-        execute_algo.send(@path_finder_method || :nodes).each &block
+      if @single && @path_finder_method
+        execute_algo.send(@path_finder_method).each &block
       else
         execute_algo.each &block
       end


### PR DESCRIPTION
Hi,
I've been working with neo4j.rb for a couple days, and I found that the behavior of single-path finders in Algo is different from that of the corresponding all-path finders.

For example, Neo4j::Algo.shortest_path allows me to iterate through only the nodes in the path, while with each path of Neo4j::Algo.shortest_paths I can iterate through both nodes and relationships. This was a surprise to me.

So I found in Algo#each, that `nodes` method is internally invoked by default, and judging from the comments there, it seems that you intended it. Is there any particular reason you did so? I believe `nodes` invocation should become optional, so that a user can explicitly choose how he/she should iterate through the result. (3 choices. Nodes and relationships, or just nodes, or just relationships)

This patch might break applications already built upon the assumption that single-path finders return iterators only for nodes. But IMO it's an invalid assumption.

Thanks,
Junegunn Choi.
