### PR TITLE
recursive rule to be applied to the top class 

### DIFF
--- a/lib/neo4j/rule/rule.rb
+++ b/lib/neo4j/rule/rule.rb
@@ -119,11 +119,18 @@ module Neo4j
           rule_node.execute_rules(node, *changes)
 
           # recursively add relationships for all the parent classes with rules that also pass for this node
-          if (clazz = eval("#{classname}.superclass")) && clazz.include?(Neo4j::NodeMixin)
-            rule_node = rule_node_for(clazz)
-            rule_node && rule_node.execute_rules(node, *changes)
-          end
+          recursive(node,classname,*changes)
         end
+
+        private 
+
+          def recursive(node,classname,*changes)
+            if (clazz = eval("#{classname}.superclass")) && clazz.include?(Neo4j::NodeMixin)
+              rule_node = rule_node_for(clazz)
+              rule_node && rule_node.execute_rules(node, *changes)
+              recursive(node,clazz.name,*changes)
+            end
+          end
       end
     end
   end


### PR DESCRIPTION
Hello, 

I have had a problem with the 1.1.1 version.  When I have more than two inheritance levels, the rule is not applied to that levels.  I have found that the recursivity is not really implemented after the parent class.

Best regards

Frédéric   
