### PR TITLE
Fix for a bug, where you where not able to create array properties on relationships

### DIFF
--- a/lib/neo4j/relationship_mixin/relationship_mixin.rb
+++ b/lib/neo4j/relationship_mixin/relationship_mixin.rb
@@ -45,7 +45,7 @@ module Neo4j
       type, from_node, to_node, props = args
       self[:_classname] = self.class.to_s
       if props.respond_to?(:each_pair)
-        props.each_pair { |k, v| @_java_rel.set_property(k.to_s, v) }
+        props.each_pair { |k, v| respond_to?("#{k}=") ? self.send("#{k}=", v) : @_java_rel[k] = v }
       end
     end
 

--- a/spec/relationship_mixin/relationship_mixin_spec.rb
+++ b/spec/relationship_mixin/relationship_mixin_spec.rb
@@ -24,14 +24,14 @@ describe Neo4j::RelationshipMixin, :type=> :transactional do
     b = Neo4j::Node.new
 
     # when
-    Friend.new(:friend, a,b, :age => 2, :colour => 'blue')
+    Friend.new(:friend, a,b, :age => 2, :colour => 'blue', :facebook_ids => [1,2,3])
 
     # then
     rel = a.rels(:friend).outgoing.first
     rel[:age].should == 2
     rel[:colour].should == 'blue'
+    rel[:facebook_ids] = [1,2,3]
   end
-
 
   it "can set properties with the []= operator and read it with the [] operator" do
     a = Neo4j::Node.new


### PR DESCRIPTION
This pull request contains a fix that enables users to create array properties in relationships, also include tests for that. 

Prior to that neo4jrb gets confused when you want to create a new array property into a relationship, something that was already resolved in nodes, but still missing in edges.

/purbon
