### PR TITLE
Provide flexibility to define index prefix

### DIFF
--- a/lib/neo4j/index/indexer.rb
+++ b/lib/neo4j/index/indexer.rb
@@ -330,9 +330,10 @@ module Neo4j
       def index_prefix
         return "" unless Neo4j.running?
         return "" unless @indexer_for.respond_to?(:ref_node_for_class)
-        ref_node = @indexer_for.ref_node_for_class
-        ref_node_name = ref_node[:name]
-        ref_node_name.blank? ? "" : ref_node_name + "_"
+        ref_node = @indexer_for.ref_node_for_class.wrapper
+        prefix = ref_node.send(:_index_prefix) if ref_node.respond_to?(:_index_prefix)
+        prefix ||= ref_node[:name] # To maintain backward compatiblity
+        prefix.blank? ? "" : prefix + "_"
       end
     end
   end


### PR DESCRIPTION
 Hi,

The previous implementation uses `name` property as index prefix. The problem is most of the domain models have name property and it can change in time. In our case we use company as tenant node (thread local ref node). When the model name changes, index search will break since it uses a different index location.

This commit allows tenant node to decide index prefix. One example implementation could be to define `_index_prefix` to be `id` or any immutable unique property of the node.

The implementation is backward compatible i.e it fallbacks to `name` property if `_index_prefix` method is not defined.

Build Status: http://travis-ci.org/#!/endeepak/neo4j/builds/244044
