### PR TITLE
Removed unnecessary rule node creation

### DIFF
--- a/lib/neo4j/rule/event_listener.rb
+++ b/lib/neo4j/rule/event_listener.rb
@@ -48,9 +48,7 @@ module Neo4j
         end
 
         def on_neo4j_started(db)
-          if Neo4j::Config[:enable_rules]
-            Rule.on_neo4j_started
-          else
+          if not Neo4j::Config[:enable_rules]
             db.event_handler.remove(self)
           end
         end

--- a/lib/neo4j/rule/rule.rb
+++ b/lib/neo4j/rule/rule.rb
@@ -90,10 +90,6 @@ module Neo4j
           @rule_nodes && @rule_nodes.values.find { |rn| rn.rule_node?(node) }
         end
 
-        def on_neo4j_started
-          @rule_nodes.each_value { |rule_node| rule_node.on_neo4j_started } if @rule_nodes
-        end
-
         def inherit(parent_class, subclass)
           # copy all the rules
           if rule_node = rule_node_for(parent_class)

--- a/lib/neo4j/rule/rule_node.rb
+++ b/lib/neo4j/rule/rule_node.rb
@@ -60,11 +60,6 @@ module Neo4j
         ref_node.rel?(@clazz.to_s) && ref_node._rel(:outgoing, @clazz.to_s)._end_node
       end
 
-      def on_neo4j_started
-        # initialize the rule node when neo4j starts
-        Thread.current[@rule_node_key] = find_node || create_node
-      end
-
       def rule_node
         clear_rule_node if ref_node_changed?
         Thread.current[@rule_node_key] ||= find_node || create_node


### PR DESCRIPTION
Hi Andreas,

Here's a pull request which defers the creation of rule nodes on database start. For multitenanted databases, neo4jrb would create empty rule nodes for every class, attached to the home node, which would never be used.

The CI passes: http://travis-ci.org/#!/vivekprahlad/neo4j/builds/206678

Vivek
