### PR TITLE
Fixing multiple assignment of has_one assocaition

### DIFF
--- a/lib/neo4j/rails/mapping/property.rb
+++ b/lib/neo4j/rails/mapping/property.rb
@@ -55,8 +55,7 @@ module Neo4j
                 def #{rel_type}=(other)
                     dsl = _decl_rels_for(:'#{rel_type}')
                     storage = _create_or_get_storage_for_decl_rels(dsl)
-                    rel = storage.single_relationship(dsl.dir)
-                    rel && rel.destroy
+                    storage.destroy_single_relationship(dsl.dir)
                     storage.create_relationship_to(other, dsl.dir)
                 end
               RUBY

--- a/lib/neo4j/rails/relationships/storage.rb
+++ b/lib/neo4j/rails/relationships/storage.rb
@@ -122,6 +122,11 @@ module Neo4j
           end
         end
 
+        def destroy_single_relationship(dir)
+          rel = single_relationship(dir)
+          rel && rel.destroy && relationships(dir).delete(rel)
+        end
+
         def all_relationships(dir)
           Enumerator.new(self, :each_rel, dir)
         end

--- a/spec/rails/relationship_spec.rb
+++ b/spec/rails/relationship_spec.rb
@@ -421,6 +421,18 @@ describe "Neo4j::Model Relationships" do
       jack.thing.should be_nil
     end
 
+    it "has_one: should not create duplicate relationships on multiple assignment" do
+      clazz = create_model
+      clazz.has_one :thing
+
+      jack = clazz.create!
+      jack.thing = Neo4j::Model.create!
+      jack.thing = Neo4j::Model.create!
+      jack.save!
+
+      expect { jack.thing }.not_to raise_error
+    end
+
     it "add nodes to a has_one method with the #new method" do
       member = Member.new
       avatar = Avatar.new


### PR DESCRIPTION
 Earlier it used to throw More than one relationship exception 

```
#<NativeException: org.neo4j.graphdb.NotFoundException: More than one relationship[DynamicRelationshipType[thing], OUTGOING] found for NodeImpl#1>
```

CI: http://travis-ci.org/#!/endeepak/neo4j/builds/392939
