### PR TITLE
Implemented id_property so that the id of the node can be specified inst...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org'
 gemspec
 
 #gem 'neo4j-core', :path => '../neo4j-core'
-
+gem 'neo4j-core', :git => 'https://github.com/andreasronge/neo4j-core.git'
 #gem 'orm_adapter', :path => '../orm_adapter'
 
 gem 'coveralls', require: false

--- a/config/neo4j/config.yml
+++ b/config/neo4j/config.yml
@@ -1,98 +1,15 @@
 #=== Neo4j.rb configuration settings
 
-# The folder location of the neo4j and lucene database
-storage_path: db
+id_module: neo_id
 
-# If enable neo4j.rb will create _all relationship to all instances inheriting from Neo4j::Rails::Model
-# If disabled all custom rules will also be unavailable.
-enable_rules: true
-
+# TODO
 # if identity map should be on or not
 # It may impact the performance. Using the identity map will keep all loaded wrapper node/relationship
 # object in memory for each thread and transaction - which may speed up or slow down operations.
 identity_map: false
 
+# TODO
 # When using the Neo4j::Model you can let neo4j automatically set timestamps when updating/creating nodes.
 # If set to true neo4j.rb automatically timestamps create and update operations if the model has properties named created_at/created_on or updated_at/updated_on
 # (similar to ActiveRecord).
 timestamps: true
-
-# Configuration for lucene
-lucene: { fulltext: { provider: lucene,
-                      type: fulltext },
-          exact:    { provider: lucene,
-                       type: exact}
-}
-
-## If online backup should be available, if it is the Online JAR file will be loaded,
-## Notice it must be either 'true' or 'false' as string
-#enable_online_backup: 'false'
-#
-##use the clustered Neo4j GraphDatabase (org.neo4j.kernel.HighlyAvailableGraphDatabase)
-#ha.db: false
-#
-## Example of HA Configuration, see http://wiki.neo4j.org/content/High_Availability_Cluster
-## This is only used when ha.db is set to true
-#ha.server_id: 2
-#ha.server: 'localhost:6002'
-#ha.coordinators: 'localhost:2181,localhost:2182,localhost:2183'
-#
-## if enabled you can use the bin/neo4j-shell command to access the database
-#enable_remote_shell: "port=9332"
-#
-##===Memory mapped I/O settings===
-#
-##Each file in the Neo store can use memory mapped I/O for reading/writing.
-##Best performance is achived if the full file can be memory mapped but if
-##there isn't enough memory for that Neo will try and make the best use of
-##the memory it gets (regions of the file that get accessed often will more
-##likley be memory mapped).
-#
-##For high traversal speed it is important to have the nodestore.db and
-##relationshipstore.db files.
-#
-#neostore.nodestore.db.mapped_memory: 25M
-#neostore.relationshipstore.db.mapped_memory: 50M
-#neostore.propertystore.db.mapped_memory: 90M
-#neostore.propertystore.db.index.mapped_memory: 1M
-#neostore.propertystore.db.index.keys.mapped_memory: 1M
-#neostore.propertystore.db.strings.mapped_memory: 130M
-#neostore.propertystore.db.arrays.mapped_memory: 130M
-#
-#
-##: ": ": "Cache settings: ": ": "
-#
-##use adaptive caches YES|NO. Let Neo try make best use of available heap.
-#use_adaptive_cache: YES
-#
-##heap usage/max heap size ratio. Neo will increase caches while ratio
-##is less and decrease if greater. Default 0.77 seems to be a good over
-##all ratio of heap usage to avoid GC trashing. Larger heaps may allow for
-##a higher ratio while tiny heaps may need even less.
-#adaptive_cache_heap_ratio: 0.77
-#
-##how aggressive Neo will decrease caches once heap ratio reached
-#adaptive_cache_manager_decrease_ratio: 1.15
-#
-##how aggresive Neo will increase caches if ratio isn't yet reached
-#adaptive_cache_manager_increase_ratio: 1.1
-#
-##if no requests are made to Neo this is the amount of time in ms Neo will wait
-##before it checks the heap usage and adapts the caches if needed
-#adaptive_cache_worker_sleep_time: 3000
-#
-##minimum size (number of nodes) of node cache. If adaptive cache is in use
-##node cache will not be decreased under this value
-#min_node_cache_size: 0
-#
-##minimum size (number of relationships) of relationship cache. If adaptive
-##cache is in use relationship cache will not be decreased under this value
-#min_relationship_cache_size: 0
-#
-##maximum size (number of nodes) of node cache. If adaptive cache is not in
-##use the node cache will not be increased above this value
-#max_node_cache_size: 1500
-#
-##maximum size (number of relationship) of node cache. If adaptive cache is
-##not in use the relationship cache will not be increased above this value
-#max_relationship_cache_size: 3500

