### PR TITLE
Fixed an issue with the threadlocal caching of the ref node in rule nodes

### DIFF
--- a/lib/neo4j/rule/rule_node.rb
+++ b/lib/neo4j/rule/rule_node.rb
@@ -15,6 +15,7 @@ module Neo4j
         @clazz = clazz
         @rules = []
         @rule_node_key = ("rule_" + clazz.to_s).to_sym
+        @ref_node_key = ("rule_ref_for_" + clazz.to_s).to_sym
       end
 
       def to_s
@@ -70,8 +71,8 @@ module Neo4j
       end
 
       def ref_node_changed?
-        if ref_node != Thread.current[:rule_cached_ref_node]
-          Thread.current[:rule_cached_ref_node] = ref_node
+        if ref_node != Thread.current[@ref_node_key]
+          Thread.current[@ref_node_key] = ref_node
           true
         else
           false

--- a/spec/rails/model_spec.rb
+++ b/spec/rails/model_spec.rb
@@ -230,6 +230,25 @@ describe Neo4j::Model do
       IceCream.all.size.should == 1
       IceCream.first.should == icecream_for_reference2
     end
+    
+    it "switching the reference node works for multiple entities" do
+      reference1 = ReferenceNode.create(:name => 'Ref1')
+      reference2 = ReferenceNode.create(:name => 'Ref2')
+      Neo4j.threadlocal_ref_node = reference1
+      icecream_for_reference1 = IceCream.create(:flavour => 'vanilla')
+      ingredient_for_reference_1 = Ingredient.create(:name => 'sugar')
+      IceCream.all.size.should == 1
+      IceCream.first.should == icecream_for_reference1
+      Ingredient.all.size.should == 1
+      Ingredient.first.should == ingredient_for_reference_1
+      Neo4j.threadlocal_ref_node = reference2
+      icecream_for_reference2 = IceCream.create(:flavour => 'strawberry')
+      ingredient_for_reference_2 = Ingredient.create(:name => 'eggs')
+      IceCream.all.size.should == 1
+      IceCream.first.should == icecream_for_reference2            
+      Ingredient.all.size.should == 1
+      Ingredient.first.should == ingredient_for_reference_2
+    end    
 
     it "should find the node given it's id" do
       model = IceCream.create(:flavour => 'thing')


### PR DESCRIPTION
Hi Andreas,

This pull request fixes an issue with the multitenancy feature. The cached rule node was effectively global, which caused issues whenever the reference node was switched. (I've added a test that exposes this bug). This fix corrects this behaviour to cache the rule node on a per class basis.

Thanks,
Vivek
