### PR TITLE
Fix to allow has_one relationships to handle nil assignments in models

### DIFF
--- a/lib/neo4j/rails/rel_persistence.rb
+++ b/lib/neo4j/rails/rel_persistence.rb
@@ -149,16 +149,18 @@ module Neo4j
       end
 
       def create()
-        # prevent calling create twice
-        @start_node.rm_outgoing_rel(type, self)
-        @end_node.rm_incoming_rel(type, self)
+        begin
+          # prevent calling create twice
+          @start_node.rm_outgoing_rel(type, self)
+          @end_node.rm_incoming_rel(type, self)
 
-        _persist_start_node
-        _persist_end_node
+          _persist_start_node
+          _persist_end_node
 
-        @_java_rel = Neo4j::Relationship.new(type, start_node, end_node)
-        init_on_create
-        clear_changes
+          @_java_rel = Neo4j::Relationship.new(type, start_node, end_node)
+          init_on_create
+          clear_changes
+        end unless @end_node.nil?
         true
       end
 

--- a/lib/neo4j/rails/relationships/storage.rb
+++ b/lib/neo4j/rails/relationships/storage.rb
@@ -141,7 +141,7 @@ module Neo4j
           @incoming_rels.clear
 
           out_rels.each do |rel|
-            rel.end_node.rm_incoming_rel(@rel_type.to_sym, rel)
+            rel.end_node.rm_incoming_rel(@rel_type.to_sym, rel) if rel.end_node
             success = rel.persisted? || rel.save
             # don't think this can happen - just in case, TODO
             raise "Can't save outgoing #{rel}, validation errors ? #{rel.errors.inspect}" unless success

--- a/spec/rails/relationship_spec.rb
+++ b/spec/rails/relationship_spec.rb
@@ -225,6 +225,23 @@ describe "Neo4j::Model Relationships" do
       member.save
       member.avatar.id.should_not be_nil
     end
+    
+    it "has_one should allow assignments to nil" do
+      member = Member.new
+      member.avatar = nil
+      member.avatar.should be_nil
+      member.save
+      member.reload.avatar.should be_nil
+    end 
+
+    it "has_one should allow changing a value to nil from a non nil value" do
+      member = Member.new
+      member.avatar = Avatar.new
+      member.save
+      member.reload.avatar = nil
+      member.save
+      member.reload.avatar.should be_nil
+    end 
 
     it "adding nodes to a has_n method created with the #new method" do
       icecream = IceCream.new


### PR DESCRIPTION
Hi Andreas,

Here's a patch that allows has_one relationships to handle nil assignments in models. I've added a couple of tests to the relationship_spec.

This allows the following code to work:

member = Member.find(member_id)
member.avatar = nil
member.save

Thanks!
