### PR TITLE
Fixing indexer prefix for class with default ref node

### DIFF
--- a/lib/neo4j/index/indexer.rb
+++ b/lib/neo4j/index/indexer.rb
@@ -322,10 +322,19 @@ module Neo4j
       end
 
       def index_names
-        @index_names ||= Hash.new do |hash,index_type|
-          default_filename = Neo4j.index_prefix + @indexer_for.to_s.gsub('::', '_')
+        @index_names ||= Hash.new do |hash, index_type|
+          default_filename = index_prefix + @indexer_for.to_s.gsub('::', '_')
           hash.fetch(index_type) {"#{default_filename}-#{index_type}"}
         end
+      end
+
+      protected
+      def index_prefix
+        return "" unless Neo4j.running?
+        return "" unless @indexer_for.respond_to?(:ref_node_for_class)
+        ref_node = @indexer_for.ref_node_for_class
+        ref_node_name = ref_node[:name]
+        ref_node_name.blank? ? "" : ref_node_name + "_"
       end
     end
   end

--- a/lib/neo4j/neo4j.rb
+++ b/lib/neo4j/neo4j.rb
@@ -150,15 +150,6 @@ module Neo4j
       Thread.current[:local_ref_node] = reference_node.nil? ? nil : reference_node._java_node
     end
 
-    # Returns a prefix for lucene indices based on the name property of the current reference node.
-    # This allows the index names to be prefixed by the reference node name, and hence scopes lucene indexes
-    # to all entities under the current reference node.
-    def index_prefix
-      return "" if not running?
-      ref_node_name = ref_node[:name]
-      ref_node_name.nil? || ref_node_name.empty? ? "" : ref_node_name + "_"
-    end
-
     # Returns a Management JMX Bean.
     #
     # Notice that this information is also provided by the jconsole Java tool, check http://wiki.neo4j.org/content/Monitoring_and_Deployment

--- a/spec/neo4j_spec.rb
+++ b/spec/neo4j_spec.rb
@@ -14,17 +14,6 @@ describe Neo4j, :type => :transactional do
     Neo4j.ref_node.should == new_ref._java_node
   end
 
-  it "should return the index prefix, if the ref node's name property exists" do
-    new_ref = Neo4j::Node.new
-    new_ref[:name] = "name_value"
-    Neo4j.threadlocal_ref_node = new_ref
-    Neo4j.index_prefix.should == "name_value_"
-  end
-
-  it "should return an empty string if there is no name property" do
-    Neo4j.index_prefix.should == ""
-  end
-
   it "#ref_node, can have relationship to this node" do
     new_tx
     a = Neo4j::Node.new


### PR DESCRIPTION
This fixes the issue : Model#find by indexed properties was returning nil for classes with default ref node, when thread local node is set.
