### PR TITLE
Allow inheritance when checking model class on a relation

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -145,7 +145,7 @@ module Neo4j
             end
           end.compact
 
-          raise ArgumentError, "Node must be of the association's class when model is specified" if @model && other_nodes.any? {|other_node| other_node.class != @model }
+          raise ArgumentError, "Node must be of the association's class when model is specified" if @model && other_nodes.any? {|other_node| !other_node.is_a?(@model) }
           other_nodes.each do |other_node|
             #Neo4j::Transaction.run do
               other_node.save if not other_node.persisted?


### PR DESCRIPTION
I have polymorphic classes stored with ActiveNode.  Many nodes have more than one label.  To have relations that reference the superclass, I had to change query_proxy to accept anything that is_a?(@model)

Is there a better way to do this?
