### PR TITLE
Do not load neo4j-core tasks in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require "bundler/gem_tasks"
-load 'neo4j/tasks/neo4j_server.rake'
+# load 'neo4j/tasks/neo4j_server.rake'
 load 'neo4j/tasks/migration.rake'
 
 desc "Generate YARD documentation"


### PR DESCRIPTION
Invoking rake on a pristine repository was failing, because it tried to load the server tasks from neo4j-core. The neo4j-core gem is no longer needed and already commented out in the Gemfile.

Should we keep the lines as comments or remove them entirely in both files?
