### PR TITLE
makes classname caching a global default

### DIFF
--- a/config/neo4j/config.yml
+++ b/config/neo4j/config.yml
@@ -29,5 +29,5 @@ timestamps: true
 # Strings shorter than 44 characters are classified, so this will have almost no impact on disk footprint. See http://docs.neo4j.org/chunked/stable/short-strings.html.
 # Alternatively, call class method Neo4j::ActiveNode:cache_class to set this on specific models.
 # By default, this property is called _classname, set as symbol to override.
-cache_class_names: false
+cache_class_names: true
 # class_name_property:  :_classname

--- a/lib/neo4j/active_node/property.rb
+++ b/lib/neo4j/active_node/property.rb
@@ -174,12 +174,8 @@ module Neo4j::ActiveNode
         end
       end
 
-      def cache_class
-        @cached_class = true
-      end
-
       def cached_class?
-        @cached_class || !!Neo4j::Config[:cache_class_names]
+        !!Neo4j::Config[:cache_class_names]
       end
 
       # Extracts keys from attributes hash which are relationships of the model

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -225,58 +225,45 @@ describe Neo4j::ActiveNode do
   end
 
   describe 'cached classnames' do
-    CachedClass = UniqueClass.create do
-      include Neo4j::ActiveNode
-      cache_class
-    end
-
-    UncachedClass = UniqueClass.create do
+    CacheTest = UniqueClass.create do
       include Neo4j::ActiveNode
     end
 
-    context 'with cache_class set in model' do
-      let(:test) { CachedClass.create }
-      before { @unwrapped = Neo4j::Node._load(test.id) }
+    context 'with cache_class set in config' do
+      before do
+        Neo4j::Config[:cache_class_names] = true
+        @cached = CacheTest.create
+        @unwrapped = Neo4j::Node._load(@cached.id)
+      end
+
       it 'responds true to :cached_class?' do
-        expect(CachedClass.cached_class?).to be_truthy
+        expect(CacheTest.cached_class?).to be_truthy
       end
 
       it 'sets _classname property equal to class name' do
-        expect(@unwrapped[:_classname]).to eq test.class.name
+        expect(@unwrapped[:_classname]).to eq @cached.class.name
       end
 
       it 'removes the _classname property from the wrapped class' do
-        expect(test.props).to_not have_key(:_classname)
+        expect(@cached.props).to_not have_key(:_classname)
       end
     end
 
     context 'without cache_class set in model' do
-      let(:test) { UncachedClass.create }
-      before { 
+      before do
         Neo4j::Config[:cache_class_names] = false
-        @unwrapped = Neo4j::Node._load(test.id) 
-      }
+        @uncached = CacheTest.create
+        @unwrapped = Neo4j::Node._load(@uncached.id)
+      end
+
+      before { Neo4j::Config[:cache_class_names] = false }
 
       it 'response false to :cached_class?' do
-        expect(UncachedClass.cached_class?).to be_falsey
+        expect(CacheTest.cached_class?).to be_falsey
       end
 
       it "does not set _classname on the node" do
         expect(@unwrapped.props).to_not have_key(:_classname)
-      end
-    end
-
-    context 'with "cache_class_names" set in config' do
-      ConfigSetsCache = UniqueClass.create do
-        include Neo4j::ActiveNode
-        property :name
-      end
-
-      it 'the response of "cached_class?" changes' do
-        Neo4j::Config[:cache_class_names] = false
-        expect(ConfigSetsCache.cached_class?).to be_falsey
-        Neo4j::Config[:cache_class_names] = true
-        expect(ConfigSetsCache.cached_class?).to be_truthy
       end
     end
   end


### PR DESCRIPTION
Makes the _classname property a default. Can still be disabled by passing `config.neo4j[:cache_class_names] = false` in application.rb or `Neo4j::Config[:cache_class_names] = false` at any time. This also removes the `cache_class` method, since it's handled at the config level.
