### PR TITLE
Fixing pending specs in orm adapter, added setter for has_n associations 

### DIFF
--- a/lib/neo4j/rails/mapping/property.rb
+++ b/lib/neo4j/rails/mapping/property.rb
@@ -75,6 +75,16 @@ module Neo4j
               RUBY
             end
 
+            unless method_defined?("#{rel_type}=".to_sym)
+              class_eval <<-RUBY, __FILE__, __LINE__
+                def #{rel_type}=(nodes)
+                    self.#{rel_type}_rels.destroy_all
+                    association = self.#{rel_type}
+                    nodes.each { |node| association << node }
+                end
+              RUBY
+            end
+
             unless method_defined?("#{rel_type}_rels".to_sym)
               class_eval <<-RUBY, __FILE__, __LINE__
                 def #{rel_type}_rels

--- a/lib/neo4j/rails/persistence.rb
+++ b/lib/neo4j/rails/persistence.rb
@@ -204,9 +204,9 @@ module Neo4j
       end
 
       def _add_relationship(rel_type, node)
-        if respond_to?("#{rel_type}=")
+        if respond_to?("#{rel_type}_rel")
           send("#{rel_type}=", node)
-        elsif respond_to?("#{rel_type}")
+        elsif respond_to?("#{rel_type}_rels")
           has_n = send("#{rel_type}")
           has_n << node
         else
@@ -216,9 +216,9 @@ module Neo4j
 
       def _find_node(rel_type, id)
         return nil if id.nil?
-        if respond_to?("#{rel_type}=")
+        if respond_to?("#{rel_type}_rel")
           send("#{rel_type}")
-        elsif respond_to?("#{rel_type}")
+        elsif respond_to?("#{rel_type}_rels")
           has_n = send("#{rel_type}")
           has_n.find { |n| n.id == id }
         else

--- a/lib/orm_adapter/adapters/neo4j.rb
+++ b/lib/orm_adapter/adapters/neo4j.rb
@@ -4,50 +4,46 @@ module Neo4j
 	module Rails
 		class Model
 			extend ::OrmAdapter::ToAdapter
-  
+
 			class OrmAdapter < ::OrmAdapter::Base
-				NEO4J_REF_NODE_ID = 0
-				
 				# Do not consider these to be part of the class list
 				def self.except_classes
 					@@except_classes ||= []
 				end
-		
+
 				# Gets a list of the available models for this adapter
 				def self.model_classes
 					::Neo4j::Rails::Model.descendants.to_a.select{|k| !except_classes.include?(k.name)}
 				end
-		
+
 				# get a list of column names for a given class
 				def column_names
 					klass._decl_props.keys
 				end
-		
+
 				# Get an instance by id of the model
 				def get!(id)
-					get(id) || raise("Node not found")
+					klass.find!(wrap_key(id))
 				end
-		
+
 				# Get an instance by id of the model
 				def get(id)
-					id = wrap_key(id)
-					return nil if id.to_i == NEO4J_REF_NODE_ID # getting the ref_node in this way is not supported
-					klass.load(id)
+					klass.find(wrap_key(id))
 				end
-		
+
 				# Find the first instance matching conditions
 				def find_first(conditions)
 					klass.first(conditions)
 				end
-		
+
 				# Find all models matching conditions
 				def find_all(conditions)
 					klass.all(conditions)
 				end
-			
+
 				# Create a model using attributes
 				def create!(attributes)
-					klass.create(attributes)
+					klass.create!(attributes)
 				end
 			end
 		end

--- a/spec/orm_adapter/example_app_shared.rb
+++ b/spec/orm_adapter/example_app_shared.rb
@@ -47,6 +47,7 @@ shared_examples_for "example app with orm_adapter" do
   describe "adapter instance" do
     let(:note_adapter) { note_class.to_adapter }
     let(:user_adapter) { user_class.to_adapter }
