### PR TITLE
Trying to update to Rails 3.2

### DIFF
--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -6,7 +6,6 @@ require 'tmpdir'
 
 # Rails
 require 'rails/railtie'
-require 'active_support/core_ext/class/inheritable_attributes'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_model'
 

--- a/lib/neo4j/core_ext/class/inheritable_attributes.rb
+++ b/lib/neo4j/core_ext/class/inheritable_attributes.rb
@@ -1,37 +1,19 @@
 # This is copied from Rails Active Support since it has been depricated and I still need it
-class Class # :nodoc:
-  def class_inheritable_reader(*syms)
-    options = syms.extract_options!
-    syms.each do |sym|
-      next if sym.is_a?(Hash)
-      class_eval(<<-EOS, __FILE__, __LINE__ + 1)
-        def self.#{sym}                                # def self.after_add
-          read_inheritable_attribute(:#{sym})          #   read_inheritable_attribute(:after_add)
-        end                                            # end
-                                                       #
-        #{"                                            #
-        def #{sym}                                     # def after_add
-          self.class.#{sym}                            #   self.class.after_add
-        end                                            # end
-        " unless options[:instance_reader] == false }  # # the reader above is generated unless options[:instance_reader] == false
-      EOS
-    end
-  end
 
-  def class_inheritable_writer(*syms)
-    options = syms.extract_options!
-    syms.each do |sym|
-      class_eval(<<-EOS, __FILE__, __LINE__ + 1)
-        def self.#{sym}=(obj)                          # def self.color=(obj)
-          write_inheritable_attribute(:#{sym}, obj)    #   write_inheritable_attribute(:color, obj)
-        end                                            # end
-                                                       #
-        #{"                                            #
-        def #{sym}=(obj)                               # def color=(obj)
-          self.class.#{sym} = obj                      #   self.class.color = obj
-        end                                            # end
-        " unless options[:instance_writer] == false }  # # the writer above is generated unless options[:instance_writer] == false
-      EOS
-    end
-  end
+# Taken from: https://raw.github.com/lifo/docrails/dd6c3676af3fa6019c53a59f62c4fd14966be728/activesupport/lib/active_support/core_ext/class/inheritable_attributes.rb
+
+# Changes made:
+# - Remove deprecation warnings
+# - Ignore if already available from ActiveSupport
+
+# TODO: convert the code to use class_attribute. dnagir failed at it :)
+
+
+
+begin
+  require 'active_support/core_ext/class/inheritable_attributes'
+rescue LoadError
+ensure
+  # Fallback to internal implementation & override deprecations
+  require 'neo4j/core_ext/class/rewrite_inheritable_attributes.rb'
 end

--- a/lib/neo4j/core_ext/class/rewrite_inheritable_attributes.rb
+++ b/lib/neo4j/core_ext/class/rewrite_inheritable_attributes.rb
@@ -1,0 +1,170 @@
+require 'active_support/core_ext/object/duplicable'
+require 'active_support/core_ext/array/extract_options'
+
+# Retained for backward compatibility. Methods are now included in Class.
+module ClassInheritableAttributes # :nodoc:
+end
+
+# It is recommended to use <tt>class_attribute</tt> over methods defined in this file. Please
+# refer to documentation for <tt>class_attribute</tt> for more information. Officially it is not
+#
+# Allows attributes to be shared within an inheritance hierarchy. Each descendant gets a copy of
+# their parents' attributes, instead of just a pointer to the same. This means that the child can add elements
+# to, for example, an array without those additions being shared with either their parent, siblings, or
+# children. This is unlike the regular class-level attributes that are shared across the entire hierarchy.
+#
+# The copies of inheritable parent attributes are added to subclasses when they are created, via the
+# +inherited+ hook.
+#
+#  class Person
+#    class_inheritable_accessor :hair_colors
+#  end
+#
+#  Person.hair_colors = [:brown, :black, :blonde, :red]
+#  Person.hair_colors     # => [:brown, :black, :blonde, :red]
+#  Person.new.hair_colors # => [:brown, :black, :blonde, :red]
+#
+# To opt out of the instance writer method, pass :instance_writer => false.
+# To opt out of the instance reader method, pass :instance_reader => false.
+#
+#   class Person
+#     class_inheritable_accessor :hair_colors :instance_writer => false, :instance_reader => false
+#   end
+#
+#   Person.new.hair_colors = [:brown]  # => NoMethodError
+#   Person.new.hair_colors             # => NoMethodError
+class Class # :nodoc:
+  def class_inheritable_reader(*syms)
+    options = syms.extract_options!
+    syms.each do |sym|
+      next if sym.is_a?(Hash)
+      class_eval(<<-EOS, __FILE__, __LINE__ + 1)
+        def self.#{sym}                                # def self.after_add
+          read_inheritable_attribute(:#{sym})          #   read_inheritable_attribute(:after_add)
+        end                                            # end
+                                                       #
+        #{"                                            #
+        def #{sym}                                     # def after_add
+          self.class.#{sym}                            #   self.class.after_add
+        end                                            # end
+        " unless options[:instance_reader] == false }  # # the reader above is generated unless options[:instance_reader] == false
+      EOS
+    end
+  end
+
+  def class_inheritable_writer(*syms)
+    options = syms.extract_options!
+    syms.each do |sym|
+      class_eval(<<-EOS, __FILE__, __LINE__ + 1)
+        def self.#{sym}=(obj)                          # def self.color=(obj)
+          write_inheritable_attribute(:#{sym}, obj)    #   write_inheritable_attribute(:color, obj)
+        end                                            # end
+                                                       #
+        #{"                                            #
+        def #{sym}=(obj)                               # def color=(obj)
+          self.class.#{sym} = obj                      #   self.class.color = obj
+        end                                            # end
+        " unless options[:instance_writer] == false }  # # the writer above is generated unless options[:instance_writer] == false
+      EOS
+    end
+  end
+
+  def class_inheritable_array_writer(*syms)
+    options = syms.extract_options!
+    syms.each do |sym|
+      class_eval(<<-EOS, __FILE__, __LINE__ + 1)
+        def self.#{sym}=(obj)                          # def self.levels=(obj)
+          write_inheritable_array(:#{sym}, obj)        #   write_inheritable_array(:levels, obj)
+        end                                            # end
+                                                       #
+        #{"                                            #
+        def #{sym}=(obj)                               # def levels=(obj)
+          self.class.#{sym} = obj                      #   self.class.levels = obj
+        end                                            # end
+        " unless options[:instance_writer] == false }  # # the writer above is generated unless options[:instance_writer] == false
+      EOS
+    end
+  end
+
+  def class_inheritable_hash_writer(*syms)
+    options = syms.extract_options!
+    syms.each do |sym|
+      class_eval(<<-EOS, __FILE__, __LINE__ + 1)
+        def self.#{sym}=(obj)                          # def self.nicknames=(obj)
+          write_inheritable_hash(:#{sym}, obj)         #   write_inheritable_hash(:nicknames, obj)
+        end                                            # end
+                                                       #
+        #{"                                            #
+        def #{sym}=(obj)                               # def nicknames=(obj)
+          self.class.#{sym} = obj                      #   self.class.nicknames = obj
+        end                                            # end
+        " unless options[:instance_writer] == false }  # # the writer above is generated unless options[:instance_writer] == false
+      EOS
+    end
+  end
+
+  def class_inheritable_accessor(*syms)
+    class_inheritable_reader(*syms)
+    class_inheritable_writer(*syms)
+  end
+
+  def class_inheritable_array(*syms)
+    class_inheritable_reader(*syms)
+    class_inheritable_array_writer(*syms)
+  end
+
+  def class_inheritable_hash(*syms)
+    class_inheritable_reader(*syms)
+    class_inheritable_hash_writer(*syms)
+  end
+
+  def inheritable_attributes
+    @inheritable_attributes ||= EMPTY_INHERITABLE_ATTRIBUTES
+  end
+
+  def write_inheritable_attribute(key, value)
+    if inheritable_attributes.equal?(EMPTY_INHERITABLE_ATTRIBUTES)
+      @inheritable_attributes = {}
+    end
+    inheritable_attributes[key] = value
+  end
+
+  def write_inheritable_array(key, elements)
+    write_inheritable_attribute(key, []) if read_inheritable_attribute(key).nil?
+    write_inheritable_attribute(key, read_inheritable_attribute(key) + elements)
+  end
+
+  def write_inheritable_hash(key, hash)
+    write_inheritable_attribute(key, {}) if read_inheritable_attribute(key).nil?
+    write_inheritable_attribute(key, read_inheritable_attribute(key).merge(hash))
+  end
+
+  def read_inheritable_attribute(key)
+    inheritable_attributes[key]
+  end
+
+  def reset_inheritable_attributes
+    @inheritable_attributes = EMPTY_INHERITABLE_ATTRIBUTES
+  end
+
+  private
+    # Prevent this constant from being created multiple times
+    EMPTY_INHERITABLE_ATTRIBUTES = {}.freeze
+
+    def inherited_with_inheritable_attributes(child)
+      inherited_without_inheritable_attributes(child) if respond_to?(:inherited_without_inheritable_attributes)
+
+      if inheritable_attributes.equal?(EMPTY_INHERITABLE_ATTRIBUTES)
+        new_inheritable_attributes = EMPTY_INHERITABLE_ATTRIBUTES
+      else
+        new_inheritable_attributes = Hash[inheritable_attributes.map do |(key, value)|
+          [key, value.duplicable? ? value.dup : value]
+        end]
+      end
+
+      child.instance_variable_set('@inheritable_attributes', new_inheritable_attributes)
+    end
+
+    alias inherited_without_inheritable_attributes inherited
+    alias inherited inherited_with_inheritable_attributes
+end

--- a/neo4j.gemspec
+++ b/neo4j.gemspec
@@ -32,6 +32,6 @@ It comes included with the Apache Lucene document database.
   s.add_dependency('orm_adapter', ">= 0.0.3")
   s.add_dependency("activemodel", ">= 3.0.0")
   s.add_dependency("will_paginate", ["3.0.pre4"])  # should be ~>3.0 but it's API has changed '
-  s.add_dependency("railties", ">= 3.0.0")
+  s.add_dependency("railties", ">= 3.2.rc2") # TODO: Rever to ~> 3.0
   s.add_dependency("neo4j-community", "1.6.0.alpha.5")
 end


### PR DESCRIPTION
Gave up trying to fix #131. This is what I ended up so far.

Sending a PR so that we can work on it further.

But I'm giving on this it today.

Even after I updated the `inhertiable_attributes` to use the internal stuff, most of the specs failed. The failures mostly look like:

```
> b/rspec spec/rails/property_spec.rb:58
Run options:
  include {:locations=>{"./spec/rails/property_spec.rb"=>[58]}}
  exclude {:identity_map=>true, :edition=>#<Proc:./spec/support/editions.rb:19>}
F

Failures:

  1) hash has a unique hash for persisted models
     Failure/Error: x = UniqueHashModel.create
     NoMethodError:
       undefined method `has_key?' for nil:NilClass
     # ./spec/../lib/neo4j/rails/attributes.rb:204:in `property?'
     # ./spec/../lib/neo4j/rails/attributes.rb:241:in `respond_to?'
     # ./spec/../lib/neo4j/rails/callbacks.rb:47:in `initialize_with_callbacks'
     # ./spec/../lib/neo4j/rails/persistence.rb:112:in `create'
     # ./spec/rails/property_spec.rb:59:in `(root)'

Finished in 0.748 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/rails/property_spec.rb:58 # hash has a unique hash for persisted models
```

Which basically means that `@properties` is not set initially.
The reason for that is that `initialize_with_callbacks` on the model is executed BEFORE the `initialize` method (thus `reset_attrubites` initialising `@properties` isn't called yet).

I'm not sure what the exact reason for the behaviour is, but it may be a breaking change in the ActiveSupport/ActiveModel, a bug or we are using it incorrectly (which I doubt a lot).

@andreasronge, any thought?
