### PR TITLE
Pull request to correct behaviour of 'Unknown outgoing relationship' message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+ == 1.3.0 / 2011-12-06
+* Added neo4j-upgrade script to rename lucene index files and upgrade to 1.5 [#197]
+* Expose Neo4j::NodeMixin#index_types returning available indices (useful for Cypher queries) [#194]
+* The to_other method is now available also in the Neo4j::Rails API [#193]
+* Expose rel_type method for Neo4j::Rails::Relationship [#196]
+* Support for breadth and depth first traversals [#198]
+* Support for cypher query [#197]
+* Fix for rule node concurrency issue (pull #78, Vivek Prahlad)
+* Bugfix for the uniqueness validation for properties with quotes (pull #76, Vivek Prahlad)
+* More performance tweaks (pull #75, #77, Vivek Prahlad)
+* Fixing add_index for properties other than type string (pull #74, Deepak N)
+* Significant performance boost for creating large numbers of models in a transaction (pull #73, Vivek Prahlad)
+* Upgrade to neo4j 1.5 jars (pull #72, Vivek Prahlad)
+* Fix for assigning nil values to incoming has_one relation (pull #70, Deepak N)
+* Support for revert and fixes for Neo4j::Rails::Versioning (pull #71, Vivek Prahlad)
+
  == 1.2.6 / 2011-11-02
 * Generators can now generate relationships as well [#195]
 * Better will_paginate support for Neo4j::Rails::Model [#194]

--- a/README.rdoc
+++ b/README.rdoc
@@ -12,6 +12,7 @@ It uses two powerful and mature Java libraries:
 === Documentation
 
 * {Guides and API}[http://neo4j.rubyforge.org/guides/index.html]
+* {RDoc}[http://neo4j.rubyforge.org]
 * {Blog: Neo4j and Rails 3}[http://blog.jayway.com/2011/03/02/neo4j-rb-1-0-0-and-rails-3/]
 * {Kvitter Example Application}[https://github.com/andreasronge/kvitter/]
 
@@ -108,6 +109,15 @@ To run it with Tomcat instead of WEBrick
   gem install trinidad
   trinidad
 
+=== Architecture
+
+As you seen above, neo4j.rb consists of a three layers API:
+
+* Layer 1. For interacting with the basic building blocks of the graph database (node, properties and relationship), see Neo4j::Node and Neo4j::Relationship classes.
+* Layer 2. A binding API to Ruby objects, see Neo4j::NodeMixin and Neo4j::RelationshipMixin modules.
+* Layer 3. An implementation of the Rails Active Model and a subset of the Active Record API, see Neo4j::Rails::Model class.
+
+Notice that you can always access the lower layers if you want to do some more advanced. You can even access the Java API directly.
 
 === Presentation Materials and other URLs
 * {Presentation: RailsConf 2011}[http://andreasronge.github.com/neo4j-railsconf.pdf]

--- a/lib/neo4j/version.rb
+++ b/lib/neo4j/version.rb
@@ -1,3 +1,3 @@
 module Neo4j
-  VERSION = "1.2.6"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
Hi Andreas,

Here's a pull request that corrects the behaviour of the 'Unknown outgoing relationship' message. It looks like the Rails model loading order sometimes causes this error message to show incorrectly.

This patch still shows the warning message in case a 'from' relationship in one entity does not have a corresponding 'to' relationship with the same name in the other entity.

Cheers,
Vivek
