### PR TITLE
don't use persisted?, use _persisted_obj and neo_id, rely on cypher errors

### DIFF
--- a/lib/neo4j/active_node/id_property.rb
+++ b/lib/neo4j/active_node/id_property.rb
@@ -47,7 +47,7 @@ module Neo4j::ActiveNode
 
         clazz.module_eval(%Q{
           def id
-            persisted? ? #{name.to_sym == :id ? 'attribute(\'id\')' : name} : nil
+            _persisted_obj ? #{name.to_sym == :id ? 'attribute(\'id\')' : name} : nil
           end
 
           validates_uniqueness_of :#{name}

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -216,7 +216,7 @@ module Neo4j
           raise ArgumentError, "Node must be of the association's class when model is specified" if @model && other_nodes.any? {|other_node| !other_node.is_a?(@model) }
           other_nodes.each do |other_node|
             #Neo4j::Transaction.run do
-              other_node.save if not other_node.persisted?
+              other_node.save unless other_node.neo_id
 
               return false if @association.perform_callback(@options[:start_object], other_node, :before) == false
 

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -34,7 +34,7 @@ module Neo4j::Shared
     def create_or_update
       # since the same model can be created or updated twice from a relationship we have to have this guard
       @_create_or_updating = true
-      result = persisted? ? update_model : create_model
+      result = _persisted_obj ? update_model : create_model
       unless result != false
         Neo4j::Transaction.current.fail if Neo4j::Transaction.current
         false

--- a/spec/unit/persistance_spec.rb
+++ b/spec/unit/persistance_spec.rb
@@ -43,11 +43,11 @@ describe Neo4j::ActiveNode::Persistence do
       o.save
     end
 
-    it 'does not updates node if already persisted before but nothing changed' do
+    it 'does not update persisted node if nothing changed' do
       o = clazz.new(name: 'kalle', age: '42')
       o.stub(:_persisted_obj).and_return(node)
       o.stub(:changed_attributes).and_return({})
-      node.should_receive(:exist?).and_return(true)
+      expect(node).not_to receive(:update_props).with(anything())
       o.save
     end
 
@@ -55,8 +55,7 @@ describe Neo4j::ActiveNode::Persistence do
       o = clazz.new
       o.name = 'sune'
       o.stub(:_persisted_obj).and_return(node)
-      node.should_receive(:exist?).and_return(true)
-      node.should_receive(:update_props).and_return(name: 'sune')
+      expect(node).to receive(:update_props).and_return(name: 'sune')
       o.save
     end
 

--- a/spec/unit/validation_spec.rb
+++ b/spec/unit/validation_spec.rb
@@ -50,7 +50,6 @@ describe Neo4j::ActiveNode::Validations do
         o = clazz.new
         o.name = 'sune'
         o.stub(:_persisted_obj).and_return(node)
-        node.should_receive(:exist?).at_least(1).times.and_return(true)
         node.should_receive(:update_props).and_return(name: 'sune')
         o.save.should be true
       end


### PR DESCRIPTION
`persisted?` causes a call to the DB to check whether an object exists. It was being called TWICE during node update and relationship creation, making each of those n + 2 queries! Totally insane.

To fix this, we can use the presence of `_persisted_obj` (the underlying CypherNode or EmbeddedNode object) as evidence that we're not working with an unsaved node. When needed,the database will give an error to indicate you're trying to work with a node that has been destroyed since instantiating the object. If someone doesn't want this to happen, then can check `persisted?` themselves in their app. This isn't a burden that should be shared by everyone for every query.

This will result in a performance boost across the board. 
