### PR TITLE
destroy_all should return to Ruby, delete_all happens in cypher

### DIFF
--- a/lib/neo4j/active_node/labels.rb
+++ b/lib/neo4j/active_node/labels.rb
@@ -95,10 +95,16 @@ module Neo4j
           find_by(args) or raise RecordNotFound, "#{self.query_as(:n).where(n: a).limit(1).to_cypher} returned no results"
         end
 
-        # Destroy all nodes and connected relationships
-        def destroy_all
+        # Deletes all nodes and connected relationships from Cypher.
+        def delete_all
           self.neo4j_session._query("MATCH (n:`#{mapped_label_name}`)-[r]-() DELETE n,r")
           self.neo4j_session._query("MATCH (n:`#{mapped_label_name}`) DELETE n")
+        end
+
+        # Returns each node to Ruby and calls `destroy`. Be careful, as this can be a very slow operation if you have many nodes. It will generate at least
+        # one database query per node in the database, more if callbacks require them.
+        def destroy_all
+          self.all.each { |n| n.destroy }
         end
 
         # Creates a Neo4j index on given property

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -57,7 +57,7 @@ describe IceLolly, :type => :integration do
 
     context "after being saved" do
       before do
-        subject.class.destroy_all
+        subject.class.delete_all
         subject.save
       end
 
@@ -543,12 +543,12 @@ describe Neo4j::ActiveNode do
 
   describe "Neo4j::Paginated.create_from" do
     before do
-      Person.destroy_all
+      Person.delete_all
       i = 1.upto(16).to_a
       i.each{ |count| Person.create(name: "Billy-#{i}", age: count) }
     end
 
-    after(:all) { Person.destroy_all }
+    after(:all) { Person.delete_al }
     let(:t) { Person.where }
     let(:p) { Neo4j::Paginated.create_from(t, 2, 5) }
 
@@ -562,7 +562,7 @@ describe Neo4j::ActiveNode do
 
     describe 'ordered pagination' do
       before do
-        Person.destroy_all
+        Person.delete_all
         ['Alice', 'Bob', 'Carol', 'David'].each { |name| Person.create(name: name) }
       end
 

--- a/spec/e2e/basic_model_spec.rb
+++ b/spec/e2e/basic_model_spec.rb
@@ -26,20 +26,26 @@ describe BasicModel do
 
   context "when there's lots of them" do
     before(:each) do
-      subject.class.destroy_all
-      subject.class.create!
-      subject.class.create!
-      subject.class.create!
+      subject.class.delete_all
+      3.times { subject.class.create! }
     end
 
     it "should be possible to #count" do
       subject.class.count.should == 3
     end
 
-    it "should be possible to #destroy_all" do
-      subject.class.all.to_a.size.should == 3
+    it "should be possible to #delete_all" do
+      expect(subject.class).not_to receive(:all)
+      expect(subject.class.count).to eq 3
+      subject.class.delete_all
+      expect(subject.class.count).to eq 0
+    end
+
+    it 'should be possible to #destroy_all' do
+      expect(subject.class).to receive(:all).and_return(subject.class.all)
+      expect(subject.class.count).to eq 3
       subject.class.destroy_all
-      subject.class.all.to_a.should be_empty
+      expect(subject.class.count).to eq 0
     end
   end
 end

--- a/spec/e2e/id_property_spec.rb
+++ b/spec/e2e/id_property_spec.rb
@@ -28,7 +28,6 @@ describe Neo4j::ActiveNode::IdProperty do
           end
         end.to raise_error(/Illegal value/)
       end
-
     end
   end
 
@@ -168,7 +167,6 @@ describe Neo4j::ActiveNode::IdProperty do
         expect(found).to eq node1
       end
     end
-
   end
 
 
@@ -214,7 +212,6 @@ describe Neo4j::ActiveNode::IdProperty do
         node.save
         expect(node.id).to eq(node.my_id)
       end
-
     end
 
 
@@ -226,7 +223,6 @@ describe Neo4j::ActiveNode::IdProperty do
         expect(clazz.find_by_id(node.my_id)).to eq(:some_node)
       end
     end
-
   end
 
   describe 'id_property :my_uuid, auto: :uuid' do
@@ -267,7 +263,6 @@ describe Neo4j::ActiveNode::IdProperty do
         node.save
         expect(node.id).to eq(node.my_uuid)
       end
-
     end
 
     describe 'find_by_id' do
@@ -284,7 +279,6 @@ describe Neo4j::ActiveNode::IdProperty do
         found = clazz.find_by_id('something else')
         expect(found).to be_nil
       end
-
     end
   end
 
@@ -319,11 +313,7 @@ describe Neo4j::ActiveNode::IdProperty do
       end
     end
 
