### PR TITLE
Refactoring `has_n.rb` so that it isn't one giant string

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,7 +16,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 244
+  Max: 248
 
 # Offense count: 2
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,7 +16,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 248
+  Max: 249
 
 # Offense count: 2
 Metrics/CyclomaticComplexity:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-script:
+before_script:
   - "bundle exec rubocop"
+script:
   - "export CODECLIMATE_REPO_TOKEN=04853df625409de0a0f4e9126aee11bbee3428c81c20c27df6e6ab5c60bff2c8 && export JRUBY_OPTS='-X+O -J-Djruby.launch.inproc=false' && bundle exec rake neo4j:install['community-2.2.0-M01'] neo4j:start default --trace"
 language: ruby
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
-before_script:
-  - "bundle exec rubocop"
 script:
+  - "bundle exec rubocop"
   - "export CODECLIMATE_REPO_TOKEN=04853df625409de0a0f4e9126aee11bbee3428c81c20c27df6e6ab5c60bff2c8 && export JRUBY_OPTS='-X+O -J-Djruby.launch.inproc=false' && bundle exec rake neo4j:install['community-2.2.0-M01'] neo4j:start default --trace"
 language: ruby
 rvm:
-  - 2.2.0
+  - ruby-head
   - 1.9.3
   - jruby-1.7.16
   # - jruby-19mode

--- a/lib/neo4j/active_node/dependent/association_methods.rb
+++ b/lib/neo4j/active_node/dependent/association_methods.rb
@@ -24,7 +24,7 @@ module Neo4j
 
         # Callback methods
         def dependent_delete_callback(object)
-          object.send("#{self.name}_query_proxy").delete_all
+          object.association_query_proxy(name).delete_all
         end
 
         def dependent_delete_orphans_callback(object)
@@ -32,7 +32,7 @@ module Neo4j
         end
 
         def dependent_destroy_callback(object)
-          object.send("#{self.name}_query_proxy").each_for_destruction(object) { |node| node.destroy }
+          object.association_query_proxy(name).each_for_destruction(object) { |node| node.destroy }
         end
 
         def dependent_destroy_orphans_callback(object)

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -121,8 +121,8 @@ module Neo4j::ActiveNode
           association_query_proxy(name).replace_with(other_nodes)
         end
 
-        define_class_method(name) do |node = nil, rel = nil, proxy_obj = nil|
-          association_query_proxy(name, node: node, rel: rel, proxy_obj: proxy_obj)
+        define_class_method(name) do |node = nil, rel = nil, proxy_obj = nil, options = {}|
+          association_query_proxy(name, {node: node, rel: rel, proxy_obj: proxy_obj}.merge(options))
         end
       end
 
@@ -135,10 +135,10 @@ module Neo4j::ActiveNode
       end
 
       def define_has_one_methods(name)
-        define_method(name) do |node = nil, rel = nil, options = {}|
+        define_method(name) do |node = nil, rel = nil|
           return nil unless self._persisted_obj
 
-          result = association_query_proxy(name, {node: node, rel: rel}.merge(options))
+          result = association_query_proxy(name, node: node, rel: rel)
           association_instance_fetch(result.to_cypher_with_params,
                                      self.class.reflect_on_association(__method__)) { result.first }
         end
@@ -149,8 +149,8 @@ module Neo4j::ActiveNode
           association_query_proxy(name).replace_with(other_node)
         end
 
-        define_class_method(name) do |node = nil, rel = nil, query_proxy = nil|
-          association_query_proxy(name, query_proxy: query_proxy, node: node, rel: rel)
+        define_class_method(name) do |node = nil, rel = nil, query_proxy = nil, options = {}|
+          association_query_proxy(name, {query_proxy: query_proxy, node: node, rel: rel}.merge(options))
         end
       end
 

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -116,10 +116,6 @@ module Neo4j::ActiveNode
           other_nodes.each { |node| send(name) << node }
         end
 
-        define_method("#{name}_rels") do
-          send(name, nil, :r).pluck(:r)
-        end
-
         # Class methods
         klass = class << self; self; end
         klass.instance_eval do
@@ -158,10 +154,6 @@ module Neo4j::ActiveNode
 
         define_method("#{name}_query_proxy") do |options = {}|
           self.class.send("#{name}_query_proxy", {start_object: self}.merge(options))
-        end
-
-        define_method("#{name}_rel") do
-          send("#{name}_query_proxy", rel: :r).pluck(:r).first
         end
 
         define_method(name) do |node = nil, rel = nil|

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -127,23 +127,6 @@ module Neo4j::ActiveNode
         define_association_query_proxy_method(name, association)
       end
 
