### PR TITLE
Added finders similar to active record and mongoid

### DIFF
--- a/lib/neo4j/rails/model.rb
+++ b/lib/neo4j/rails/model.rb
@@ -29,6 +29,7 @@ module Neo4j
         reset_attributes
         clear_relationships
         self.attributes = attributes if attributes.is_a?(Hash)
+        yield self if block_given?
       end
 
       def id
@@ -86,7 +87,7 @@ module Neo4j
         def entity_load(id)
           Neo4j::Node.load(id)
         end
-        
+
         ##
         # Determines whether to use Time.local (using :local) or Time.utc (using :utc) when pulling
         # dates and times from the database. This is set to :local by default.


### PR DESCRIPTION
This commit has 4 new methods.
- find! : This is to similar active record `find`, which raises `RecordNotFoundError` if record does not exist. This is a very helpful to dry up controller code in rails apps. One can use generic `recue_from` block in ApplicationController to return 404 when this exception is raised.
- find_or_create_by, find_or_create_by! and find_or_initialize_by: These are few more finders avilable in active record and mongoid.

Most of code has been shamelessly copied from mongoid code and modified to suit the neo4j.
