### PR TITLE
magic property makeover

### DIFF
--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -19,20 +19,15 @@ module Neo4j::ActiveNode
     # If any of them fail the action is cancelled and save returns false. If the flag is false validations are bypassed altogether. See ActiveRecord::Validations for more information.
     # There’s a series of callbacks associated with save. If any of the before_* callbacks return false the action is cancelled and save returns false.
     def save(*)
-      # Update magic properties
       update_magic_properties
       create_or_update
-    end
-
-    def update_magic_properties
-      self.updated_at = DateTime.now if respond_to?(:updated_at=) && changed?
     end
 
     # Creates a model with values matching those of the instance attributes and returns its id.
     # @private
     # @return true
     def create_model(*)
-      self.created_at = DateTime.now if respond_to?(:created_at=)
+      set_timestamps
       properties = convert_properties_to :db, props
       node = _create_node(properties)
       init_on_load(node, node.props)
@@ -234,12 +229,20 @@ module Neo4j::ActiveNode
 
     private
 
+    def update_magic_properties
+      self.updated_at = DateTime.now if respond_to?(:updated_at=) && changed?
+    end
+
     def assign_attributes(attributes)
       attributes.each do |attribute, value|
         send("#{attribute}=", value)
       end
     end
 
+    def set_timestamps
+      self.created_at = DateTime.now if respond_to?(:created_at=)
+      self.updated_at = self.created_at if respond_to?(:updated_at=)
+    end
   end
 
 end

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -9,9 +9,10 @@ IceLolly = UniqueClass.create do
   property :required_on_create
   property :required_on_update
   property :created
+  property :start, type: Time
 
-  property :created_at, type: DateTime
-  property :updated_at, type: DateTime
+  property :created_at
+  property :updated_at
 
   attr_reader :saved
 
@@ -227,8 +228,9 @@ describe Neo4j::ActiveNode do
 
     Person = UniqueClass.create do
       include Neo4j::ActiveNode
-      attribute :name
-      attribute :age, type: Integer
+      property :name
+      property :age,   type: Integer
+      property :start,  type: Time
     end
 
     it 'generate accessors for declared attribute' do
@@ -236,6 +238,11 @@ describe Neo4j::ActiveNode do
       expect(person.name).to eq("hej")
       person.name = 'new name'
       expect(person.name).to eq("new name")
+    end
+
+    it 'accepts Time type, converts to DateTime' do
+      person = Person.create(start: Time.now)
+      person.start.class.should eq(DateTime)
     end
 
     it 'declared attribute can have type conversion' do


### PR DESCRIPTION
-Moved the addition of the `DateTime` type for `created_at` and `updated_at` to a `magic_properties` method.

-Added support for the `Time` property type, which is supported by ActiveRecord and was supported by Neo4j.rb 2.3 but is not supported by ActiveAttr. It's converted to DateTime behind the scenes but it should make migration and adoption easier. If we want to be really nice, we could convert these back to `Time` objects, I guess?

-Fixed the `updated_at` property so it is set to the same as `created_at` when the object is first created. This is consistent with ActiveRecord's behavior.

-Specs for this stuff. I changed some examples to use the `property` method instead of `attribute.` `attribute :property` works but it bypasses the magic properties, which screws up type conversion and didn't make sense for the purpose of the spec I added. If this was by design, my apologies!
