### PR TITLE
Adds Paginated class

### DIFF
--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -32,6 +32,7 @@ require 'neo4j/active_node/query/query_proxy'
 require 'neo4j/active_node/query'
 require 'neo4j/active_node/quick_query'
 require 'neo4j/active_node/serialized_properties'
+require 'neo4j/paginated'
 require 'neo4j/active_node'
 
 require 'neo4j/active_node/orm_adapter'

--- a/lib/neo4j/paginated.rb
+++ b/lib/neo4j/paginated.rb
@@ -1,0 +1,19 @@
+module Neo4j
+  class Paginated
+    include Enumerable
+    attr_reader :items, :total, :current_page
+
+    def initialize(items, total, current_page)
+      @items, @total, @current_page = items, total, current_page
+    end
+
+    def self.create_from(source, page, per_page)
+      #partial = source.drop((page-1) * per_page).first(per_page)
+      partial = source.skip(page-1).limit(per_page)
+      Paginated.new(partial, source.count, page)
+    end
+
+    delegate :each, :to => :items
+    delegate :size, :[], :to => :items
+  end
+end

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -432,4 +432,23 @@ describe Neo4j::ActiveNode do
       end
     end
   end
+
+  describe "Neo4j::Paginated.create_from" do
+    before {
+      Person.destroy_all
+      i = 1.upto(16).to_a
+      i.each{|i| Person.create(age: i) }
+    }
+    after(:all) { Person.destroy_all }
+    let(:t) { Person.where }
+    let(:p) { Neo4j::Paginated.create_from(t, 2, 5) }
+
+    it "returns a Neo4j::Paginated" do
+      expect(p).to be_a(Neo4j::Paginated)
+    end
+
+    it 'returns the expected number of objects' do
+      expect(p.count).to eq 5
+    end
+  end
 end

--- a/spec/unit/paginated_spec.rb
+++ b/spec/unit/paginated_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Neo4j::Paginated do
+  describe 'initialize' do
+    it 'sets instance variables @items, @total, @current_page' do
+      a = Neo4j::Paginated.new(5, 10, 15)
+      %w[@items @total @current_page].each { |i| expect(a.instance_variable_defined?(i.to_sym)).to be_truthy }
+    end
+  end
+end


### PR DESCRIPTION
This adds the Paginated class back in, essentially unchanged from 2.3.

I also updated the neo4j-will_paginate gem to work with QueryProxy. The original repo hasn't been updated in so long so I'm not sure if I should do a PR there, to Andreas, or just leave it as is, so I'm gonna sit on it for now. Point your gemfile to my fork to use:

```
gem 'neo4j-will_paginate', '0.3.1', git: 'git@github.com:subvertallchris/neo4j-will_paginate.git'
```

https://github.com/subvertallchris/neo4j-will_paginate
