### PR TITLE
allows protected attributes in rels

### DIFF
--- a/lib/neo4j/rails/relationship.rb
+++ b/lib/neo4j/rails/relationship.rb
@@ -16,6 +16,10 @@ module Neo4j
       include Neo4j::RelationshipMixin
       include ActiveModel::Dirty # track changes to attributes
       include ActiveModel::Observing # enable observers
+      begin
+      include ActiveModel::MassAssignmentSecurity # protected_attributes gem if available
+      rescue NameError
+      end
       include Neo4j::Rails::Identity
       include Neo4j::Rails::Persistence # handles how to save, create and update the model
       include Neo4j::Rails::RelationshipPersistence # handles how to save, create and update the model


### PR DESCRIPTION
Similar to my last commit, this allows the protected_attributes gem to work for Relationship models as one would expect based on Rails 4 documentation.