-      def define_association_query_proxy_method(name, association)
-        define_class_method("#{name}_query_proxy") do |options = {}|
-          query_proxy = options[:proxy_obj] || Neo4j::ActiveNode::Query::QueryProxy.new("::#{self.class.name}".constantize, nil,
-                                                                                        session: self.neo4j_session, query_proxy: nil, context: self.class.name + "##{name}")
-          context = (query_proxy && query_proxy.context ? query_proxy.context : self.class.name) + '##{name}'
-          Neo4j::ActiveNode::Query::QueryProxy.new(association.target_class_or_nil,
-                                                   associations[name],
-                                                   {session: self.neo4j_session,
-                                                   query_proxy: query_proxy,
-                                                   node: options[:node],
-                                                   rel: options[:rel],
-                                                   context: context,
-                                                   optional: query_proxy.optional?,
-                                                   caller: query_proxy.caller}.merge(options))
-        end
-      end
-
       def define_class_method(*args, &block)
         klass = class << self; self; end
         klass.instance_eval do
@@ -194,6 +177,23 @@ module Neo4j::ActiveNode
       # rubocop:enable Style/PredicateName
 
       private
+
+      def define_association_query_proxy_method(name, association)
+        define_class_method("#{name}_query_proxy") do |options = {}|
+          query_proxy = options[:proxy_obj] || Neo4j::ActiveNode::Query::QueryProxy.new("::#{self.class.name}".constantize, nil,
+                                                                                        session: self.neo4j_session, query_proxy: nil, context: self.class.name + "##{name}")
+          context = (query_proxy && query_proxy.context ? query_proxy.context : self.class.name) + '##{name}'
+          Neo4j::ActiveNode::Query::QueryProxy.new(association.target_class_or_nil,
+                                                   associations[name],
+                                                   {session: self.neo4j_session,
+                                                    query_proxy: query_proxy,
+                                                    node: options[:node],
+                                                    rel: options[:rel],
+                                                    context: context,
+                                                    optional: query_proxy.optional?,
+                                                    caller: query_proxy.caller}.merge(options))
+        end
+      end
 
       def build_association(macro, direction, name, options)
         Neo4j::ActiveNode::HasN::Association.new(macro, direction, name, options).tap do |association|

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -147,8 +147,8 @@ module Neo4j::ActiveNode
           return nil unless self._persisted_obj
 
           result = association_query_proxy(name, node: node, rel: rel)
-          association_reflection = self.class.reflect_on_association(__method__)
-          association_instance_fetch(result.to_cypher_with_params, association_reflection) { result.first }
+          association_instance_fetch(result.to_cypher_with_params,
+                                     self.class.reflect_on_association(__method__)) { result.first }
         end
 
         # Class methods

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -152,8 +152,8 @@ module Neo4j::ActiveNode
       # rubocop:enable Style/PredicateName
 
       def association_query_proxy(name, options = {})
-        query_proxy = options[:proxy_obj] || Neo4j::ActiveNode::Query::QueryProxy.new("::#{self.class.name}".constantize, nil,
-                                                                                      session: neo4j_session, query_proxy: nil, context: "#{self.class.name}##{name}")
+        query_proxy = options[:proxy_obj] || default_association_proxy_obj(name)
+
         Neo4j::ActiveNode::Query::QueryProxy.new(associations[name].target_class_or_nil,
                                                  associations[name],
                                                  {session: neo4j_session,
@@ -161,6 +161,14 @@ module Neo4j::ActiveNode
                                                   context: "#{query_proxy.context || self.class.name}##{name}",
                                                   optional: query_proxy.optional?,
                                                   caller: query_proxy.caller}.merge(options))
+      end
+
+      def default_association_proxy_obj(name)
+        Neo4j::ActiveNode::Query::QueryProxy.new("::#{self.class.name}".constantize,
+                                                 nil,
+                                                 session: neo4j_session,
+                                                 query_proxy: nil,
+                                                 context: "#{self.class.name}##{name}")
       end
 
       private

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -123,13 +123,6 @@ module Neo4j::ActiveNode
         end
       end
 
-      def define_class_method(*args, &block)
-        klass = class << self; self; end
-        klass.instance_eval do
-          define_method(*args, &block)
-        end
-      end
-
       def has_one(direction, name, options = {})
         name = name.to_sym
         build_association(:has_one, direction, name, options)

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -101,10 +101,10 @@ module Neo4j::ActiveNode
         build_association(:has_many, direction, name, options)
         # TODO: Make assignment more efficient? (don't delete nodes when they are being assigned)
 
-        define_method(name) do |node = nil, rel = nil|
+        define_method(name) do |node = nil, rel = nil, options = {}|
           return [].freeze unless self._persisted_obj
 
-          association_query_proxy(name, node: node, rel: rel, caller: self)
+          association_query_proxy(name, {node: node, rel: rel, caller: self}.merge(options))
         end
 
         define_method("#{name}=") do |other_nodes|
@@ -137,16 +137,16 @@ module Neo4j::ActiveNode
           query_proxy << other_node
         end
 
