### PR TITLE
Allow to specify empty types/lables and default class for nodes/rels

### DIFF
--- a/config/neo4j/config.yml
+++ b/config/neo4j/config.yml
@@ -31,5 +31,7 @@ timestamps: true
 # By default, this property is called _classname, set as symbol to override.
 cache_class_names: true
 # class_name_property:  :_classname
-
+# default_node_class: 'Node'
+# default_rel_class: 'Link'
+    
 transform_rel_type: :upcase

--- a/lib/neo4j/active_node/node_wrapper.rb
+++ b/lib/neo4j/active_node/node_wrapper.rb
@@ -16,7 +16,9 @@ class Neo4j::Node
     def class_to_wrap
       load_classes_from_labels
 
-      named_class || ::Neo4j::ActiveNode::Labels.model_for_labels(labels)
+      default_class = Neo4j::Config[:default_node_class]
+      default_class = default_class.constantize if default_class
+      named_class || ::Neo4j::ActiveNode::Labels.model_for_labels(labels) || default_class
     end
 
     private

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -101,7 +101,7 @@ module Neo4j
         def _model_label_string
           return if !@model
 
-          @model.mapped_label_names.map { |label_name| ":`#{label_name}`" }.join
+          @model.mapped_label_names.map { |label_name| ":`#{label_name}`" if label_name.size > 0 }.join
         end
 
         # Scope all queries to the current scope.

--- a/lib/neo4j/active_rel/query.rb
+++ b/lib/neo4j/active_rel/query.rb
@@ -46,7 +46,8 @@ module Neo4j::ActiveRel
       end
 
       def all_query
-        Neo4j::Session.query.match("#{cypher_string}-[r1:`#{self._type}`]->#{cypher_string(:inbound)}")
+        type = self._type == '' ?  '' : ":`#{self._type}`"
+        Neo4j::Session.query.match("#{cypher_string}-[r1"+type+"]->#{cypher_string(:inbound)}")
       end
 
       def cypher_string(dir = :outbound)
@@ -61,8 +62,14 @@ module Neo4j::ActiveRel
       end
 
       def cypher_label(dir = :outbound)
-        target_class = dir == :outbound ? as_constant(_from_class) : as_constant(_to_class)
-        ":`#{target_class.mapped_label_name}`)"
+        if dir == :outbound and _from_class
+          target_class = as_constant(_from_class)
+          return ":`#{target_class.mapped_label_name}`)"
+        elsif dir == :inbound and _to_class
+          target_class = as_constant(_to_class)
+          return ":`#{target_class.mapped_label_name}`)"
+        end
+        ')'
       end
 
       def as_constant(given_class)

--- a/lib/neo4j/active_rel/rel_wrapper.rb
+++ b/lib/neo4j/active_rel/rel_wrapper.rb
@@ -7,7 +7,11 @@ class Neo4j::Relationship
         most_concrete_class = sorted_wrapper_classes
         wrapped_rel = most_concrete_class.constantize.new
       rescue NameError
-        return self
+        if Neo4j::Config[:default_rel_class]
+          wrapped_rel =  Neo4j::Config[:default_rel_class].constantize.new
+        else
+          return self
+        end
       end
 
       wrapped_rel.init_on_load(self, self._start_node_id, self._end_node_id, self.rel_type)


### PR DESCRIPTION
It is useful for cases, when i may have default abstract classes with common behavior:

    class Node
      include Neo4j::ActiveNode
      self.mapped_label_name = ''
      ... common behavior goes here ...

    class Link
      include Neo4j::ActiveRel
      type ''
      ... common behavior goes here ...

So when i want to fetch all the relations/nodes from database,
i can do it with `Link.all` and `Node.all`

Also i may have some some types in database, which don't have implemented class in ruby
Then it's useful to wrap them with those abstract classes:

    config.neo4j[:default_node_class] = 'Node'
    config.neo4j[:default_rel_class] = 'Link'