### PR TITLE
A suggestion on NodeMixin interface

### DIFF
--- a/lib/neo4j/property/class_methods.rb
+++ b/lib/neo4j/property/class_methods.rb
@@ -40,18 +40,14 @@ module Neo4j
       # :to_java in the Neo4j::TypeConverters module.
       #
       def property(*props)
-        if props.size == 2 and props[1].kind_of?(Hash)
-          props[1].each_pair do |key, value|
-            pname = props[0].to_sym
-            _decl_props[pname] ||= {}
-            _decl_props[pname][key] = value
-          end
-          props = props[0..0]
-        end
+        options = props.last.kind_of?(Hash) ? props.pop : {}
 
-        props.each do |prop|
+        props.uniq.each do |prop|
           pname = prop.to_sym
           _decl_props[pname] ||= {}
+          options.each do |key, value|
+            _decl_props[pname][key] = value
+          end
 
           define_method(pname) do
             Neo4j::TypeConverters.to_ruby(self.class, pname, self[pname])

--- a/spec/node_mixin/node_mixin_find_spec.rb
+++ b/spec/node_mixin/node_mixin_find_spec.rb
@@ -7,7 +7,9 @@ describe Neo4j::NodeMixin, "find", :type => :transactional do
     before(:all) do
       @clazz = create_node_mixin do
         property :year, :type => Fixnum
+        property :month, :day, :type => Fixnum
         index :year
+        index :month, :day
         def to_s
           "Year #{year}"
         end
@@ -15,11 +17,11 @@ describe Neo4j::NodeMixin, "find", :type => :transactional do
     end
 
     before(:each) do
-      @x49 = @clazz.new(:year => 49)
-      @x50 = @clazz.new(:year => 50)
-      @x51 = @clazz.new(:year => 51)
-      @x52 = @clazz.new(:year => 52)
-      @x53 = @clazz.new(:year => 53)
+      @x49 = @clazz.new(:year => 49, :month => 1, :day => 11)
+      @x50 = @clazz.new(:year => 50, :month => 2, :day => 12)
+      @x51 = @clazz.new(:year => 51, :month => 3, :day => 13)
+      @x52 = @clazz.new(:year => 52, :month => 4, :day => 14)
+      @x53 = @clazz.new(:year => 53, :month => 5, :day => 15)
       new_tx
     end
 
@@ -35,8 +37,14 @@ describe Neo4j::NodeMixin, "find", :type => :transactional do
       res.should include(@x50,@x51,@x52)
     end
 
-    it "find(:year => 50..52) returns all integer between 50 and 51" do
+    it "find(:year => 50...52) returns all integer between 50 and 51" do
       res = [*@clazz.find(:year=> 50...52)]
+      res.should include(@x50,@x51)
+      res.should_not include(@x49,@x52,@x53)
+    end
+    
+    it "find(:month=> 2..5, :day => 11...14) finds nodes matching both conditions" do
+      res = [*@clazz.find(:month=> 2..5, :day => 11...14)]
       res.should include(@x50,@x51)
       res.should_not include(@x49,@x52,@x53)
     end

--- a/spec/node_mixin/node_mixin_spec.rb
+++ b/spec/node_mixin/node_mixin_spec.rb
@@ -11,14 +11,19 @@ describe Neo4j::NodeMixin, "inheritance", :type=> :transactional do
     end
 
     @employee_class = create_node_mixin_subclass(person_class) do
-      property :employee_id
+      property :employee_id, :ssn
+      property :weight, :height, :type => Float
       has_n :contracts
     end
   end
 
   it "#new creates node and set properties with given hash" do
-    empl = @employee_class.new(:name => 'andreas', :employee_id => 123)
+    empl = @employee_class.new(:name => 'andreas', :employee_id => 123, :ssn => 1000, :height => '6.3')
+
     empl[:name].should == 'andreas'
+    empl.ssn == 1000
+    empl.height.class.should == Float
+    empl.height.should == 6.3
   end
 
   it "#has_n can use baseclass definition" do


### PR DESCRIPTION
Hi,
I think it would be more convenient if two NodeMixin class methods, property and index                                                                                 take arbitrary number of symbols followed by an optional hash.
Then we could write as follows,

``` ruby
  class Person
    include Neo4j::NodeMixin

    property :name, :address, :email, :type => String
    property :height, :weight, :type => Float
    index :name, :address, :type => :fulltext
    index :height, :weight
  end
```

This should feel natural to most Ruby developers.
I made changes to the both methods and spec files were extended accordingly.
The change is backward compatible.
So, what do you think? Please pull this patch if you think it's appropriate.
Thanks!