-        define_method(name) do |node = nil, rel = nil|
+        define_method(name) do |node = nil, rel = nil, options = {}|
           return nil unless self._persisted_obj
 
-          result = association_query_proxy(name, node: node, rel: rel)
+          result = association_query_proxy(name, {node: node, rel: rel}.merge(options))
           association_instance_fetch(result.to_cypher_with_params,
                                      self.class.reflect_on_association(__method__)) { result.first }
         end
 
         define_class_method(name) do |node = nil, rel = nil, query_proxy = nil|
-          association_query_proxy(name, query_proxy: query_proxy, node: node, rel: rel, context: context)
+          association_query_proxy(name, query_proxy: query_proxy, node: node, rel: rel)
         end
       end
       # rubocop:enable Style/PredicateName

--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -45,8 +45,8 @@ module Neo4j
           @target_class_name ||= @target_class_option.to_s if @target_class_option
         end
 
-        def target_class_name_or_nil
-          @target_class_name_or_nil ||= target_class_name || 'nil'
+        def target_class_or_nil
+          @target_class_or_nil ||= target_class_name ? target_class_name.constantize : nil
         end
 
         def target_class

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -178,6 +178,16 @@ module Neo4j
           end
         end
 
+        def rels
+          fail 'Cannot get rels without a relationship variable.' if !@rel_var
+
+          pluck(@rel_var)
+        end
+
+        def rel
+          rels.first
+        end
+
         def _nodeify(*args)
           [args].flatten.map do |arg|
             (arg.is_a?(Integer) || arg.is_a?(String)) ? @model.find(arg) : arg

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -38,8 +38,8 @@ module Neo4j
           @context = options.delete(:context)
           @options = options
 
-          @node_var, @session, @caller, @starting_query, @optional, @start_object, @query_proxy =
-            options.values_at(:node, :session, :caller, :starting_query, :optional, :start_object, :query_proxy)
+          @node_var, @session, @caller, @starting_query, @optional, @start_object, @query_proxy, @chain_level =
+            options.values_at(:node, :session, :caller, :starting_query, :optional, :start_object, :query_proxy, :chain_level)
 
           @rel_var = options[:rel] || _rel_chain_var
 
@@ -81,9 +81,11 @@ module Neo4j
         # @param [String,Symbol] var The identifier to use for node at this link of the QueryProxy chain.
         #   student.lessons.query_as(:l).with('your cypher here...')
         def query_as(var)
-          @chain.inject(base_query(var).params(@params)) do |query, (method, arg)|
+          result_query = @chain.inject(base_query(var).params(@params)) do |query, (method, arg)|
             query.send(method, arg.respond_to?(:call) ? arg.call(var) : arg)
           end
+
+          result_query.tap { |query| query.proxy_chain_level = _chain_level }
         end
 
         def base_query(var)
@@ -264,7 +266,13 @@ module Neo4j
         end
 
         def _chain_level
-          @query_proxy ? (@query_proxy._chain_level + 1) : 1
+          if @query_proxy
+            @query_proxy._chain_level + 1
+          elsif @chain_level
+            @chain_level + 1
+          else
+            1
+          end
         end
 
         def _association_chain_var

--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -129,7 +129,7 @@ module Neo4j
         # A shortcut for attaching a new, optional match to the end of a QueryProxy chain.
         # TODO: It's silly that we have to call constantize here. There should be a better way of finding the target class of the destination.
         def optional(association, node_var = nil, rel_var = nil)
-          self.send(association, node_var, rel_var, optional: true)
+          self.send(association, node_var, rel_var, nil, optional: true)
         end
 
         private

--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -114,11 +114,8 @@ module Neo4j
 
         # A shortcut for attaching a new, optional match to the end of a QueryProxy chain.
         # TODO: It's silly that we have to call constantize here. There should be a better way of finding the target class of the destination.
-        def optional(association, node_id = nil)
-          target_qp = self.send(association)
-          model = target_qp.name.constantize
-          var = node_id || target_qp.identity
-          self.query.proxy_as(model, var, true)
+        def optional(association, node_var = nil, rel_var = nil)
+          self.send(association, node_var, rel_var, optional: true)
         end
 
         private

--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -127,7 +127,6 @@ module Neo4j
         end
 
         # A shortcut for attaching a new, optional match to the end of a QueryProxy chain.
-        # TODO: It's silly that we have to call constantize here. There should be a better way of finding the target class of the destination.
         def optional(association, node_var = nil, rel_var = nil)
           self.send(association, node_var, rel_var, nil, optional: true)
         end

--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -106,6 +106,20 @@ module Neo4j
           clear_caller_cache
         end
 