-    after(:all) do
-      IdProp::Teacher.destroy_all
-      IdProp::Car.destroy_all
-      IdProp::Apple.destroy_all
-    end
+    after(:all) { [IdProp::Teacher, IdProp::Car, IdProp::Apple].each { |c| c.delete_all } }
 
     it 'inherits the base id_property' do
       expect(IdProp::Substitute.create.my_id).to eq 'an id'
@@ -337,5 +327,4 @@ describe Neo4j::ActiveNode::IdProperty do
       expect(IdProp::Apple.create.my_id).not_to be_nil
     end
   end
-
 end

--- a/spec/e2e/inheritance_spec.rb
+++ b/spec/e2e/inheritance_spec.rb
@@ -23,8 +23,7 @@ describe 'Inheritance', type: :e2e do
   end
 
   before(:each) do
-    InheritanceTest::Car.destroy_all
-    InheritanceTest::Vehicle.destroy_all
+    [InheritanceTest::Car, InheritanceTest::Vehicle].each { |c| c.delete_all }
     @bike = InheritanceTest::Vehicle.create(name: 'bike')
     @volvo = InheritanceTest::Car.create(name: 'volvo', model: 'v60')
     @saab = InheritanceTest::Car.create(name: 'saab', model: '900')

--- a/spec/e2e/migration_spec.rb
+++ b/spec/e2e/migration_spec.rb
@@ -41,7 +41,7 @@ describe 'migration tasks' do
         include Neo4j::ActiveRel
         from_class false
         to_class false
-        type 'singers' 
+        type 'singers'
       end
 
       class ThirdRelClass
@@ -122,8 +122,8 @@ describe 'migration tasks' do
   describe 'AddClassnames class' do
     let(:full_path) { '/hd/gems/rails/add_classnames.yml' }
     let(:clazz) { Neo4j::Migration::AddClassnames }
-    let(:map_template) do 
-      {  
+    let(:map_template) do
+      {
         nodes: { 'add' => ['MigrationSpecs::User'], 'overwrite' => ['MigrationSpecs::Song'] },
         relationships: {
           'add' =>       {  'MigrationSpecs::FirstRelClass' => { :type => 'songs' } },
@@ -144,10 +144,7 @@ describe 'migration tasks' do
       clazz.any_instance.instance_variable_set(:@model_map, map_template)
     end
 
-    after(:each) do
-      MigrationSpecs::User.destroy_all
-      MigrationSpecs::Song.destroy_all
-    end
+    after(:each) { [MigrationSpecs::User, MigrationSpecs::Song].each { |c| c.delete_all } }
 
     it 'loads an initialization file' do
       expect{ clazz.new }.not_to raise_error

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -182,9 +182,7 @@ describe 'query_proxy_methods' do
 
   describe 'delete_all' do
     before do
-      IncludeStudent.destroy_all
-      IncludeLesson.destroy_all
-      IncludeTeacher.destroy_all
+      [IncludeStudent, IncludeLesson, IncludeTeacher].each { |c| c.delete_all }
       @tom = IncludeStudent.create(name: 'Tom')
       @math = IncludeLesson.create(name: 'Math')
       @science = IncludeLesson.create(name: 'Science')

--- a/spec/e2e/wrapped_transactions_spec.rb
+++ b/spec/e2e/wrapped_transactions_spec.rb
@@ -30,8 +30,8 @@ describe 'wrapped nodes in transactions', api: :server do
   before(:all) do
     @Student = TransactionNode::Student
     @Teacher = TransactionNode::Teacher
-    @Student.destroy_all
-    @Teacher.destroy_all
+    @Student.delete_all
+    @Teacher.delete_all
 
     @Student.create(name: 'John')
     @Teacher.create(name: 'Mr Jones')

--- a/spec/integration/label_spec.rb
+++ b/spec/integration/label_spec.rb
@@ -102,13 +102,13 @@ describe "Labels" do
 
     describe 'when indexed' do
       it 'can find it using the index' do
-        IndexedTestClass.destroy_all
+        IndexedTestClass.delete_all
         kalle = IndexedTestClass.create(name: 'kalle')
         IndexedTestClass.where(name: 'kalle').first.should == kalle
       end
 
       it 'does not find it if deleted' do
-        IndexedTestClass.destroy_all
+        IndexedTestClass.delete_all
         kalle2 = IndexedTestClass.create(name: 'kalle2')
         result = IndexedTestClass.where(name: 'kalle2').first
         result.should == kalle2


### PR DESCRIPTION
This has bugged me for a little while. Our `destroy_all` class method was behaving like `delete_all`, killing everything in Cypher. This fixes that, updates all specs that were using it for cleanup, and adds new specs to prove that it is calling `all` on the class, which we take to mean that it is returning them to Ruby.

I considered going a step further and proving that it is executing callbacks but that's not the point of that spec file and I wanted to keep it as basic as possible.
