### PR TITLE
support for serialization of node properties

### DIFF
--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -31,6 +31,7 @@ require 'neo4j/active_node/has_n/nodes'
 require 'neo4j/active_node/query/query_proxy'
 require 'neo4j/active_node/query'
 require 'neo4j/active_node/quick_query'
+require 'neo4j/active_node/serialized_properties'
 require 'neo4j/active_node'
 
 require 'neo4j/active_node/orm_adapter'

--- a/lib/neo4j/active_node.rb
+++ b/lib/neo4j/active_node.rb
@@ -32,6 +32,7 @@ module Neo4j
     include Neo4j::ActiveNode::Initialize
     include Neo4j::ActiveNode::Identity
     include Neo4j::ActiveNode::Persistence
+    include Neo4j::ActiveNode::SerializedProperties
     include Neo4j::ActiveNode::Property
     include Neo4j::ActiveNode::Labels
     include Neo4j::ActiveNode::Validations

--- a/lib/neo4j/active_node/property.rb
+++ b/lib/neo4j/active_node/property.rb
@@ -65,7 +65,6 @@ module Neo4j::ActiveNode
         attribute(name, options)
       end
 
-      #overrides ActiveAttr's attribute! method
       def attribute!(name, options={})
         super(name, options)
         define_method("#{name}=") do |value|

--- a/lib/neo4j/active_node/serialized_properties.rb
+++ b/lib/neo4j/active_node/serialized_properties.rb
@@ -1,0 +1,25 @@
+module Neo4j::ActiveNode
+	module SerializedProperties
+    extend ActiveSupport::Concern
+
+    def serialized_properties
+    	self.class.serialized_properties
+    end
+
+		module ClassMethods
+
+			def serialized_properties=(name)
+				@serialize ||= []
+				@serialize.push name
+			end
+
+			def serialized_properties
+				@serialize || []
+			end
+
+			def serialize(name)
+				self.serialized_properties = name
+			end
+		end
+	end
+end

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -231,6 +231,9 @@ describe Neo4j::ActiveNode do
       property :name
       property :age,   type: Integer
       property :start,  type: Time
+      property :links
+
+      serialize :links
     end
 
     it 'generate accessors for declared attribute' do
@@ -341,4 +344,20 @@ describe Neo4j::ActiveNode do
     end
   end
 
+  describe 'serialization' do
+    let!(:chris) { Person.create(name: 'chris') }
+    
+    it 'correctly identifies properties for serialization' do
+      expect(Person.serialized_properties).to include(:links)
+      expect(chris.serialized_properties).to include(:links)
+    end
+
+    it 'successfully saves and returns hashes' do
+      links = {neo4j: 'http://www.neo4j.org', neotech: 'http://www.neotechnology.com/' }
+      chris.links = links
+      chris.save
+      expect(chris.links).to eq links
+      expect(chris.links.class).to eq Hash
+    end
+  end
 end

--- a/spec/integration/type_converters/type_converters_spec.rb
+++ b/spec/integration/type_converters/type_converters_spec.rb
@@ -14,6 +14,10 @@ describe Neo4j::TypeConverters do
     it 'has converters for Date' do
       Neo4j::TypeConverters.converters[Date].should eq(Neo4j::TypeConverters::DateConverter)
     end
+
+    it 'has converters for Hash' do
+      Neo4j::TypeConverters.converters[Hash].should eq(Neo4j::TypeConverters::HashConverter)
+    end
   end
 
   describe 'to_ruby' do
@@ -44,6 +48,19 @@ describe Neo4j::TypeConverters do
     end
   end
 
+  describe Neo4j::TypeConverters::HashConverter do
+    subject { Neo4j::TypeConverters::HashConverter }
+
+    let(:links) { {neo4j: 'http://www.neo4j.org', neotech: 'http://www.neotechnology.com/' } }
+
+    it 'translates from and to database' do
+      db_value = Neo4j::TypeConverters::HashConverter.to_db(links)
+      ruby_value = Neo4j::TypeConverters::HashConverter.to_ruby(db_value)
+      db_value.class.should eq String
+      ruby_value.class.should eq Hash
+      ruby_value['neo4j'].should eq 'http://www.neo4j.org'
+    end
+  end
 
   describe Neo4j::TypeConverters::DateConverter do
     subject { Neo4j::TypeConverters::DateConverter }


### PR DESCRIPTION
This lets you save hashes to the database. It operates in a way that should be familiar to ActiveRecord users.

``` ruby
class Person
  include Neo4j::ActiveNode
  property :links
  serialize :links
end
```