+        # Deletes the relationships between all nodes for the last step in the QueryProxy chain.  Executed in the database, callbacks will not be run.
+        def delete_all_rels
+          self.query.delete(rel_var).exec
+        end
+
+        # Deletes the relationships between all nodes for the last step in the QueryProxy chain and replaces them with relationships to the given nodes.
+        # Executed in the database, callbacks will not be run.
+        def replace_with(node_or_nodes)
+          nodes = Array(node_or_nodes)
+
+          self.delete_all_rels
+          nodes.each { |node| self << node }
+        end
+
         # Returns all relationships between a node and its last link in the QueryProxy chain, destroys them in Ruby. Callbacks will be run.
         def destroy(node)
           self.rels_to(node).map!(&:destroy)

--- a/lib/neo4j/active_rel/types.rb
+++ b/lib/neo4j/active_rel/types.rb
@@ -33,9 +33,9 @@ module Neo4j
 
         # @param type [String] sets the relationship type when creating relationships via this class
         def type(given_type = self.name, auto = false)
-          use_type = auto ? decorated_rel_type(given_type) : given_type
-          add_wrapped_class use_type
-          @rel_type = use_type
+          @rel_type = (auto ? decorated_rel_type(given_type) : given_type).tap do |type|
+            add_wrapped_class type unless uses_classname?
+          end
         end
 
         # @return [String] a string representing the relationship type that will be created

--- a/lib/neo4j/core/query.rb
+++ b/lib/neo4j/core/query.rb
@@ -8,7 +8,7 @@ module Neo4j::Core
     # @return [Neo4j::ActiveNode::Query::QueryProxy] A QueryProxy object.
     def proxy_as(model, var, optional = false)
       # TODO: Discuss whether it's necessary to call `break` on the query or if this should be left to the user.
-      Neo4j::ActiveNode::Query::QueryProxy.new(model, nil,  starting_query: self.break, node: var, optional: optional)
+      Neo4j::ActiveNode::Query::QueryProxy.new(model, nil, node: var, optional: optional)
     end
 
     # Calls proxy_as with `optional` set true. This doesn't offer anything different from calling `proxy_as` directly but it may be more readable.

--- a/lib/neo4j/core/query.rb
+++ b/lib/neo4j/core/query.rb
@@ -8,12 +8,15 @@ module Neo4j::Core
     # @return [Neo4j::ActiveNode::Query::QueryProxy] A QueryProxy object.
     def proxy_as(model, var, optional = false)
       # TODO: Discuss whether it's necessary to call `break` on the query or if this should be left to the user.
-      Neo4j::ActiveNode::Query::QueryProxy.new(model, nil, node: var, optional: optional)
+      Neo4j::ActiveNode::Query::QueryProxy.new(model, nil, node: var, optional: optional, starting_query: self, chain_level: @proxy_chain_level)
     end
 
     # Calls proxy_as with `optional` set true. This doesn't offer anything different from calling `proxy_as` directly but it may be more readable.
     def proxy_as_optional(model, var)
       proxy_as(model, var, true)
     end
+
+    # For instances where you turn a QueryProxy into a Query and then back to a QueryProxy with `#proxy_as`
+    attr_accessor :proxy_chain_level
   end
 end

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -94,7 +94,7 @@ describe 'ActiveRel' do
       after { f1.destroy && t1.destroy }
 
       it 'returns the activerel class' do
-        expect(f1.others_rels.first).to be_a(MyRelClass)
+        expect(f1.others.rels.first).to be_a(MyRelClass)
       end
 
       it 'correctly interprets strings as class names' do

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -92,9 +92,9 @@ describe 'has_many' do
   end
 
   it 'access relationships via declared has_n method' do
-    node.friends_rels.to_a.should eq([])
+    node.friends.rels.to_a.should eq([])
     node.friends << friend1
-    rels = node.friends_rels
+    rels = node.friends.rels
     rels.count.should eq(1)
     rel = rels.first
     rel.start_node.should eq(node)

--- a/spec/e2e/has_one_spec.rb
+++ b/spec/e2e/has_one_spec.rb
@@ -45,11 +45,11 @@ describe 'has_one' do
       a.children.to_a.should eq([b])
     end
 
-    it 'can return relationship object via parent_rel' do
+    it 'can return relationship object via parent.rel' do
       a = HasOneA.create(name: 'a')
       b = HasOneB.create(name: 'b')
       b.parent = a
-      rel = b.parent_rel
+      rel = b.parent.rel
       rel.other_node(b).should eq(a)
     end
 

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -402,25 +402,10 @@ describe 'query_proxy_methods' do
     end
 
     it 'starts a new optional match' do
-      result = @lauren.lessons(:l).optional(:teachers, :t).where(age: 40).lessons(:l).pluck('distinct l, t')
-      expect(result.count).to eq 2
+      result = @lauren.lessons(:l).optional(:teachers, :t).where(age: 40).lessons(:l).query.order(l: :name).pluck('distinct l, t')
 
