### PR TITLE
More performance tweaks

### DIFF
--- a/lib/neo4j/index/indexer.rb
+++ b/lib/neo4j/index/indexer.rb
@@ -155,7 +155,7 @@ module Neo4j
       end
 
       def update_single_index_on(node, field, old_val, new_val) #:nodoc:
-        if @field_types.include?(field)
+        if @field_types.has_key?(field)
           rm_index(node, field, old_val) if old_val
           add_index(node, field, new_val) if new_val
         end

--- a/lib/neo4j/index/indexer_registry.rb
+++ b/lib/neo4j/index/indexer_registry.rb
@@ -10,7 +10,7 @@ module Neo4j
         def create_for(this_clazz, using_other_clazz, type)
           @@indexers                  ||= {}
           index                       = Indexer.new(this_clazz, type)
-          index.inherit_fields_from(@@indexers[using_other_clazz.to_s])
+          index.inherit_fields_from(@@indexers[using_other_clazz.to_s]) if @@indexers[using_other_clazz.to_s]
           @@indexers[this_clazz.to_s] = index
         end
 

--- a/lib/neo4j/node_mixin/node_mixin.rb
+++ b/lib/neo4j/node_mixin/node_mixin.rb
@@ -80,7 +80,7 @@ module Neo4j
     def _java_entity
       @_java_node
     end
-    
+
     # Trigger rules.
     # You don't normally need to call this method (except in Migration) since
     # it will be triggered automatically by the Neo4j::Rule::Rule
@@ -131,7 +131,7 @@ module Neo4j
         super
       end
 
-      c.node_indexer c
+      c.node_indexer c unless c == Neo4j::Rails::Model
     end
   end
 end

--- a/lib/neo4j/rails/attributes.rb
+++ b/lib/neo4j/rails/attributes.rb
@@ -201,8 +201,8 @@ module Neo4j
       # Known properties are either in the @properties, the declared
       # properties or the property keys for the persisted node
       def property?(name)
-        @properties.keys.include?(name) ||
-            self.class._decl_props.map { |k| k.to_s }.include?(name) ||
+        @properties.has_key?(name) ||
+            self.class._decl_props.has_key?(name) ||
             begin
               persisted? && super
             rescue org.neo4j.graphdb.NotFoundException

--- a/lib/neo4j/rule/rule_node.rb
+++ b/lib/neo4j/rule/rule_node.rb
@@ -186,7 +186,7 @@ module Neo4j
       end
 
       def connect(rule_name, end_node)
-        rule_node.outgoing(rule_name) << end_node
+        rule_node._java_node.createRelationshipTo(end_node._java_node, org.neo4j.graphdb.DynamicRelationshipType.withName(rule_name))
       end
 
       # sever a direct one-to-one relationship if it exists


### PR DESCRIPTION
Hi Andreas,

Here's another set of performance tweaks:
- Preventing Neo4j::Rails::Model from being treated as a parent indexer (this is similar to the previous issue where a rule node was getting created for the rails model base class)
- Using has_key? instead of include? for several hashes
- Dropping down to the java API to create relationships to the rule node
- Iterating over created nodes once (instead of 3 times previously) in the event_handler

Cheers,
Vivek