--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -15,10 +15,12 @@ require 'active_support/concern'
 require 'active_support/core_ext/class/attribute.rb'
 
 require 'active_attr'
+require 'neo4j/config'
 require 'neo4j/wrapper'
 require 'neo4j/type_converters'
 require "neo4j/active_node/labels"
 require 'neo4j/active_node/identity'
+require 'neo4j/active_node/id_property'
 require 'neo4j/active_node/callbacks'
 require 'neo4j/active_node/initialize'
 require 'neo4j/active_node/property'

--- a/lib/neo4j/active_node.rb
+++ b/lib/neo4j/active_node.rb
@@ -31,6 +31,7 @@ module Neo4j
 
     include Neo4j::ActiveNode::Initialize
     include Neo4j::ActiveNode::Identity
+    include Neo4j::ActiveNode::IdProperty
     include Neo4j::ActiveNode::Persistence
     include Neo4j::ActiveNode::SerializedProperties
     include Neo4j::ActiveNode::Property

--- a/lib/neo4j/active_node/id_property.rb
+++ b/lib/neo4j/active_node/id_property.rb
@@ -1,0 +1,96 @@
+module Neo4j::ActiveNode
+
+  module IdProperty
+    extend ActiveSupport::Concern
+
+
+    module TypeMethods
+      def define_id_methods(clazz, name, conf)
+        validate_conf(conf)
+        if conf[:on]
+          define_custom_method(clazz, name, conf[:on])
+        elsif conf[:auto]
+          raise "only :uuid auto id_property allowed, got #{conf[:auto]}" unless conf[:auto] == :uuid
+          define_uuid_method(clazz, name)
+        else conf.empty?
+          define_property_method(clazz, name)
+        end
+      end
+
+      private
+
+      def validate_conf(conf)
+        return if conf.empty?
+
+        raise "Expected a Hash, got #{conf.class} (#{conf.to_s}) for id_property" unless conf.is_a?(Hash)
+
+        unless conf.include?(:auto) || conf.include?(:on)
+          raise "Illegal value #{conf.inspect} for id_property, expected :on or :auto"
+        end
+      end
+
+      def define_property_method(clazz, name)
+        clazz.module_eval(%Q{
+          def id
+            persisted? ? #{name} : nil
+          end
+
+          property :#{name}
+          validates_uniqueness_of :#{name}
+        }, __FILE__, __LINE__)
+      end
+
+
+      def define_uuid_method(clazz, name)
+        clazz.module_eval(%Q{
+          default_property :#{name} do
+             ::SecureRandom.uuid
+          end
+
+          def #{name}
+             default_property :#{name}
+          end
+
+          alias_method :id, :#{name}
+        }, __FILE__, __LINE__)
+      end
+
+      def define_custom_method(clazz, name, on)
+        clazz.module_eval(%Q{
+          default_property :#{name} do |instance|
+             raise "Specifying custom id_property #{name} on none existing method #{on}" unless instance.respond_to?(:#{on})
+             instance.#{on}
+          end
+
+          def #{name}
+             default_property :#{name}
+          end
+
+          alias_method :id, :#{name}
+        }, __FILE__, __LINE__)
+      end
+
+      extend self
+    end
+
+    module ClassMethods
+
+      def find_by_id(key, session = Neo4j::Session.current!)
+        Neo4j::Node.load(key.to_i, session)
+      end
+
+
+      def id_property(name, conf = {})
+        TypeMethods.define_id_methods(self, name, conf)
+
+        constraint name, type: :unique
+
+        self.define_singleton_method(:find_by_id) do |key|
+          self.where(name => key).first
+        end
+      end
+    end
+
+  end
+
+end

--- a/lib/neo4j/active_node/identity.rb
+++ b/lib/neo4j/active_node/identity.rb
@@ -1,6 +1,5 @@
 module Neo4j::ActiveNode
   module Identity
-
     def ==(o)
       o.class == self.class && o.id == id
     end
@@ -17,13 +16,10 @@ module Neo4j::ActiveNode
       _persisted_node ? _persisted_node.neo_id : nil
     end
 
-    # @return [String, nil] same as #neo_id
     def id
       id = neo_id
       id.is_a?(Integer) ? id : nil
     end
 
-
   end
-
 end

--- a/lib/neo4j/active_node/initialize.rb
+++ b/lib/neo4j/active_node/initialize.rb
@@ -11,6 +11,7 @@ module Neo4j::ActiveNode::Initialize
     @_persisted_node = persisted_node
     changed_attributes && changed_attributes.clear
     @attributes = attributes.merge(properties.stringify_keys)
+    self.default_properties=properties
     @attributes = convert_properties_to :ruby, @attributes
   end
 

--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -129,7 +129,8 @@ module Neo4j::ActiveNode
 
     def _create_node(*args)
       session = self.class.neo4j_session
-      props = args[0] if args[0].is_a?(Hash)
+      props = self.class.default_property_values(self)
+      props.merge!(args[0]) if args[0].is_a?(Hash)
       labels = self.class.mapped_label_names
       session.create_node(props, labels)
     end
@@ -239,6 +240,9 @@ module Neo4j::ActiveNode
 
     private
 
+    def create_magic_properties
+
+    end
     def update_magic_properties
       self.updated_at = DateTime.now if respond_to?(:updated_at=) && changed?
     end

--- a/lib/neo4j/active_node/property.rb
+++ b/lib/neo4j/active_node/property.rb
@@ -32,6 +32,23 @@ module Neo4j::ActiveNode
     end
     alias_method :[], :read_attribute
 
+    def default_properties=(properties)
+      keys = self.class.default_properties.keys
+      @default_properties = properties.reject{|key| !keys.include?(key)}
+    end
+
+    def default_property(key)
+      keys = self.class.default_properties.keys
+      keys.include?(key.to_sym) ? default_properties[key.to_sym] : nil
+    end
+
+    def default_properties
+      @default_properties ||= {}
+      # keys = self.class.default_properties.keys
+      # _persisted_node.props.reject{|key| !keys.include?(key)}
+    end
+
+
     private
 
     # Changes attributes hash to remove relationship keys
@@ -91,13 +108,61 @@ module Neo4j::ActiveNode
 
     module ClassMethods
 
+      # Defines a property on the class
+      #
+      # See active_attr gem for allowed options, e.g which type
+      # Notice, in Neo4j you don't have to declare properties before using them, see the neo4j-core api.
+      #
+      # @example Without type
+      #    class Person
+      #      # declare a property which can have any value
+      #      property :name
+      #    end
+      #
+      # @example With type and a default value
+      #    class Person
+      #      # declare a property which can have any value
+      #      property :score, type: Integer, default: 0
+      #    end
+      #
+      # @example With an index
+      #    class Person
+      #      # declare a property which can have any value
+      #      property :name, index: :exact
+      #    end
+      #
+      # @example With a constraint
+      #    class Person
+      #      # declare a property which can have any value
+      #      property :name, constraint: :unique
+      #    end
       def property(name, options={})
         magic_properties(name, options)
-
-        # if (name.to_s == 'remember_created_at')
-        #   binding.pry
-        # end
         attribute(name, options)
+
+        # either constraint or index, do not set both
+        if options[:constraint]
+          raise "unknown constraint type #{options[:constraint]}, only :unique supported" if options[:constraint] != :unique
+          constraint(name, constraint: :unique)
+        elsif options[:index]
+          raise "unknown index type #{options[:index]}, only :exact supported" if options[:index] != :exact
+          index(name, options) if options[:index] == :exact
+        end
+      end
+
+      def default_property(name, &block)
+        default_properties[name] = block
+      end
+
+      # @return [Hash<Symbol,Proc>]
+      def default_properties
+        @default_property ||= {}
+      end
+
+      def default_property_values(instance)
+        default_properties.inject({}) do |result,pair|
+          result.tap{|obj| obj[pair[0]] = pair[1].call(instance)}
+        end
       end
 
       def attribute!(name, options={})

--- a/lib/neo4j/config.rb
+++ b/lib/neo4j/config.rb
@@ -1,0 +1,115 @@
+module Neo4j
+
+
+  # == Keeps configuration for neo4j
+  #
+  # == Configurations keys
+  #
+  class Config
+
+    DEFAULT_FILE = File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "neo4j", "config.yml"))
+
+    class << self
+
+      # @return [Fixnum] The location of the default configuration file.
+      def default_file
+        @default_file ||= DEFAULT_FILE
+      end
+
+      # Sets the location of the configuration YAML file and old deletes configurations.
+      #
+      # @param [String] file_path represent the path to the file.
+      def default_file=(file_path)
+        delete_all
+        @defaults = nil
+        @default_file = File.expand_path(file_path)
+      end
+
+      # @return [Hash] the default file loaded by yaml
+      def defaults
+        require 'yaml'
+        @defaults ||= ActiveSupport::HashWithIndifferentAccess.new(YAML.load_file(default_file))
+      end
+
+      # Reads from the default_file if configuration is not set already
+      # @return [Hash] the configuration
+      def get_or_setup_configuration
+        @configuration ||= setup
+      end
+
+      # @return [Hash] the configuration
+      def configuration
+        @configuration || {}
+      end
+
+      # Yields the configuration
+      #
+      # @example
+      #   Neo4j::Config.use do |config|
+      #     config[:storage_path] = '/var/neo4j'
+      #   end
+      #
+      # @return nil
+      # @yield config
+      # @yieldparam [Neo4j::Config] config - this configuration class
+      def use
+        @configuration ||= ActiveSupport::HashWithIndifferentAccess.new
+        yield @configuration
+        nil
+      end
+
+
+      # Sets the value of a config entry.
+      #
+      # @param [Symbol] key the key to set the parameter for
+      # @param val the value of the parameter.
+      def []=(key, val)
+        get_or_setup_configuration[key.to_s] = val
+      end
+
+
+      # @param [Symbol] key The key of the config entry value we want
+      # @return the the value of a config entry
+      def [](key)
+        get_or_setup_configuration[key.to_s]
+      end
+
+
+      # Remove the value of a config entry.
+      #
+      # @param [Symbol] key the key of the configuration entry to delete
+      # @return The value of the removed entry.
+      def delete(key)
+        get_or_setup_configuration.delete(key)
+      end
+
+
+      # Remove all configuration. This can be useful for testing purpose.
+      #
+      # @return nil
+      def delete_all
+        @configuration = nil
+      end
+
+
+      # @return [Hash] The config as a hash.
+      def to_hash
+        get_or_setup_configuration.to_hash
+      end
+
+      # @return [String] The config as a YAML
+      def to_yaml
+        get_or_setup_configuration.to_yaml
+      end
+
+      # @return The a new configuration using default values as a hash.
+      def setup
+        @configuration = ActiveSupport::HashWithIndifferentAccess.new
+        @configuration.merge!(defaults)
+        @configuration
+      end
+
+    end
+  end
+
+end