-      expect(result[0][0]).not_to be_nil
-      # The order of results changes between Neo4j 2.1.6 and 2.2.0.
-      # Until we stop supporting 2.1.6, this workaround is necessary.
-      if result[0][0] == @science
-        expect(result[0][0]).to eq @science
-        expect(result[0][1]).to be_nil
-
-        expect(result[1][0]).to eq @math
-        expect(result[1][1]).to eq @johnson
-      else
-        expect(result[0][0]).to eq @math
-        expect(result[0][1]).to eq @johnson
-
-        expect(result[1][0]).to eq @science
-        expect(result[1][1]).to be_nil
-      end
+      expect(result).to eq [[@math, @johnson],
+                            [@science, nil]]
     end
   end
 end

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -2,53 +2,48 @@ require 'spec_helper'
 
 describe 'query_proxy_methods' do
   # goofy names to differentiate from same classes used elsewhere
-  before(:all) do
-    class IncludeLesson; end
-    class IncludeTeacher; end
-    class IncludeEmptyClass; end
-    class IncludeEnrolledIn; end
-    class IncludeStudent
-      include Neo4j::ActiveNode
+  before(:each) do
+    Neo4j::ActiveNode::Labels.clear_model_for_label_cache
+    Neo4j::ActiveNode::Labels.clear_wrapped_models
+
+    stub_active_node_class('Student') do
       property :name
-      has_many :out, :lessons, model_class: IncludeLesson, rel_class: IncludeEnrolledIn
+      has_many :out, :lessons, model_class: 'Lesson', rel_class: 'EnrolledIn'
       has_many :out, :things, model_class: false, type: 'lessons'
     end
 
-    class IncludeLesson
-      include Neo4j::ActiveNode
+    stub_active_node_class('Lesson') do
       property :name
-      has_many :in, :students, model_class: IncludeStudent, rel_class: IncludeEnrolledIn
-      has_many :in, :teachers, model_class: IncludeTeacher, origin: :lessons
+      has_many :in, :students, model_class: 'Student', rel_class: 'EnrolledIn'
+      has_many :in, :teachers, model_class: 'Teacher', origin: :lessons
     end
 
-    class IncludeTeacher
-      include Neo4j::ActiveNode
+    stub_active_node_class('Teacher') do
       property :name
       property :age, type: Integer
-      has_many :out, :lessons, model_class: IncludeLesson, type: 'teaching_lesson'
+      has_many :out, :lessons, model_class: 'Lesson', type: 'teaching_lesson'
     end
 
-    class IncludeEmptyClass
-      include Neo4j::ActiveNode
-      has_many :out, :lessons, model_class: IncludeLesson
+    stub_active_node_class('EmptyClass') do
+      has_many :out, :lessons, model_class: 'Lesson'
     end
 
-    class IncludeEnrolledIn
-      include Neo4j::ActiveRel
-      from_class IncludeStudent
-      to_class IncludeLesson
+    stub_active_rel_class('EnrolledIn') do
+      from_class 'Student'
+      to_class 'Lesson'
       type 'lessons'
 
       after_destroy :destroy_called
 
-      def destroy_called; end
+      def destroy_called
+      end
     end
   end
-  let!(:jimmy)    { IncludeStudent.create(name: 'Jimmy') }
-  let!(:math)     { IncludeLesson.create(name: 'math') }
-  let!(:science)  { IncludeLesson.create(name: 'science') }
-  let!(:mr_jones) { IncludeTeacher.create }
-  let!(:mr_adams) { IncludeTeacher.create }
+  let!(:jimmy)    { Student.create(name: 'Jimmy') }
+  let!(:math)     { Lesson.create(name: 'math') }
+  let!(:science)  { Lesson.create(name: 'science') }
+  let!(:mr_jones) { Teacher.create }
+  let!(:mr_adams) { Teacher.create }
 
   describe 'first and last' do
     it 'returns objects across multiple associations' do
@@ -68,8 +63,8 @@ describe 'query_proxy_methods' do
       expect(jimmy.lessons.teachers.include?(mr_jones)).to be_falsey
       expect(jimmy.lessons.where(name: 'science').teachers.include?(mr_jones)).to be_falsey
       expect(jimmy.lessons.where(name: 'science').teachers.include?(mr_adams)).to be_truthy
-      expect(IncludeTeacher.all.include?(mr_jones)).to be_truthy
-      expect(IncludeTeacher.all.include?(math)).to be_falsey
+      expect(Teacher.all.include?(mr_jones)).to be_truthy
+      expect(Teacher.all.include?(math)).to be_falsey
     end
 
     it 'works with multiple relationships to the same object' do
@@ -79,7 +74,7 @@ describe 'query_proxy_methods' do
     end
 
     it 'returns correctly when model_class is false' do
-      woodworking = IncludeLesson.create(name: 'woodworking')
+      woodworking = Lesson.create(name: 'woodworking')
       expect(jimmy.things.include?(woodworking)).to be_falsey
       jimmy.lessons << woodworking
       expect(jimmy.things.include?(woodworking)).to be_truthy