+    let(:non_existent_id) { "99999999" }
     
     describe "#get!(id)" do
       it "should return the instance with id if it exists" do
@@ -60,7 +61,7 @@ shared_examples_for "example app with orm_adapter" do
       end
 
       it "should raise an error if there is no instance with that id" do
-        lambda { user_adapter.get!("non-exitent id") }.should raise_error
+        lambda { user_adapter.get!(non_existent_id) }.should raise_error
       end
     end
 
@@ -76,7 +77,7 @@ shared_examples_for "example app with orm_adapter" do
       end
 
       it "should return nil if there is no instance with that id" do
-        user_adapter.get("non-exitent id").should be_nil
+        user_adapter.get(non_existent_id).should be_nil
       end
     end
   
@@ -129,16 +130,16 @@ shared_examples_for "example app with orm_adapter" do
         lambda { user_adapter.create!(:user => create_model(note_class)) }.should raise_error
       end
       
-      pending "when attributes contain an associated object, should create a model with the attributes" do
+      it "when attributes contain an associated object, should create a model with the attributes" do
         user = create_model(user_class)
         note = note_adapter.create!(:owner => user)
         reload_model(note).owner.should == user
       end
       
-      pending "when attributes contain an has_many assoc, should create a model with the attributes" do
+      it "when attributes contain an has_many assoc, should create a model with the attributes" do
         notes = [create_model(note_class), create_model(note_class)]
         user = user_adapter.create!(:notes => notes)
-        reload_model(user).notes.should == notes
+        reload_model(user).notes.to_a.should == notes
       end
     end
 

--- a/spec/rails/relationship_spec.rb
+++ b/spec/rails/relationship_spec.rb
@@ -90,6 +90,42 @@ describe "Neo4j::Model Relationships" do
 
   end
 
+  describe "has_n generated setter" do
+    let(:sugar) { Ingredient.new :name => 'sugar'}
+    let(:brown_sugar) { Ingredient.new :name => 'brown sugar' }
+
+    context "when node is new" do
+      it "should create relations to associated nodes" do
+        icecream = IceCream.new
+
+        icecream.ingredients = [sugar, brown_sugar]
+
+        icecream.ingredients.to_a.should =~ [sugar, brown_sugar]
+      end
+    end
+
+    context "creating a node with associated nodes" do
+      it "should create relations to associated nodes" do
+        icecream = IceCream.create!(:flavour => "Yummy!", :ingredients => [sugar, brown_sugar])
+
+        icecream.ingredients.to_a.should =~ [sugar, brown_sugar]
+        icecream.reload.ingredients.to_a.should =~ [sugar, brown_sugar]
+      end
+    end
+
+    context "assinging associated nodes to node with existing associations" do
+      it "should delete old relations and create new relations to associated nodes" do
+        icecream = IceCream.create!(:flavour => "Yummy!", :ingredients => [brown_sugar])
+
+        icecream.ingredients = [sugar]
+
+        icecream.ingredients.to_a.should == [sugar]
+        icecream.save!
+        icecream.reload.ingredients.to_a.should == [sugar]
+      end
+    end
+  end
+
   describe "has_one, has_n, outgoing" do
     it "node.friends << MyModel.create; node.save! should work" do
       clazz = create_model
@@ -990,7 +1026,7 @@ describe "SettingRelationship" do
          member.update_attributes(:descriptions_attributes => {"0" => {:id => description.id, :title => "New title"}})
          member.errors.should_not be_present
        end
-       
+
        it "should allow delete_all" do
          description = Description.create!(:title => 'Title', :text => "First description")
          member = Member.create.tap do |member|


### PR DESCRIPTION
Fixing pending specs in orm adapter, added setter for has_n associations + using find instead of load in adapter

Using find and find! removes duplication and ensures it works well in multitenant system (Once multitenant fix : https://github.com/andreasronge/neo4j/pull/47  is merged )
