### PR TITLE
adds unique: true, creates_unique_rel to ActiveNode and ActiveRel

### DIFF
--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -107,7 +107,7 @@ module Neo4j
         end
 
         def unique?
-          !!@unique
+          @origin ? origin_association.unique? : !!@unique
         end
 
         private
@@ -135,8 +135,12 @@ module Neo4j
           p.size == 0 ? '' : " {#{p}}"
         end
 
+        def origin_association
+          target_class.associations[@origin]
+        end
+
         def origin_type
-          target_class.associations[@origin].relationship_type
+          origin_association.relationship_type
         end
 
         private
@@ -195,7 +199,7 @@ module Neo4j
 
           fail ArgumentError, 'Cannot use :origin without a model_class (implied or explicit)' if not target_class
 
-          association = target_class.associations[@origin]
+          association = origin_association
           fail ArgumentError, "Origin `#{@origin.inspect}` association not found for #{target_class} (specified in #{base_declaration})" if not association
 
           fail ArgumentError, "Origin `#{@origin.inspect}` (specified in #{base_declaration}) has same direction `#{@direction}`)" if @direction == association.direction

--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -106,6 +106,10 @@ module Neo4j
           properties
         end
 
+        def unique?
+          !!@unique
+        end
+
         private
 
         def get_direction(relationship_cypher, create)
@@ -144,6 +148,7 @@ module Neo4j
           @relationship_class = options[:rel_class]
           @relationship_type  = options[:type] && options[:type].to_sym
           @dependent = options[:dependent]
+          @unique = options[:unique]
         end
 
         # Return basic details about association as declared in the model

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -172,7 +172,7 @@ module Neo4j
             _session.query(context: @options[:context])
               .match("(start#{match_string(start_object)}), (end#{match_string(other_node)})").where('ID(start) = {start_id} AND ID(end) = {end_id}')
               .params(start_id: start_object.neo_id, end_id: other_node.neo_id)
-              .create("start#{_association_arrow(properties, true)}end").exec
+              .send(create_method, "start#{_association_arrow(properties, true)}end").exec
 
             @association.perform_callback(@options[:start_object], other_node, :after)
             # end
@@ -282,6 +282,10 @@ module Neo4j
         attr_writer :context
 
         private
+
+        def create_method
+          association.unique? ? :create_unique : :create
+        end
 
         def build_deeper_query_proxy(method, args)
           self.dup.tap do |new_query|

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -91,11 +91,15 @@ module Neo4j::ActiveRel
           .where("n1.#{from_class.primary_key} = {from_node_id}")
           .where("n2.#{to_class.primary_key} = {to_node_id}")
           .params(from_node_id: from_node.id, to_node_id: to_node.id)
-          .create("(n1)-[r:`#{type}`]->(n2)")
+          .send(create_method, ("(n1)-[r:`#{type}`]->(n2)"))
           .with('r').set(r: props).return(:r).first.r
-      rescue NoMethodError
-        raise RelCreateFailedError, "Unable to create relationship. from_node: #{from_node}, to_node: #{to_node}"
+      rescue NoMethodError => e
+        raise RelCreateFailedError, "Unable to create relationship. from_node: #{from_node}, to_node: #{to_node}, error: #{e}"
       end
+    end
+
+    def create_method
+      self.class.unique? ? :create_unique : :create
     end
   end
 end

--- a/lib/neo4j/active_rel/property.rb
+++ b/lib/neo4j/active_rel/property.rb
@@ -45,6 +45,14 @@ module Neo4j::ActiveRel
       def load_entity(id)
         Neo4j::Node.load(id)
       end
+
+      def creates_unique_rel
+        @unique = true
+      end
+
+      def unique?
+        !!@unique
+      end
     end
 
     private

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -34,6 +34,22 @@ describe 'ActiveRel' do
       expect(from_node).to receive(:id).at_least(1).times.and_return(nil)
       expect { MyRelClass.create(from_node: from_node, to_node: to_node) }.to raise_error Neo4j::ActiveRel::Persistence::RelCreateFailedError
     end
