### PR TITLE
Do not override Module#include?

### DIFF
--- a/lib/neo4j/active_node/query_methods.rb
+++ b/lib/neo4j/active_node/query_methods.rb
@@ -36,11 +36,6 @@ module Neo4j
 
       alias_method :blank?, :empty?
 
-      def include?(other)
-        raise(InvalidParameterError, ':include? only accepts nodes') unless other.respond_to?(:neo_id)
-        self.query_as(:n).where(n: {primary_key => other.id}).return("count(n) AS count").first.count > 0
-      end
-
       def find_in_batches(options = {})
         self.query_as(:n).return(:n).find_in_batches(:n, primary_key, options) do |batch|
           yield batch.map(&:n)


### PR DESCRIPTION
Commit af2fe8b37ae2ba32c853665e288b644050a76550 causes a regression on issue #508.
It was re-adding a definition for `include?`. Maybe due to an error while merging conflicts?
