### PR TITLE
username/password in connection string are recognized now

### DIFF
--- a/lib/neo4j/railtie.rb
+++ b/lib/neo4j/railtie.rb
@@ -18,6 +18,11 @@ module Neo4j
         cfg.session_options ||= {}
         cfg.sessions ||= []
 
+        unless (uri = URI(cfg.session_path)).user.blank?
+          cfg.session_options.reverse_merge!({ basic_auth: { username: uri.user, password: uri.password } })
+          cfg.session_path = cfg.session_path.gsub("#{uri.user}:#{uri.password}@", '')
+        end
+
         if cfg.sessions.empty?
           cfg.sessions << {type: cfg.session_type, path: cfg.session_path, options: cfg.session_options}
         end

--- a/spec/e2e/railite_spec.rb
+++ b/spec/e2e/railite_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'ostruct'
 
 module Rails
   class Config
@@ -51,12 +52,19 @@ module Rails
       Railtie.init['neo4j.start'].call(app)
     end
 
-    it 'allows sessions with authentication' do
+    it 'allows sessions with additional options' do
       expect(Neo4j::Session).to receive(:open).with(:server_db, 'http://localhost:7474', basic_auth: {username: 'user', password: 'password'})
       app = App.new
       app.neo4j.sessions = [{type: :server_db, path: 'http://localhost:7474',
                              options: {basic_auth: {username: 'user', password: 'password'}}}]
       Railtie.init['neo4j.start'].call(app)
+    end
+
+    it 'allows sessions with authentication' do
+      cfg = OpenStruct.new(session_path: 'http://user:password@localhost:7474')
+      Neo4j::Railtie.set_default_session(cfg)
+      cfg.session_path.should == 'http://localhost:7474'
+      cfg.session_options.should == {basic_auth: {username: 'user', password: 'password'}}
     end
 
     it 'allows named session' do


### PR DESCRIPTION
allows heroku-style urls with username/password in path

use with ENV["GRAPHENEDB_URL"]