+
+    describe 'creates_unique_rel' do
+      after do
+        MyRelClass.instance_variable_set(:@unique, false)
+        [from_node, to_node].each(&:destroy)
+      end
+
+      it 'creates a unique relationship between to nodes' do
+        expect(from_node.others.count).to eq 0
+        MyRelClass.create(from_node: from_node, to_node: to_node)
+        expect(from_node.others.count).to eq 1
+        MyRelClass.creates_unique_rel
+        MyRelClass.create(from_node: from_node, to_node: to_node)
+        expect(from_node.others.count).to eq 1
+      end
+    end
   end
 
   describe 'properties' do

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'has_n' do
+describe 'has_many' do
   let(:clazz_a) do
     UniqueClass.create do
       include Neo4j::ActiveNode
@@ -36,6 +36,20 @@ describe 'has_n' do
 
     it 'has a frozen array' do
       expect { unsaved_node.friends << friend1 }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe 'unique: true' do
+    before { clazz_a.reflect_on_association(:friends).association.instance_variable_set(:@unique, true) }
+    after  { clazz_a.reflect_on_association(:friends).association.instance_variable_set(:@unique, false) }
+
+
+    it 'only creates one relationship between two nodes' do
+      expect(friend1.friends.count).to eq 0
+      friend1.friends << friend2
+      expect(friend1.friends.count).to eq 1
+      friend1.friends << friend2
+      expect(friend1.friends.count).to eq 1
     end
   end
 

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -40,16 +40,26 @@ describe 'has_many' do
   end
 
   describe 'unique: true' do
-    before { clazz_a.reflect_on_association(:friends).association.instance_variable_set(:@unique, true) }
-    after  { clazz_a.reflect_on_association(:friends).association.instance_variable_set(:@unique, false) }
-
+    before { clazz_a.reflect_on_association(:knows).association.instance_variable_set(:@unique, true) }
+    after do
+      clazz_a.reflect_on_association(:knows).association.instance_variable_set(:@unique, false)
+      [friend1, friend2].each(&:destroy)
+    end
 
     it 'only creates one relationship between two nodes' do
-      expect(friend1.friends.count).to eq 0
-      friend1.friends << friend2
-      expect(friend1.friends.count).to eq 1
-      friend1.friends << friend2
-      expect(friend1.friends.count).to eq 1
+      expect(friend1.knows.count).to eq 0
+      friend1.knows << friend2
+      expect(friend1.knows.count).to eq 1
+      friend1.knows << friend2
+      expect(friend1.knows.count).to eq 1
+    end
+
+    it 'is respected with an association using origin' do
+      expect(friend1.knows.count).to eq 0
+      friend2.knows_me << friend1
+      expect(friend1.knows.count).to eq 1
+      friend2.knows_me << friend1
+      expect(friend1.knows.count).to eq 1
     end
   end
 

--- a/spec/unit/association_spec.rb
+++ b/spec/unit/association_spec.rb
@@ -183,5 +183,19 @@ describe Neo4j::ActiveNode::HasN::Association do
         expect(association.send(:relationship_class)).to eq :foo
       end
     end
+
+    describe 'unique' do
+      context 'true' do
+        let(:options) { {unique: true} }
+
+        it { expect(subject).to be_unique }
+      end
+
+      context 'false' do
+        let(:options) { {unique: false} }
+
+        it { expect(subject).not_to be_unique }
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves #473 

Usage:

```ruby
class Student
  include Neo4j::ActiveNode
  has_many :out, :lessons, type: 'ENROLLED_IN', unique: true
end

# or for ActiveRel

class Student
  include Neo4j::ActiveNode
  has_many :out, :lessons, rel_class: 'ENROLLED_IN'
end

class EnrolledIn
  from_node Student
  to_node Lesson
  creates_unique_rel
end
```

Both `student.lessons << lesson` and `EnrolledIn.create(from_node: student, to_node: lesson)` will now use `CREATE UNIQUE` instead of `CREATE` in the Cypher statement. 