### PR TITLE
Override ActiveModel i18n_scope for neo4j

### DIFF
--- a/lib/neo4j/rails/model.rb
+++ b/lib/neo4j/rails/model.rb
@@ -86,7 +86,7 @@ module Neo4j
         def entity_load(id)
           Neo4j::Node.load(id)
         end
-        
+
         ##
         # Determines whether to use Time.local (using :local) or Time.utc (using :utc) when pulling
         # dates and times from the database. This is set to :local by default.
@@ -126,6 +126,13 @@ module Neo4j
             end
 
           end
+        end
+
+        # Set the i18n scope to overwrite ActiveModel.
+        #
+        # @return [ Symbol ] :neo4j
+        def i18n_scope
+          :neo4j
         end
       end
     end

--- a/spec/rails/model_spec.rb
+++ b/spec/rails/model_spec.rb
@@ -478,8 +478,10 @@ describe Neo4j::Model do
       item.reload
       item.orders.should include(order)
     end
-
   end
 
-
+  describe "i18n_scope" do
+    subject { Neo4j::Rails::Model.i18n_scope }
+    it { should == :neo4j }
+  end
 end


### PR DESCRIPTION
ActiveModel orms like active_record and mongoid have specific i18n_scope. This will be useful when using multiple orms in same app.