--- a/lib/neo4j/type_converters.rb
+++ b/lib/neo4j/type_converters.rb
@@ -125,6 +125,10 @@ module Neo4j
       serialize = self.respond_to?(:serialized_properties) ? self.serialized_properties : {}
       properties = properties.inject({}) do |new_attributes, key_value_pair|
         attr, value = key_value_pair
+
+        # skip "secret" undeclared attributes such as uuid
+        next new_attributes unless self.class.attributes[attr]
+
         type = serialize.has_key?(attr.to_sym) ? serialize[attr.to_sym] : self.class._attribute_type(attr)
         new_attributes[attr] = if TypeConverters.converters[type].nil?
                                   value

--- a/spec/e2e/id_property_spec.rb
+++ b/spec/e2e/id_property_spec.rb
@@ -1,0 +1,248 @@
+require 'spec_helper'
+
+describe Neo4j::ActiveNode::IdProperty do
+
+  describe 'when no id_property' do
+    let(:clazz) do
+      UniqueClass.create do
+        include Neo4j::ActiveNode
+      end
+    end
+  end
+
+
+  describe 'abnormal cases' do
+    describe 'id_property' do
+      it 'raise for id_property :something, :bla' do
+        expect do
+          UniqueClass.create do
+            include Neo4j::ActiveNode
+            id_property :something, :bla
+          end
+        end.to raise_error(/Expected a Hash/)
+      end
+
+      it 'raise for id_property :something, bla: 42' do
+        expect do
+          UniqueClass.create do
+            include Neo4j::ActiveNode
+            id_property :something, bla: 42
+          end
+        end.to raise_error(/Illegal value/)
+      end
+
+    end
+  end
+
+
+  describe 'when no id_property' do
+    let(:clazz) do
+      UniqueClass.create do
+        include Neo4j::ActiveNode
+      end
+    end
+
+    it 'uses the neo_id as id after save' do
+      node = clazz.new
+      expect(node.id).to eq(nil)
+      node.save!
+      expect(node.id).to eq(node.neo_id)
+    end
+
+    it 'can find by id uses the neo_id' do
+      node = clazz.create!
+      expect(clazz.find_by_id(node.id)).to eq(node)
+    end
+
+    describe 'when having a configuration' do
+      before do
+        Neo4j::Config[:id_property] = :the_id
+        Neo4j::Config[:id_property_type] = :auto # :uuid # auto: :uuid
+        Neo4j::Config[:id_property_type_value] = :uuid # :uuid # auto: :uuid
+      end
+
+      it 'will use the configuration value'
+    end
+  end
+
+  describe 'id_property :myid' do
+    let(:clazz) do
+      UniqueClass.create do
+        include Neo4j::ActiveNode
+        id_property :myid
+      end
+    end
+
+    it 'has an index' do
+      expect(clazz.mapped_label.indexes).to eq(:property_keys => [[:myid]])
+    end
+
+    it 'throws exception if the same uuid is generated when saving node' do
+      clazz.create(myid: 'z')
+      a = clazz.new(myid: 'z')
+      expect { clazz.create!(myid: 'z') }.to raise_error(Neo4j::ActiveNode::Persistence::RecordInvalidError)
+    end
+
+    describe 'property myid' do
+      it 'is not defined when before save ' do
+        node = clazz.new
+        expect(node.myid).to be_nil
+      end
+
+      it 'can be set' do
+        node = clazz.new
+        node.myid = '42'
+        expect(node.myid).to eq('42')
+      end
+
+      it 'can be saved after set' do
+        node = clazz.new
+        node.myid = '42'
+        node.save!
+        expect(node.myid).to eq('42')
+      end
+
+      it 'is same as id' do
+        node = clazz.new
+        node.myid = '42'
+        expect(node.id).to be_nil
+      end
+    end
+
+    describe 'find_by_id' do
+      it 'finds it if it exists' do
+        node1 = clazz.create(myid: 'a')
+        node2 = clazz.create(myid: 'b')
+        node3 = clazz.create(myid: 'c')
+        found = clazz.find_by_id('b')
+        expect(found).to eq(node2)
+      end
+
+      it 'does not find it if it does not exist' do
+        node = clazz.create(myid: 'd')
+        found = clazz.find_by_id('something else')
+        expect(found).to be_nil
+      end
+
+    end
+
+  end
+
+
+  describe 'id_property :my_id, on: :foobar' do
+    let(:clazz) do
+      UniqueClass.create do
+        include Neo4j::ActiveNode
+        id_property :my_id, on: :foobar
+
+        def foobar
+          'some id'
+        end
+      end
+    end
+
+    it 'has an index' do
+      expect(clazz.mapped_label.indexes).to eq(:property_keys => [[:my_id]])
+    end
+
+    it 'throws exception if the same uuid is generated when saving node' do
+      clazz.default_property :my_id do
+        'same uuid'
+      end
+      clazz.create
+      expect { clazz.create }.to raise_error(/Node \d+ already exists with label/)
+    end
+
+    describe 'property my_id' do
+      it 'is not defined when before save ' do
+        node = clazz.new
+        expect(node.my_id).to be_nil
+      end
+
+      it "is set to foobar's return value after save" do
+        node = clazz.new
+        node.save
+        expect(node.my_id).to eq('some id')
+      end
+
+      it 'is same as id' do
+        node = clazz.new
+        expect(node.id).to be_nil
+        node.save
+        expect(node.id).to eq(node.my_id)
+      end
+
+    end
+
+
+    describe 'find_by_id' do
+      it 'finds it if it exists' do
+        clazz.any_instance.stub(:foobar) { 100 }
+        node = clazz.create!
+        clazz.should_receive(:where).with(my_id: 100).and_return([:some_node])
+        expect(clazz.find_by_id(node.my_id)).to eq(:some_node)
+      end
+    end
+
+  end
+
+  describe 'id_property :my_uuid, auto: :uuid' do
+    let(:clazz) do
+      UniqueClass.create do
+        include Neo4j::ActiveNode
+        id_property :my_uuid, auto: :uuid
+      end
+    end
+
+    it 'has an index' do
+      expect(clazz.mapped_label.indexes).to eq(:property_keys => [[:my_uuid]])
+    end
+
+    it 'throws exception if the same uuid is generated when saving node' do
+      clazz.default_property :my_uuid do
+        'same uuid'
+      end
+      clazz.create
+      expect { clazz.create }.to raise_error(/Node \d+ already exists with label/)
+    end
+
+    describe 'property my_uuid' do
+      it 'is not defined when before save ' do
+        node = clazz.new
+        expect(node.my_uuid).to be_nil
+      end
+
+      it 'is is set when saving ' do
+        node = clazz.new
+        node.save
+        expect(node.my_uuid).to_not be_empty
+      end
+
+      it 'is same as id' do
+        node = clazz.new
+        expect(node.id).to be_nil
+        node.save
+        expect(node.id).to eq(node.my_uuid)
+      end
+
+    end
+
+    describe 'find_by_id' do
+      it 'finds it if it exists' do
+        node1 = clazz.create
+        node2 = clazz.create
+        node3 = clazz.create
+        found = clazz.find_by_id(node2.my_uuid)
+        expect(found).to eq(node2)
+      end
+
+      it 'does not find it if it does not exist' do
+        node = clazz.create
+        found = clazz.find_by_id('something else')
+        expect(found).to be_nil
+      end
+
+    end
+  end
+
+end

