### PR TITLE
add string converter

### DIFF
--- a/lib/neo4j/type_converters/type_converters.rb
+++ b/lib/neo4j/type_converters/type_converters.rb
@@ -88,6 +88,26 @@ module Neo4j
     end
 
 
+    class StringConverter
+      class << self
+
+        def convert?(class_or_symbol)
+          [String, :string, :text].include? class_or_symbol
+        end
+
+        def to_java(value)
+          return nil unless value
+          value.to_s
+        end
+
+        def to_ruby(value)
+          return nil unless value
+          value.to_s
+        end
+      end
+    end
+
+
 
     class FixnumConverter
       class << self

--- a/spec/type_converters/type_converters_spec.rb
+++ b/spec/type_converters/type_converters_spec.rb
@@ -82,6 +82,34 @@ describe Neo4j::TypeConverters, :type => :transactional do
   end
 
 
+  context Neo4j::TypeConverters::StringConverter, "property :name => String" do
+    before(:all) do
+      @clazz = create_node_mixin do
+        property :name, :type => String
+      end
+    end
+
+    it "should save String as String" do
+      v = @clazz.new :name => 'me'
+      val = v._java_node.get_property('name')
+      val.class.should == String
+    end
+
+    it "should load as String" do
+      v = @clazz.new :name => 'me'
+      v.name.should == 'me'
+    end
+
+    it "should treat anything as String" do
+      @clazz.new(:name=>123).name.should == '123'
+      @clazz.new(:name=>1.23).name.should == '1.23'
+      @clazz.new(:name=>:sym).name.should == 'sym'
+      @clazz.new(:name=> Object.new).name.class.should == String
+    end
+  end
+
+
+
   context Neo4j::TypeConverters::DateConverter, "property :born => Date" do
     before(:all) do
       @clazz = create_node_mixin do


### PR DESCRIPTION
Using `:type => String` (or `:string`, `:text`) will ensure that the return value is always converted to string no matter what you assign initially.
