### PR TITLE
support for hidden _classname property and cache_class method

### DIFF
--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -27,6 +27,7 @@ module Neo4j::ActiveNode
     # @private
     # @return true
     def create_model(*)
+      create_magic_properties
       set_timestamps
       properties = convert_properties_to :db, props
       node = _create_node(properties)
@@ -131,6 +132,7 @@ module Neo4j::ActiveNode
       session = self.class.neo4j_session
       props = self.class.default_property_values(self)
       props.merge!(args[0]) if args[0].is_a?(Hash)
+      set_classname(props)
       labels = self.class.mapped_label_names
       session.create_node(props, labels)
     end
@@ -241,10 +243,14 @@ module Neo4j::ActiveNode
     private
 
     def create_magic_properties
-
     end
+
     def update_magic_properties
       self.updated_at = DateTime.now if respond_to?(:updated_at=) && changed?
+    end
+
+    def set_classname(props)
+      props[:_classname] = self.class.name if self.class.cached_class?
     end
 
     def assign_attributes(attributes)

--- a/lib/neo4j/active_node/property.rb
+++ b/lib/neo4j/active_node/property.rb
@@ -174,6 +174,14 @@ module Neo4j::ActiveNode
         end
       end
 
+      def cache_class
+        @cached_class = true
+      end
+
+      def cached_class?
+        @cached_class || false
+      end
+
       # Extracts keys from attributes hash which are relationships of the model
       # TODO: Validate separately that relationships are getting the right values?  Perhaps also store the values and persist relationships on save?
       def extract_relationship_attributes!(attributes)

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -224,6 +224,46 @@ describe Neo4j::ActiveNode do
 
   end
 
+  describe 'cached classnames' do
+    CachedClass = UniqueClass.create do
+      include Neo4j::ActiveNode
+      cache_class
+    end
+
+    UncachedClass = UniqueClass.create do
+      include Neo4j::ActiveNode
+    end
+
+    context 'with cache_class set in model' do
+      let(:test) { CachedClass.create }
+      before { @unwrapped = Neo4j::Node._load(test.id) }
+      it 'responds true to :cached_class?' do
+        expect(CachedClass.cached_class?).to be_truthy
+      end
+
+      it 'sets _classname property equal to class name' do
+        expect(@unwrapped[:_classname]).to eq test.class.name
+      end
+
+      it 'removes the _classname property from the wrapped class' do
+        expect(test.props).to_not have_key(:_classname)
+      end
+    end
+
+    context 'without cache_class set in model' do
+      let(:test) { UncachedClass.create }
+      before { @unwrapped = Neo4j::Node._load(test.id) }
+
+      it 'response false to :cached_class?' do
+        expect(UncachedClass.cached_class?).to be_falsey
+      end
+
+      it "does not set _classname on the node" do
+        expect(@unwrapped.props).to_not have_key(:_classname)
+      end
+    end
+  end
+
   describe 'basic persistance' do
 
     Person = UniqueClass.create do

--- a/spec/unit/wrapper_spec.rb
+++ b/spec/unit/wrapper_spec.rb
@@ -6,7 +6,6 @@ describe Neo4j::Node::Wrapper do
     obj.extend(Neo4j::Node::Wrapper)
   end
 
-
   describe 'load_class_from_label' do
     it 'find classes' do
       clazz = UniqueClass.create
@@ -42,6 +41,37 @@ describe Neo4j::Node::Wrapper do
   end
 
   describe 'wrapper' do
+    describe "with _classname property" do
+      context 'present on class' do
+        it 'does not call :_class_wrappers' do
+          class CachedClassName
+            include Neo4j::Node::Wrapper
+            def props
+              { _classname: 'CachedClassName'}
+            end
+          end
+
+          expect(wrapper).to_not receive(:_class_wrappers)
+          wrapper = CachedClassName.new
+          wrapper.sorted_wrapper_classes
+        end
+      end
+
+      context "missing on class" do
+        it 'calls :_class_wrappers' do
+          class NotCachedClassName
+            include Neo4j::Node::Wrapper
+            def props
+              { name: 'foo' }
+            end
+          end
+          wrapper = NotCachedClassName.new
+          expect(wrapper).to receive(:_class_wrappers).once
+          wrapper.sorted_wrapper_classes
+        end
+      end
+    end
+
     it 'can find the wrapper even if it is auto loaded' do
       module AutoLoadTest
       end


### PR DESCRIPTION
This does two important things:

First, it adds support for the `_classname` property on nodes to resolve https://github.com/andreasronge/neo4j-core/issues/79. Each of those second queries pointed out in that issue is an attempt to determine the class of the node. This patch changes the behavior to look for a `_classname` property and if it finds it, it uses the value to wrap the class. If it does not find it, it performs a label lookup.

Second, it adds a `cache_class` class method for nodes. Add this to any model and `_classname` will be set automatically. Frankly, I think this should be automatic for every node but a lot of specs break when this is added in, so I had to make it an opt-in option. (Is this the first step towards a master ActiveNode class that all others inherit from, similar to `Neo4j::Rails::Model` in 2.x?)

I'm pushing this to your UUID branch because you added the behavior that undeclared properties are hidden during the node wrap. This is important because _classname should not be visible to users.

The result is that it cuts the number of queries in half for many pages. The label query/return is quick but I can't see how it wouldn't make a difference on a busy app.