--- a/spec/e2e/label_spec.rb
+++ b/spec/e2e/label_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe "Neo4j::ActiveNode" do
   let(:clazz) do
-    UniqueClass.create() do
+    UniqueClass.create do
       include Neo4j::ActiveNode
     end
   end
@@ -17,6 +17,129 @@ describe "Neo4j::ActiveNode" do
       expect(clazz.create.labels).to eq([label_name])
     end
   end
+
+  describe 'property' do
+
+    describe 'property :age, index: :exact' do
+      let(:clazz) do
+        UniqueClass.create do
+          include Neo4j::ActiveNode
+        end
+      end
+
+      it 'creates an index' do
+        clazz.should_receive(:index).with(:age, {:index=>:exact})
+        clazz.property :age, index: :exact
+      end
+    end
+
+    describe 'property :age, index: :exact, constraint: :unique' do
+      let(:clazz) do
+        UniqueClass.create do
+          include Neo4j::ActiveNode
+        end
+      end
+
+      it 'creates a constraint but not an index' do # creating an constraint does also automatically create an index
+        clazz.should_not_receive(:index).with(:age, {:index=>:exact})
+        clazz.should_receive(:constraint).with(:age, {constraint: :unique})
+        clazz.property :age, index: :exact, constraint: :unique
+      end
+    end
+
+    describe 'property :age, constraint: :unique' do
+      let(:clazz) do
+        UniqueClass.create do
+          include Neo4j::ActiveNode
+        end
+      end
+
+      it 'creates a constraint but not an index' do # creating an constraint does also automatically create an index
+        clazz.should_not_receive(:index).with(:age, {:index=>:exact})
+        clazz.should_receive(:constraint).with(:age, {constraint: :unique})
+        clazz.property :age, constraint: :unique
+      end
+    end
+
+  end
+
+
+  describe 'constraint' do
+    let(:clazz_with_constraint) do
+      UniqueClass.create do
+        include Neo4j::ActiveNode
+        property :name
+        constraint :name, type: :unique
+
+        property :colour
+        index :colour, constraint: {type: :unique}
+      end
+    end
+
+    describe 'constraint :name, type: :unique' do
+      it 'can not create two nodes with unique properties' do
+        clazz_with_constraint.create(name: 'foobar')
+        expect{clazz_with_constraint.create(name: 'foobar')}.to raise_error
+      end
+
+      it 'can create two nodes with different properties' do
+        clazz_with_constraint.create(name: 'foobar1')
+        expect{clazz_with_constraint.create(name: 'foobar2')}.to_not raise_error
+      end
+
+    end
+
+    describe 'index :colour, constraint: {type: :unique}' do
+      it 'can not create two nodes with unique properties' do
+        clazz_with_constraint.create(colour: 'red')
+        expect{clazz_with_constraint.create(colour: 'red')}.to raise_error
+      end
+    end
+
+  end
+
+  describe 'index' do
+
+    let(:clazz) do
+      UniqueClass.create do
+        include Neo4j::ActiveNode
+        property :name
+        index :name
+      end
+    end
+
+    let(:other_class) do
+      UniqueClass.create do
+        include Neo4j::ActiveNode
+      end
+    end
+
+    it 'creates an index' do
+      expect(clazz.mapped_label.indexes).to eq(:property_keys => [[:name]])
+    end
+
+    it 'does not create index on other classes' do
+      expect(clazz.mapped_label.indexes).to eq(:property_keys => [[:name]])
+      expect(other_class.mapped_label.indexes).to eq(:property_keys => [])
+    end
+
+    describe 'when inherited' do
+      let(:subclass) do
+        Class.new(clazz)
+      end
+
+      it 'has an index on the baseclass' do
+        expect(clazz.mapped_label.indexes).to eq(:property_keys => [[:name]])
+      end
+
+      it 'has an index on the subclass' do
+        puts "subclass.mapped_label #{subclass.mapped_label_name}"
+        expect(subclass.mapped_label.indexes).to eq(:property_keys => [[:name]])
+      end
+
+    end
+  end
+
 
   describe 'add_label' do
     it "can add one label" do

