### PR TITLE
Infer class from record in UniquenessValidator

### DIFF
--- a/lib/neo4j/active_node/validations.rb
+++ b/lib/neo4j/active_node/validations.rb
@@ -41,7 +41,6 @@ module Neo4j
       class UniquenessValidator < ::ActiveModel::EachValidator
         def initialize(options)
           super(options.reverse_merge(:case_sensitive => true))
-          @klass = options[:class]
         end
 
         def validate_each(record, attribute, value)
@@ -56,9 +55,9 @@ module Neo4j
             conditions[attribute] = /^#{Regexp.escape(value.to_s)}$/i
           end
 
-          # prevent that same object is returned 
+          # prevent that same object is returned
           # TODO: add negative condtion to not return current record
-          found = @klass.all(conditions: conditions).to_a
+          found = record.class.all(conditions: conditions).to_a
           found.delete(record)
 
           if found.count > 0
@@ -75,7 +74,7 @@ module Neo4j
             conditions.merge(key => instance[key])
           end
         end
-      end      
+      end
 
       private
       def perform_validations(options={})


### PR DESCRIPTION
I've been using neo4j in a Rails app and have wanted to use a uniqueness validation on one of my classes.

I have set up the following class:

``` ruby
class Person
  include Neo4j::ActiveNode

  property :username, type: String
  validates_uniqueness_of :username
end
```

along with a corresponding spec:

``` ruby
describe Person do
  it 'validates uniqueness of username' do
      original = create(:person)
      expect(build(:person, username: original.username))
        .to have(1).errors_on(:username)
  end
end
```

The above spec fails with the following output:

```
Person validates uniqueness of github_username
     Failure/Error: original = create(:person)
     NoMethodError:
       undefined method `all' for nil:NilClass
     # ./spec/models/person_spec.rb:13:in `block (2 levels) in <top (required)>'
     # -e:1:in `<main>'
```

I've traced the problem down and there is no class being passed into the options hash on `UniquenessValidator#initialize`.

[Line 61](https://github.com/andreasronge/neo4j/blob/master/lib/neo4j/active_node/validations.rb#L61) in the `UniquenessValidator` calls all on a class that can't be found.

To remedy this, the class is now inferred from the record in `validate_each`.

I wasn't able to write any specs in the gem that replicate the problem. However, making the changes fixed the problem in my Rails app and doesn't cause any of the current specs to fail.
