### PR TITLE
Timestamps generator

### DIFF
--- a/lib/generators/neo4j/model/model_generator.rb
+++ b/lib/generators/neo4j/model/model_generator.rb
@@ -27,11 +27,11 @@ class Neo4j::Generators::ModelGenerator < Neo4j::Generators::Base #:nodoc:
 	
 	def timestamp_statements
 		%q{
-  property :created_at, DateTime
-  # property :created_on, Date
+  property :created_at, :type => DateTime
+  # property :created_on, :type => Date
 
-  property :updated_at, DateTime
-  # property :updated_on, Date
+  property :updated_at, :type => DateTime
+  # property :updated_on, :type => Date
 }            
 	end
 	


### PR DESCRIPTION
Hi, scaffolding with the timestamps option generates properties like this:

  property :created_at, DateTime
  # property :created_on, Date

  property :updated_at, DateTime
  # property :updated_on, Date

this raise a error "DateTime is not a string"

I just put ":type => DateTime" and now it´s ok.
