### PR TITLE
Start Neo4j on app startup

### DIFF
--- a/lib/neo4j/rails/railtie.rb
+++ b/lib/neo4j/rails/railtie.rb
@@ -19,7 +19,7 @@ module Neo4j
       cfg.storage_path = "#{app.config.root}/db/neo4j-#{::Rails.env}" unless cfg.storage_path
       Neo4j::Config.setup.merge!(cfg.to_hash)
       
-      if app.config.allow_concurrency
+      if cfg.auto_start
         Neo4j.start
       end
     end


### PR DESCRIPTION
As discussed in https://github.com/andreasronge/neo4j/issues/237, Neo4j startup seems to not be thread safe. Until we can figure out the root cause, this patch simply starts up Neo4j on app startup if config.threadsafe! is enabled. This works for me and resolves the issues I was having.
