### PR TITLE
fix activerel classes not assigning type when inheriting

### DIFF
--- a/lib/neo4j/active_rel/types.rb
+++ b/lib/neo4j/active_rel/types.rb
@@ -27,6 +27,10 @@ module Neo4j
       module ClassMethods
         include Neo4j::Shared::RelTypeConverters
 
+        def inherited(other)
+          other.type other.name, true
+        end
+
         # @param type [String] sets the relationship type when creating relationships via this class
         def type(given_type = self.name, auto = false)
           use_type = auto ? decorated_rel_type(given_type) : given_type

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -70,6 +70,8 @@ describe 'ActiveRel' do
       to_class ToClass
     end
 
+    class InheritedRelClass < AutomaticRelType; end
+
     it 'allows omission of `type`' do
       expect(AutomaticRelType._type).to eq 'AUTOMATIC_REL_TYPE'
     end
@@ -77,6 +79,10 @@ describe 'ActiveRel' do
     it 'uses `type` to override the default type' do
       AutomaticRelType.type 'NEW_TYPE'
       expect(AutomaticRelType._type).to eq 'NEW_TYPE'
+    end
+
+    it 'uses the defined class name when inheriting' do
+      expect(InheritedRelClass._type).to eq 'INHERITED_REL_CLASS'
     end
   end
 


### PR DESCRIPTION
ActiveRel classes don't set type at all when inheriting. This fixes that. The class will use its own name, you can call `type` in the model to override.