### PR TITLE
adds simple rel_where method to queryproxy

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -106,7 +106,7 @@ module Neo4j
           self.to_a == value
         end
 
-        METHODS = %w[where order skip limit]
+        METHODS = %w[where rel_where order skip limit]
 
         METHODS.each do |method|
           module_eval(%Q{
@@ -320,7 +320,7 @@ module Neo4j
           node_num = 1
           result = []
           if arg.is_a?(Hash)
-            arg.map do |key, value|
+            arg.each do |key, value|
               if @model && @model.has_association?(key)
 
                 neo_id = value.try(:neo_id) || value
@@ -336,6 +336,18 @@ module Neo4j
               else
                 result << [:where, ->(v) { {v => {key => value}}}]
               end
+            end
+          elsif arg.is_a?(String)
+            result << [:where, arg]
+          end
+          result
+        end
+
+        def links_for_rel_where_arg(arg)
+          result = []
+          if arg.is_a?(Hash)
+            arg.each do |key, value|
+              result << [:where, ->(v) {{ rel_identity => { key => value }}}]
             end
           elsif arg.is_a?(String)
             result << [:where, arg]

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -237,13 +237,34 @@ describe 'Query API' do
         describe 'on classes' do
           before(:each) do
             danny.lessons << math101
+            rel = danny.lessons(:l, :r).pluck(:r).first
+            rel[:grade] = 65
+
             bobby.lessons << math101
+            rel = bobby.lessons(:l, :r).pluck(:r).first
+            rel[:grade] = 71
+
+            math101.teachers << othmar
+            rel = math101.teachers(:t, :r).pluck(:r).first
+            rel[:since] = 2001
+
             sandra.lessons << ss101
           end
 
           context 'students, age 15, who are taking level 101 lessons' do
             it { Student.as(:student).where(age: 15).lessons(:lesson).where(level: 101).pluck(:student).should == [danny] }
             it { Student.where(age: 15).lessons(:lesson).where(level: '101').pluck(:lesson).should_not == [[othmar]] }
+          end
+
+          context 'Students enrolled in math 101 with grade 65' do
+            # with automatic identifier
+            it { Student.as(:student).lessons.rel_where(grade: 65).pluck(:student).should == [danny] }
+
+            # with manual identifier
+            it { Student.as(:student).lessons(:l, :r).rel_where(grade: 65).pluck(:student).should == [danny] }
+
+            # with multiple instances of rel_where
+            it { Student.as(:student).lessons(:l).rel_where(grade: 65).teachers(:t, :t_r).rel_where(since: 2001).pluck(:t).should == [othmar] }
           end
 
           context 'with has_one' do


### PR DESCRIPTION
Very simple. Uses the most recently set rel identifier (either manual or automatic) and builds `where` around it.