@@ -89,40 +84,40 @@ describe 'query_proxy_methods' do
     it 'allows you to check for an identifier in the middle of a chain' do
       jimmy.lessons << science
       science.teachers << mr_adams
-      expect(IncludeLesson.as(:l).students.where(name: 'Jimmy').include?(science, :l)).to be_truthy
+      expect(Lesson.as(:l).students.where(name: 'Jimmy').include?(science, :l)).to be_truthy
     end
 
     it 'raises an error if something other than a node is given' do
-      expect { IncludeStudent.lessons.include?(:foo) }.to raise_error(Neo4j::ActiveNode::Query::QueryProxyMethods::InvalidParameterError)
+      expect { Student.lessons.include?(:foo) }.to raise_error(Neo4j::ActiveNode::Query::QueryProxyMethods::InvalidParameterError)
     end
   end
 
   describe 'exists?' do
     context 'class methods' do
       it 'can run by a class' do
-        expect(IncludeEmptyClass.empty?).to be_truthy
-        expect(IncludeLesson.empty?).to be_falsey
+        expect(EmptyClass.empty?).to be_truthy
+        expect(Lesson.empty?).to be_falsey
       end
 
       it 'can be called with a property and value' do
-        expect(IncludeLesson.exists?(name: 'math')).to be_truthy
-        expect(IncludeLesson.exists?(name: 'boat repair')).to be_falsey
+        expect(Lesson.exists?(name: 'math')).to be_truthy
+        expect(Lesson.exists?(name: 'boat repair')).to be_falsey
       end
 
       it 'can be called on the class with a neo_id' do
-        expect(IncludeLesson.exists?(math.neo_id)).to be_truthy
-        expect(IncludeLesson.exists?(8_675_309)).to be_falsey
+        expect(Lesson.exists?(math.neo_id)).to be_truthy
+        expect(Lesson.exists?(8_675_309)).to be_falsey
       end
 
       it 'raises an error if something other than a neo id is given' do
-        expect { IncludeLesson.exists?(:fooooo) }.to raise_error(Neo4j::ActiveNode::QueryMethods::InvalidParameterError)
+        expect { Lesson.exists?(:fooooo) }.to raise_error(Neo4j::ActiveNode::QueryMethods::InvalidParameterError)
       end
     end
 
     context 'QueryProxy methods' do
       it 'can be called on a query' do
-        expect(IncludeLesson.where(name: 'history').exists?).to be_falsey
-        expect(IncludeLesson.where(name: 'math').exists?).to be_truthy
+        expect(Lesson.where(name: 'history').exists?).to be_falsey
+        expect(Lesson.where(name: 'math').exists?).to be_truthy
       end
 
       it 'can be called with property and value' do
@@ -133,8 +128,8 @@ describe 'query_proxy_methods' do
       end
 
       it 'can be called with a neo_id' do
-        expect(IncludeLesson.where(name: 'math').exists?(math.neo_id)).to be_truthy
-        expect(IncludeLesson.where(name: 'math').exists?(science.neo_id)).to be_falsey
+        expect(Lesson.where(name: 'math').exists?(math.neo_id)).to be_truthy
+        expect(Lesson.where(name: 'math').exists?(science.neo_id)).to be_falsey
       end
 
       it 'is called by :blank? and :empty?' do
@@ -148,9 +143,11 @@ describe 'query_proxy_methods' do
   end
 
   describe 'count' do
-    before(:all) do
-      @john = IncludeStudent.create(name: 'John')
-      @history = IncludeLesson.create(name: 'history')
+    before(:each) do
+      [Student, Lesson].each(&:delete_all)
+
+      @john = Student.create(name: 'John')
+      @history = Lesson.create(name: 'history')
       3.times { @john.lessons << @history }
     end
 
@@ -167,11 +164,11 @@ describe 'query_proxy_methods' do
     end
 
     it 'works on an object earlier in the chain' do
-      expect(IncludeStudent.as(:s).lessons.where(name: 'history').count(:distinct, :s)).to eq 1
+      expect(Student.as(:s).lessons.where(name: 'history').count(:distinct, :s)).to eq 1
     end
 
     it 'works with order clause' do
-      expect { IncludeStudent.order(name: :asc).count }.not_to raise_error
+      expect { Student.order(name: :asc).count }.not_to raise_error
     end
 
     it 'is aliased by length and size' do
@@ -182,12 +179,12 @@ describe 'query_proxy_methods' do
 
   describe 'delete_all' do
     before do
