### PR TITLE
Fixing  non-deterministic behavior of "reachable_from_ref_node?" method

### DIFF
--- a/lib/neo4j/rails/model.rb
+++ b/lib/neo4j/rails/model.rb
@@ -92,9 +92,7 @@ module Neo4j
       end
 
       def reachable_from_ref_node?
-        class_node = self._java_node._rels(:incoming, :_all).first._start_node
-        ref_node = class_node._rel(:incoming, self.class.to_s)._start_node
-        ref_node == self.class.ref_node_for_class
+        Neo4j::Algo.all_path(self.class.ref_node_for_class, self).outgoing(self.class).outgoing(:_all).count > 0
       end
 
       ##


### PR DESCRIPTION
The path traversal method is non-deterministic since we find first of many relations. In some cases _resl.first returns base class relation and this method yields wrong results. I tried to add a spec for this, but it was always passing in unit tests. 

The algorithm approach also takes less than ms and it yields correct result.  This shouldn't be cause any noticeable change in performance.

This reverts commit "Using more efficient path traversing to find if a node can be reached from ref node"
https://github.com/andreasronge/neo4j/pull/47
