### PR TITLE
Fixing updated_at to be set only if model has changed

### DIFF
--- a/lib/neo4j/rails/model.rb
+++ b/lib/neo4j/rails/model.rb
@@ -262,9 +262,9 @@ module Neo4j
       include Attributes # handles how to save and retrieve attributes
       include Mapping::Property # allows some additional options on the #property class method
       include Serialization # enable to_xml and to_json
-      include Timestamps # handle created_at, updated_at timestamp properties
       include Validations # enable validations
       include Callbacks # enable callbacks
+      include Timestamps # handle created_at, updated_at timestamp properties
       include ActiveModel::Observing # enable observers
       include Finders # ActiveRecord style find
       include Relationships # for none persisted relationships

--- a/lib/neo4j/rails/relationship.rb
+++ b/lib/neo4j/rails/relationship.rb
@@ -128,9 +128,9 @@ module Neo4j
       include Attributes # handles how to save and retrieve attributes
       include Mapping::Property # allows some additional options on the #property class method
       include Serialization # enable to_xml and to_json
-      include Timestamps # handle created_at, updated_at timestamp properties
       include Validations # enable validations
       include Callbacks # enable callbacks
+      include Timestamps # handle created_at, updated_at timestamp properties
       include Finders # ActiveRecord style find
       include Compositions
     end

--- a/lib/neo4j/rails/timestamps.rb
+++ b/lib/neo4j/rails/timestamps.rb
@@ -6,16 +6,10 @@ module Neo4j
 
 			TIMESTAMP_PROPERTIES = [ :created_at, :created_on, :updated_at, :updated_on ]
 
-			def write_changed_attributes
-				update_timestamp
-				super
-			end
-
-			def init_on_create(*args)
-				create_timestamp
-				super
-			end
-
+      included do
+        before_create :create_timestamp
+        before_save :update_timestamp, :if => :new_or_changed?
+      end
 			# Set the timestamps for this model if timestamps is set to true in the config
 			# and the model is set up with the correct property name, e.g.:
 			#
@@ -49,6 +43,10 @@ module Neo4j
 
 				send("#{attribute}=", value)
 			end
+
+      def new_or_changed?
+        self.new? or self.changed?
+      end
 
 			module ClassMethods
 				def property_setup(property, options)

--- a/spec/support/shared_model_examples.rb
+++ b/spec/support/shared_model_examples.rb
@@ -5,16 +5,16 @@ require 'active_support/core_ext/date_time/calculations'
 share_examples_for "a new model" do
   context "when unsaved" do
     it { should_not be_persisted }
-  
+
     it "should allow direct access to properties before it is saved" do
       subject["fur"] = "none"
       subject["fur"].should == "none"
     end
-    
+
     it "should allow access to all properties before it is saved" do
       subject.props.should be_a(Hash)
     end
-    
+
     it "should allow properties to be accessed with a symbol" do
       lambda{ subject.props[:test] = true }.should_not raise_error
     end
@@ -26,7 +26,7 @@ share_examples_for "a loadable model" do
     before :each do
       subject.save!
     end
-    
+
     it "should load a previously stored node" do
       result = subject.class.load(subject.id)
       result.should == subject
@@ -40,86 +40,86 @@ share_examples_for "a saveable model" do
     it "should save ok" do
       subject.save.should be_true
     end
-      
+
     it "should save without raising an exception" do
       subject.save!.should_not raise_error(org.neo4j.graphdb.NotInTransactionException)
     end
-    
+
     context "after save" do
       before(:each) { subject.save}
-    
+
       it { should be_valid }
-      
+
       it { should == subject.class.find(subject.id.to_s) }
       it "should be included in all" do
         subject.class.all.to_a.should include(subject)
       end
     end
   end
-  
+
   context "after being saved" do
     # make sure it looks like an ActiveModel model
     include ActiveModel::Lint::Tests
-    
+
     before :each do
       subject.save
     end
-    
+
     it { should be_persisted }
     it { should == subject.class.load(subject.id) }
     it { should be_valid }
-    
+
     it "should be found in the database" do
       subject.class.all.to_a.should include(subject)
     end