-      [IncludeStudent, IncludeLesson, IncludeTeacher].each(&:delete_all)
-      @tom = IncludeStudent.create(name: 'Tom')
-      @math = IncludeLesson.create(name: 'Math')
-      @science = IncludeLesson.create(name: 'Science')
-      @adams = IncludeTeacher.create(name: 'Mr Adams')
-      @johnson = IncludeTeacher.create(name: 'Mrs Johnson')
+      [Student, Lesson, Teacher].each(&:delete_all)
+      @tom = Student.create(name: 'Tom')
+      @math = Lesson.create(name: 'Math')
+      @science = Lesson.create(name: 'Science')
+      @adams = Teacher.create(name: 'Mr Adams')
+      @johnson = Teacher.create(name: 'Mrs Johnson')
       @tom.lessons << @math
       @tom.lessons << @science
       @math.teachers << @adams
@@ -210,7 +207,7 @@ describe 'query_proxy_methods' do
 
     it 'works when called from a class' do
       expect(@tom.lessons.teachers.include?(@adams)).to be_truthy
-      IncludeStudent.all.lessons.teachers.delete_all
+      Student.all.lessons.teachers.delete_all
       expect(@adams.persisted?).to be_falsey
     end
 
@@ -229,10 +226,10 @@ describe 'query_proxy_methods' do
   end
 
   describe 'match_to and first_rel_to' do
-    before(:all) do
-      @john = IncludeStudent.create(name: 'Paul')
-      @history = IncludeLesson.create(name: 'history')
-      @math = IncludeLesson.create(name: 'math')
+    before(:each) do
+      @john = Student.create(name: 'Paul')
+      @history = Lesson.create(name: 'history')
+      @math = Lesson.create(name: 'math')
       @john.lessons << @history
     end
 
@@ -265,7 +262,9 @@ describe 'query_proxy_methods' do
 
       context 'with an array' do
         context 'of nodes' do
-          after { @john.lessons.first_rel_to(@math).destroy }
+          after(:each) do
+            @john.lessons.first_rel_to(@math).destroy
+          end
 
           it 'generates cypher using IN with the IDs of contained nodes' do
             expect(@john.lessons.match_to([@history, @math]).to_cypher).to include('AND (result_lessons.uuid IN')
@@ -295,11 +294,11 @@ describe 'query_proxy_methods' do
 
       context 'on Model.all' do
         it 'works with a node' do
-          expect(IncludeLesson.all.match_to(@history).first).to eq @history
+          expect(Lesson.all.match_to(@history).first).to eq @history
         end
 
         it 'works with an id' do
-          expect(IncludeLesson.all.match_to(@history.id).first).to eq @history
+          expect(Lesson.all.match_to(@history.id).first).to eq @history
         end
       end
 
@@ -317,14 +316,14 @@ describe 'query_proxy_methods' do
         end
 
         it 'works with a chain starting with `all`' do
-          expect(IncludeStudent.all.match_to(jimmy).lessons(:l).match_to(math).teachers.where(age: 40).first).to eq mr_jones
+          expect(Student.all.match_to(jimmy).lessons(:l).match_to(math).teachers.where(age: 40).first).to eq mr_jones
         end
       end
     end
 
     describe 'first_rel_to' do
       it 'returns the first relationship across a QueryProxy chain to a given node' do
-        expect(@john.lessons.first_rel_to(@history)).to be_a IncludeEnrolledIn
+        expect(@john.lessons.first_rel_to(@history)).to be_a EnrolledIn
       end
 
       it 'returns nil when nothing matches' do
@@ -350,7 +349,7 @@ describe 'query_proxy_methods' do
 
       describe 'delete' do
         it 'removes relationships between a node and the last link of the QP chain from the server' do
-          expect_any_instance_of(IncludeEnrolledIn).not_to receive(:destroy_called)
+          expect_any_instance_of(EnrolledIn).not_to receive(:destroy_called)
           expect(@john.lessons.include?(@history)).to be_truthy
           @john.lessons.delete(@history)
           expect(@john.lessons.include?(@history)).to be_falsey
@@ -370,7 +369,7 @@ describe 'query_proxy_methods' do
       describe 'destroy' do
         it 'returns relationships and destroys them in Ruby, executing callbacks in the process' do
           expect(@john.lessons.include?(@history)).to be_truthy
-          expect_any_instance_of(IncludeEnrolledIn).to receive(:destroy_called)
+          expect_any_instance_of(EnrolledIn).to receive(:destroy_called)
           @john.lessons.destroy(@history)
           expect(@john.lessons.include?(@history)).to be_falsey
 
@@ -389,12 +388,14 @@ describe 'query_proxy_methods' do
   end
 
   describe 'optional' do
-    before(:all) do
-      @lauren = IncludeStudent.create(name: 'Lauren')
-      @math = IncludeLesson.create(name: 'Math')
-      @science = IncludeLesson.create(name: 'Science')
-      @johnson = IncludeTeacher.create(name: 'Mr. Johnson', age: 40)
-      @clancy = IncludeTeacher.create(name: 'Mr. Clancy', age: 50)
+    before(:each) do
+      delete_db
+
+      @lauren = Student.create(name: 'Lauren')
+      @math = Lesson.create(name: 'Math')
+      @science = Lesson.create(name: 'Science')
+      @johnson = Teacher.create(name: 'Mr. Johnson', age: 40)
+      @clancy = Teacher.create(name: 'Mr. Clancy', age: 50)
 
       @lauren.lessons << [@math, @science]
       @math.teachers << @johnson
