### PR TITLE
attempts to take advantage of protected_attributes gem

### DIFF
--- a/lib/neo4j/rails/model.rb
+++ b/lib/neo4j/rails/model.rb
@@ -104,6 +104,10 @@ module Neo4j
       include Neo4j::NodeMixin
       include ActiveModel::Dirty # track changes to attributes
       include ActiveModel::Observing # enable observers
+      begin
+      include ActiveModel::MassAssignmentSecurity # protected_attributes gem if available
+      rescue NameError
+      end
       include Neo4j::Rails::Identity
       include Neo4j::Rails::Persistence # handles how to save, create and update the model
       include Neo4j::Rails::NodePersistence # handles how to save, create and update the model


### PR DESCRIPTION
attr_accessible and others were split into the protected_attributes gem with Rails 4. This attempts to import that module and fails silently if it's unavailable. This or something similar will be needed with Neo4j.rb 3.0, it failed in the same spot when I tested it briefly.
