### PR TITLE
make include_root_in_json configurable, defaults to false

### DIFF
--- a/lib/neo4j/config.rb
+++ b/lib/neo4j/config.rb
@@ -113,7 +113,9 @@ module Neo4j
         Neo4j::Config[:class_name_property] || :_classname
       end
 
+      def include_root_in_json
+        Neo4j::Config[:include_root_in_json] || false
+      end
     end
   end
-
 end

--- a/lib/neo4j/shared.rb
+++ b/lib/neo4j/shared.rb
@@ -22,7 +22,7 @@ module Neo4j
     end
 
     included do
-      self.include_root_in_json = true
+      self.include_root_in_json = Neo4j::Config.include_root_in_json
 
       def self.i18n_scope
         :neo4j

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -8,7 +8,6 @@ describe Neo4j::Config do
     end
   end
 
-
   describe 'when using a different existing config' do
     before do
       Neo4j::Config.default_file = File.expand_path(File.join(File.dirname(__FILE__), "config.yml"))
@@ -83,6 +82,19 @@ describe Neo4j::Config do
       it 'deletes all' do
         Neo4j::Config.delete_all
         expect(Neo4j::Config.configuration).to eq({})
+      end
+    end
+  end
+
+  describe 'options' do
+    describe 'include_root_in_json' do
+      it 'defaults to true' do
+        expect(Neo4j::Config.include_root_in_json).to be_falsey
+      end
+
+      it 'respects config' do
+        Neo4j::Config[:include_root_in_json] = true
+        expect(Neo4j::Config.include_root_in_json).to be_truthy
       end
     end
   end

--- a/spec/unit/query_proxy_methods_spec.rb
+++ b/spec/unit/query_proxy_methods_spec.rb
@@ -22,6 +22,7 @@ describe 'query_proxy_methods' do
 
     class IncludeTeacher
       include Neo4j::ActiveNode
+      property :name
       has_many :out, :lessons, model_class: IncludeLesson, type: 'teaching_lesson'
     end
 


### PR DESCRIPTION
As the commit says, it makes `include_root_in_json` configurable through `config.neo4j.include_root_in_json` or `Neo4j::Config[:include_root_in_json]`. It also sets the default to false to mirror ActiveRecord's behavior.