-    
+
     it { should respond_to(:to_param) }
-    
+
     #it "should respond to primary_key" do
     #  subject.class.should respond_to(:primary_key)
     #end
-    
+
     it "should render as XML" do
       subject.to_xml.should =~ /^<\?xml version=/
     end
-    
+
     context "attributes" do
       before(:each) do
         @original_subject = @original_subject.attributes
       end
-      
+
       it { should_not include("_neo-id") }
       it { should_not include("_classname") }
     end
   end
 end
 
-share_examples_for "an unsaveable model" do 
+share_examples_for "an unsaveable model" do
   context "when attempting to save" do
     it "should not save ok" do
       subject.save.should_not be_true
     end
-    
+
     it "should raise an exception" do
       lambda { subject.save! }.should raise_error
     end
   end
-  
+
   context "after attempted save" do
     before { subject.save }
-    
+
     it { should_not be_persisted }
-    
+
     it "should have a nil id after save" do
       subject.id.should be_nil
     end
   end
-  
+
   context "without validation" do
   	it "should save ok" do
   		subject.save(:validate => false).should == true
   	end
-  	
+
   	it "shouldn't cause an exception while saving" do
   		lambda { subject.save!(:validate => false) }.should_not raise_error
   	end
@@ -134,11 +134,11 @@ share_examples_for "a destroyable model" do
       subject.destroy
     end
     it { should be_frozen }
-    
+
     it "should remove the model from the database" do
       subject.class.load(subject.id).should be_nil
     end
-    
+
     it "should also be frozen in @other" do
     	@other.should be_frozen
     end
@@ -147,20 +147,20 @@ end
 
 share_examples_for "a creatable model" do
   context "when attempting to create" do
-    
+
     it "should create ok" do
       subject.class.create(subject.attributes).should be_true
     end
-    
+
     it "should not raise an exception on #create!" do
       lambda { subject.class.create!(subject.attributes) }.should_not raise_error
     end
-    
+
     it "should save the model and return it" do
       model = subject.class.create(subject.attributes)
       model.should be_persisted
     end
-  
+
     it "should accept attributes to be set" do
       model = subject.class.create(subject.attributes.merge(:name => "Ben"))
       model[:name].should == "Ben"
@@ -193,11 +193,11 @@ end
 
 share_examples_for "an uncreatable model" do
   context "when attempting to create" do
-    
+
     it "shouldn't create ok" do
       subject.class.create(subject.attributes).persisted?.should_not be_true
     end
-    
+
     it "should raise an exception on #create!" do
       lambda { subject.class.create!(subject.attributes) }.should raise_error
     end
@@ -220,7 +220,7 @@ end
 share_examples_for "an updatable model" do
   context "when saved" do
     before { subject.save! }
-    
+
     context "and updated" do
       it "should have altered attributes" do
         lambda { subject.update_attributes!(:a => 1, :b => 2) }.should_not raise_error
@@ -247,7 +247,7 @@ share_examples_for "a timestamped model" do
 		Time.stub!(:now).and_return(@time)
 		subject.save!
 	end
-    
+
 	it "should have set updated_at" do
 		subject.updated_at.to_i.should == Time.now.to_i
 	end
@@ -255,18 +255,24 @@ share_examples_for "a timestamped model" do
 	it "should have set created_at" do
 		subject.created_at.to_i == Time.now.to_i
 	end
-	
+
 	context "when updated" do
     before(:each) do
     	Time.stub!(:now).and_return(@tomorrow)
     end
-    
+
     it "created_at is not changed" do
       lambda { subject.update_attributes!(:a => 1, :b => 2) }.should_not change(subject, :created_at)
     end
-    
+
     it "should have altered the updated_at property" do
       lambda { subject.update_attributes!(:a => 1, :b => 2) }.should change(subject, :updated_at)
+    end
+
+    context "without modifications" do
+      it "should not alter the updated_at property" do
+        lambda { subject.save! }.should_not change(subject, :updated_at)
+      end
     end
   end
 end


### PR DESCRIPTION
This ensures nested models are not time stamped when parent is saved without changing any attributes in nested ones.
