### PR TITLE
Fix very old matchers to allow running on RSpec 2.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group 'test' do
   gem "rake", ">= 0.8.7"
   gem "rdoc", ">= 2.5.10"
   gem "horo", ">= 1.0.2"
-  gem "rspec", "= 2.6.0"
+  gem "rspec", "~> 2.8.0"
 
   gem 'guard'
   gem 'ruby_gntp', :require => false # GrowlNotify for Mac
@@ -16,7 +16,7 @@ group 'test' do
   gem "guard-rspec"
 
   # use this version for rspec-rails-matchers which work with latest RSpec (Rspec => RSpec)
-  gem "rspec-rails-matchers", :git => 'git://github.com/afcapel/rspec-rails-matchers.git'
+  gem "rspec-rails-matchers", :git => 'git://github.com/dnagir/rspec-rails-matchers.git'
 
   gem "test-unit"
   gem 'rcov'


### PR DESCRIPTION
If interesting, here is the actual [issue](https://github.com/rspec/rspec-expectations/issues/108).
# Improvement is ~10 seconds (~15%) per test run.
## RSpec 2.6:

``` sh
> time b/rspec spec
real    0m57.419s
user    0m42.232s
sys 0m7.091s
```
## RSpec 2.8:

``` sh
> time b/rspec spec
real    0m48.237s
user    0m30.093s
sys 0m6.745s
```
