### PR TITLE
Allow rails 4 beta testing

### DIFF
--- a/neo4j.gemspec
+++ b/neo4j.gemspec
@@ -30,7 +30,7 @@ It comes included with the Apache Lucene document database.
   s.rdoc_options = ["--quiet", "--title", "Neo4j.rb", "--line-numbers", "--main", "README.rdoc", "--inline-source"]
 
   s.add_dependency('orm_adapter', ">= 0.0.3")
-  s.add_dependency("activemodel", ">= 3.0.0", "< 3.3")
-  s.add_dependency("railties", ">= 3.0.0", "< 3.3")
+  s.add_dependency("activemodel", ">= 3.0.0", "< 5")
+  s.add_dependency("railties", ">= 3.0.0", "< 5")
   s.add_dependency("neo4j-wrapper", '2.2.3')
 end


### PR DESCRIPTION
EDIT: Will need to be pulled into a rails4 branch to fix other issues like this:

```
uninitialized constant ActiveModel::Observer
org/jruby/RubyModule.java:2677:in `const_missing'
/Users/pboling/.rvm/gems/jruby-1.7.2@rails4/bundler/gems/neo4j-edce5343e8cd/lib/neo4j/rails/observer.rb:121:in `Rails'
/Users/pboling/.rvm/gems/jruby-1.7.2@rails4/bundler/gems/neo4j-edce5343e8cd/lib/neo4j/rails/observer.rb:2:in `Neo4j'
```
