### PR TITLE
Added symbol converter

### DIFF
--- a/lib/neo4j/type_converters/type_converters.rb
+++ b/lib/neo4j/type_converters/type_converters.rb
@@ -68,6 +68,26 @@ module Neo4j
       end
     end
 
+    class SymbolConverter
+      class << self
+
+        def convert?(class_or_symbol)
+          :symbol == class_or_symbol || Symbol == class_or_symbol
+        end
+
+        def to_java(value)
+          return nil unless value
+          value.to_s
+        end
+
+        def to_ruby(value)
+          return nil unless value
+          value.to_sym
+        end
+      end
+    end
+
+
 
     class FixnumConverter
       class << self

--- a/spec/type_converters/type_converters_spec.rb
+++ b/spec/type_converters/type_converters_spec.rb
@@ -57,6 +57,31 @@ describe Neo4j::TypeConverters, :type => :transactional do
 
   end
 
+  context Neo4j::TypeConverters::SymbolConverter, "property :status => Symbol" do
+    before(:all) do
+      @clazz = create_node_mixin do
+        property :status, :type => Symbol
+      end
+    end
+
+    it "should save Symbol as String" do
+      v = @clazz.new :status => :active
+      val = v._java_node.get_property('status')
+      val.class.should == String
+    end
+
+    it "should load as Symbol" do
+      v = @clazz.new :status => :active
+      v.status.should == :active
+    end
+
+    it "should treat String as Symbol" do
+      v = @clazz.new :status => 'active'
+      v.status.should == :active
+    end
+  end
+
+
   context Neo4j::TypeConverters::DateConverter, "property :born => Date" do
     before(:all) do
       @clazz = create_node_mixin do


### PR DESCRIPTION
This allows using symbols instead of Strings:

``` ruby
class User < Neo4j::Model
  property :status, :type => Symbol
end

User.new(:status => :active).active # :active
```