@@ -402,7 +403,7 @@ describe 'query_proxy_methods' do
     end
 
     it 'starts a new optional match' do
-      result = @lauren.lessons(:l).optional(:teachers, :t).where(age: 40).lessons(:l).query.order(l: :name).pluck('distinct l, t')
+      result = @lauren.lessons(:l).optional(:teachers, :t).where(age: 40).query.order(l: :name).pluck('distinct l, t')
 
       expect(result).to eq [[@math, @johnson],
                             [@science, nil]]

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -362,10 +362,10 @@ describe 'Query API' do
 
     let(:query_proxy) { Student.as(:s).lessons.where(subject: 'Math') }
     it 'builds a new QueryProxy object upon an existing Core::Query object' do
-      combined_query = core_query.proxy_as(Student, :s).lessons.where(subject: 'Math')
       combined_strings = "#{core_query.to_cypher} #{query_proxy.to_cypher}"
+      combined_query = core_query.proxy_as(Student, :s).lessons.where(subject: 'Math')
 
-      expect(combined_strings).to eq combined_query.to_cypher
+      expect(combined_query.to_cypher).to eq combined_strings
     end
 
     let(:brian) { Student.create(name: 'Brian') }

--- a/spec/e2e/wrapped_transactions_spec.rb
+++ b/spec/e2e/wrapped_transactions_spec.rb
@@ -80,7 +80,7 @@ describe 'wrapped nodes in transactions' do
     end
 
     it 'does not create an additional relationship after load then save' do
-      starting_count = @john.teachers_rels.count
+      starting_count = @john.teachers.rels.count
       begin
         tx = Neo4j::Transaction.new
         @john.teachers.each_rel do |r|
@@ -91,7 +91,7 @@ describe 'wrapped nodes in transactions' do
         tx.close
       end
       @john.reload
-      expect(@john.teachers_rels.count).to eq starting_count
+      expect(@john.teachers.rels.count).to eq starting_count
     end
   end
 end

--- a/spec/integration/association_cache_spec.rb
+++ b/spec/integration/association_cache_spec.rb
@@ -7,7 +7,7 @@ describe 'Association Cache' do
 
     stub_active_node_class('Student') do
       property :name
-      has_many :out, :lessons, model_class: 'Lesson'
+      has_many :out, :lessons, type: :has_student, model_class: 'Lesson'
       has_many :in, :exams, model_class: 'Exam', origin: :students
       has_one :out, :favorite_lesson, model_class: 'Lesson'
     end

--- a/spec/integration/association_cache_spec.rb
+++ b/spec/integration/association_cache_spec.rb
@@ -7,7 +7,7 @@ describe 'Association Cache' do
 
     stub_active_node_class('Student') do
       property :name
-      has_many :out, :lessons, type: :has_student, model_class: 'Lesson'
+      has_many :out, :lessons, model_class: 'Lesson'
       has_many :in, :exams, model_class: 'Exam', origin: :students
       has_one :out, :favorite_lesson, model_class: 'Lesson'
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,7 +90,7 @@ module ActiveNodeRelStubHelpers
     named_class(class_name) do
       include Neo4j::ActiveNode
 
-      instance_eval(&block) if block
+      module_eval(&block) if block
     end
   end
 
@@ -98,7 +98,7 @@ module ActiveNodeRelStubHelpers
     named_class(class_name) do
       include Neo4j::ActiveRel
 
-      instance_eval(&block) if block
+      module_eval(&block) if block
     end
   end
 
@@ -110,7 +110,7 @@ module ActiveNodeRelStubHelpers
         alias_method :name, :class_name
       end
 
-      instance_eval(&block) if block
+      module_eval(&block) if block
     end
   end
 end

--- a/spec/unit/active_rel/property_spec.rb
+++ b/spec/unit/active_rel/property_spec.rb
@@ -15,6 +15,10 @@ describe Neo4j::ActiveRel::Property do
         'Clazz'
       end
 
+      def self.uses_classname?
+        false
+      end
+
       include Neo4j::ActiveRel::Property
       include Neo4j::ActiveRel::Types
     end


### PR DESCRIPTION
```
lib/neo4j/active_node/has_n.rb:91:7: C: Metrics/AbcSize: Assignment Branch Condition size for has_many is too high. [57.36/18]
      def has_many(direction, name, options = {})
      ^^^
lib/neo4j/active_node/has_n.rb:147:7: C: Metrics/AbcSize: Assignment Branch Condition size for has_one is too high. [48.76/18]
      def has_one(direction, name, options = {})
      ^^^
```

Oh my...  Working on that next...