### PR TITLE
column_names method on neo4j orm adapter throws NoMethodError

### DIFF
--- a/lib/orm_adapter/adapters/neo4j.rb
+++ b/lib/orm_adapter/adapters/neo4j.rb
@@ -20,7 +20,7 @@ module Neo4j
 		
 				# get a list of column names for a given class
 				def column_names
-					klass.props.keys
+					klass._decl_props.keys
 				end
 		
 				# Get an instance by id of the model

--- a/spec/orm_adapter/example_app_shared.rb
+++ b/spec/orm_adapter/example_app_shared.rb
@@ -141,5 +141,11 @@ shared_examples_for "example app with orm_adapter" do
         reload_model(user).notes.should == notes
       end
     end
+
+    describe "#column_names" do
+      it "should include declared property names" do
+          user_adapter.column_names.should include(:name)
+      end
+    end
   end
 end


### PR DESCRIPTION
The column_names method assumes props is a class method on model. This results in NoMethodError as shown below

``` log
NoMethodError: undefined method `props' for User:Class
    neo4j-1.2.0 (java) lib/orm_adapter/adapters/neo4j.rb:23:in `column_names'
```

I have fixed this issue by changing column_names method to return only the declared properties, as it cannot be aware of custom properties on instance of the model. I have added a spec for the same.

PS: There was a date/time related spec in the trunk/master prior to this change.

``` log
Failures:

  1) DateProperties update_attributes with Time
     Failure/Error: subject.time.day.should == 5
       expected: 5
            got: 4 (using ==)
     # org/jruby/RubyProc.java:268:in `call'
     # ./spec/rails/property_spec.rb:308:in `(root)'
     # org/jruby/RubyKernel.java:2061:in `instance_eval'
```