--- a/spec/e2e/validation_uniqueness_spec.rb
+++ b/spec/e2e/validation_uniqueness_spec.rb
@@ -45,12 +45,6 @@ describe Neo4j::ActiveNode::Validations do
     it "should allow to update an object" do
       o = @clazz.new("name" => "joe")
       o.save.should be true
-
-      @clazz \
-        .stub(:first) \
-        .with(:name => 'joe') \
-        .and_return(o)
-
       o.name = "joe"
       o.valid?.should be true
       o.should_not have_error_on(:name)

--- a/spec/unit/config.yml
+++ b/spec/unit/config.yml
@@ -1,0 +1,1 @@
+my_conf: My value

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe Neo4j::Config do
+
+  describe 'default_file' do
+    it 'should exist' do
+      expect(File.exist?(Neo4j::Config.default_file)).to eq(true)
+    end
+  end
+
+
+  describe 'when using a different existing config' do
+    before do
+      Neo4j::Config.default_file = File.expand_path(File.join(File.dirname(__FILE__), "config.yml"))
+    end
+
+    after do
+      Neo4j::Config.default_file= Neo4j::Config::DEFAULT_FILE
+    end
+
+    describe 'defaults' do
+      it 'has values' do
+        expect(Neo4j::Config.defaults[:my_conf]).to eq('My value')
+      end
+    end
+
+    describe '[]' do
+      it 'returns the configuration property' do
+        expect(Neo4j::Config[:my_conf]).to eq('My value')
+      end
+    end
+
+    describe '[]=' do
+      it 'can set new configuration' do
+        Neo4j::Config[:foo] = 42
+        Neo4j::Config[:my_conf] = 43
+        expect(Neo4j::Config[:foo]).to eq(42)
+        expect(Neo4j::Config[:my_conf]).to eq(43)
+      end
+
+      it 'can use both strings and symbols as keys' do
+        Neo4j::Config[:foo] = 1
+        Neo4j::Config['bar'] = 2
+        expect(Neo4j::Config[:foo]).to eq(1)
+        expect(Neo4j::Config['bar']).to eq(2)
+        expect(Neo4j::Config['foo']).to eq(1)
+        expect(Neo4j::Config[:bar]).to eq(2)
+      end
+    end
+
+    describe 'delete' do
+      it 'deletes a configuration' do
+        expect(Neo4j::Config[:my_conf]).to eq('My value')
+        Neo4j::Config.delete(:my_conf)
+        expect(Neo4j::Config[:my_conf]).to be_nil
+      end
+    end
+
+
+    describe 'use' do
+      it 'yields the configuration' do
+        Neo4j::Config.use do |c|
+          c[:bar] = 'foo'
+        end
+        expect(Neo4j::Config[:bar]).to eq('foo')
+      end
+    end
+
+    describe 'to_yaml' do
+      it 'returns yaml string' do
+        expect(Neo4j::Config.to_yaml).to match(/my_conf: My value/)
+      end
+    end
+
+    describe 'to_hash' do
+      it 'returns hash' do
+        expect(Neo4j::Config.to_hash).to be_a(Hash)
+        expect(Neo4j::Config.to_hash['my_conf']).to eq('My value')
+      end
+    end
+
+    describe 'delete_all' do
+      it 'deletes all' do
+        Neo4j::Config.delete_all
+        expect(Neo4j::Config.configuration).to eq({})
+      end
+    end
+  end
+end

--- a/spec/unit/identity_spec.rb
+++ b/spec/unit/identity_spec.rb
@@ -6,6 +6,10 @@ describe Neo4j::ActiveNode::Identity do
       include Neo4j::ActiveNode::Persistence
       include Neo4j::ActiveNode::Identity
       include Neo4j::ActiveNode::Property
+
+      def id
+        neo_id
+      end
     end
   end
 


### PR DESCRIPTION
Implemented id_property so that the id of the node can be specified instead of using neo_id, see issue andreasronge/neo4j#354
- Reimplemented Neo4j::Config so that default value for id_property can be specified
- Allow Model.property to specify index and constraint
### TODO
- Use the Neo4j::Config to set default value for id_property. Probably need some callback from neo4j-core when session is started to configure the id property
- Improve the speed of id_property spec and mock more
