### PR TITLE
Improves node wrap time by almost 50% using stackprof report

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem 'neo4j-core', github: 'neo4jrb/neo4j-core', branch: 'master'
 # gem 'neo4j-core', path: '../neo4j-core'
 
-gem 'active_attr', github: 'neo4jrb/active_attr'
+# gem 'active_attr', github: 'neo4jrb/active_attr', branch: 'performance'
 # gem 'active_attr', path: '../active_attr'
 
 group 'test' do

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ gemspec
 gem 'neo4j-core', github: 'neo4jrb/neo4j-core', branch: 'master'
 # gem 'neo4j-core', path: '../neo4j-core'
 
+gem 'active_attr', github: 'neo4jrb/active_attr'
+# gem 'active_attr', path: '../active_attr'
+
 group 'test' do
   gem 'coveralls', require: false
   gem 'simplecov', require: false

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -92,7 +92,7 @@ module Neo4j::ActiveNode
       end
 
       def associations
-        @associations || {}
+        @associations ||= {}
       end
 
       # make sure the inherited classes inherit the <tt>_decl_rels</tt> hash

--- a/lib/neo4j/active_node/initialize.rb
+++ b/lib/neo4j/active_node/initialize.rb
@@ -10,7 +10,7 @@ module Neo4j::ActiveNode::Initialize
     self.class.extract_association_attributes!(properties)
     @_persisted_obj = persisted_node
     changed_attributes && changed_attributes.clear
-    @attributes = attributes.merge(properties.stringify_keys)
+    @attributes = attributes.merge!(properties.stringify_keys)
     self.default_properties = properties
     @attributes = convert_properties_to :ruby, @attributes
   end

--- a/lib/neo4j/active_node/node_wrapper.rb
+++ b/lib/neo4j/active_node/node_wrapper.rb
@@ -26,17 +26,17 @@ class Neo4j::Node
     end
 
     # Only load classes once for performance
-    CONSTANTS_FOR_LABELS_CACHE = ActiveSupport::Cache::MemoryStore.new
+    CONSTANTS_FOR_LABELS_CACHE = {}
 
     def self.constant_for_label(label)
-      @constants_for_labels ||= {}
-      CONSTANTS_FOR_LABELS_CACHE.fetch(label.to_sym) do
-        begin
-          label.to_s.constantize
-        rescue NameError
-          nil
-        end
-      end
+      # @constants_for_labels ||= {}
+      CONSTANTS_FOR_LABELS_CACHE[label] || CONSTANTS_FOR_LABELS_CACHE[label] = constantized_label(label)
+    end
+
+    def self.constantized_label(label)
+      label.to_s.constantize
+      rescue NameError
+        nil
     end
 
     def named_class

--- a/lib/neo4j/active_node/property.rb
+++ b/lib/neo4j/active_node/property.rb
@@ -5,8 +5,7 @@ module Neo4j::ActiveNode
 
     def initialize(attributes = {}, options = {})
       super(attributes, options)
-
-      send_props(@relationship_props) if persisted? && !@relationship_props.nil?
+      send_props(@relationship_props) if _persisted_obj && !@relationship_props.nil?
     end
 
     module ClassMethods

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -22,7 +22,7 @@ module Neo4j::Shared
       @relationship_props = self.class.extract_association_attributes!(attributes)
       writer_method_props = extract_writer_methods!(attributes)
       validate_attributes!(attributes)
-      send_props(writer_method_props) unless writer_method_props.nil?
+      send_props(writer_method_props) unless writer_method_props.empty?
 
       @_persisted_obj = nil
 
@@ -67,6 +67,7 @@ module Neo4j::Shared
     end
 
     def extract_writer_methods!(attributes)
+      return attributes if attributes.empty?
       {}.tap do |writer_method_props|
         attributes.each_key do |key|
           writer_method_props[key] = attributes.delete(key) if self.respond_to?("#{key}=")

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -61,6 +61,7 @@ module Neo4j::Shared
     # Changes attributes hash to remove relationship keys
     # Raises an error if there are any keys left which haven't been defined as properties on the model
     def validate_attributes!(attributes)
+      return attributes if attributes.empty?
       invalid_properties = attributes.keys.map(&:to_s) - self.attributes.keys
       fail UndefinedPropertyError, "Undefined properties: #{invalid_properties.join(',')}" if invalid_properties.size > 0
     end

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -111,10 +111,6 @@ module Neo4j::Shared
       klass ? klass.new(*values) : values
     end
 
-    def magic_typecast_properties
-      self.class.magic_typecast_properties
-    end
-
     module ClassMethods
       # Defines a property on the class
       #

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -200,7 +200,7 @@ module Neo4j::Shared
         @magic_typecast_properties ||= {}
       end
 
-      def magic_typecase_properties_keys
+      def magic_typecast_properties_keys
         @magic_typecast_properties_keys ||= magic_typecast_properties.keys
       end
 

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -18,7 +18,7 @@ module Neo4j::Shared
     attr_reader :_persisted_obj
 
     def initialize(attributes = {}, options = {})
-      attributes = process_attributes(attributes)
+      attributes = process_attributes(attributes) unless attributes.empty?
       @relationship_props = self.class.extract_association_attributes!(attributes)
       writer_method_props = extract_writer_methods!(attributes)
       validate_attributes!(attributes)

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -38,8 +38,8 @@ module Neo4j::Shared
     alias_method :[], :read_attribute
 
     def default_properties=(properties)
-      keys = self.class.default_properties.keys
-      @default_properties = properties.select { |key| keys.include?(key) }
+      default_property_keys = self.class.default_properties_keys
+      @default_properties = properties.select { |key| default_property_keys.include?(key) }
     end
 
     def default_property(key)
@@ -168,10 +168,16 @@ module Neo4j::Shared
         @default_property ||= {}
       end
 
+      def default_properties_keys
+        @default_properties_keys ||= default_properties.keys
+      end
+
       def reset_default_properties(name_to_keep)
         default_properties.each_key do |property|
+          @default_properties_keys = nil
           undef_method(property) unless property == name_to_keep
         end
+        @default_properties_keys = nil
         @default_property = {}
       end
 
@@ -192,6 +198,10 @@ module Neo4j::Shared
 
       def magic_typecast_properties
         @magic_typecast_properties ||= {}
+      end
+
+      def magic_typecase_properties_keys
+        @magic_typecast_properties_keys ||= magic_typecast_properties.keys
       end
 
       private
@@ -234,6 +244,7 @@ module Neo4j::Shared
         typecaster = Neo4j::Shared::TypeConverters.typecaster_for(options[:type])
         return unless typecaster && typecaster.respond_to?(:primitive_type)
         magic_typecast_properties[name] = options[:type]
+        @magic_typecast_properties_keys = nil
         options[:type] = typecaster.primitive_type
         options[:typecaster] = typecaster
       end

--- a/lib/neo4j/shared/serialized_properties.rb
+++ b/lib/neo4j/shared/serialized_properties.rb
@@ -20,7 +20,12 @@ module Neo4j::Shared
         @serialize ||= {}
       end
 
+      def serialized_properties_keys
+        @serialized_property_keys ||= serialized_properties.keys
+      end
+
       def serialized_properties=(serialize_hash)
+        @serialized_property_keys = nil
         @serialize = serialize_hash.clone
       end
 

--- a/lib/neo4j/shared/serialized_properties.rb
+++ b/lib/neo4j/shared/serialized_properties.rb
@@ -17,7 +17,7 @@ module Neo4j::Shared
 
     module ClassMethods
       def serialized_properties
-        @serialize || {}
+        @serialize ||= {}
       end
 
       def serialized_properties=(serialize_hash)

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -136,10 +136,12 @@ module Neo4j::Shared
 
     # Returns true if the property isn't defined in the model or it's both nil and unchanged.
     def skip_conversion?(attr, value)
-      !self.class.attributes[attr] || (value.nil? && !changed_attributes.key?(attr))
+      !self.class.attributes[attr] || (value.nil? && !changed_attributes[attr])
     end
 
     class << self
+      attr_reader :converters
+
       def included(_)
         return if @converters
         @converters = {}
@@ -150,6 +152,7 @@ module Neo4j::Shared
       end
 
       def typecaster_for(primitive_type)
+        return nil if primitive_type.nil?
         converters.key?(primitive_type) ? converters[primitive_type] : nil
       end
 
@@ -163,8 +166,6 @@ module Neo4j::Shared
       def register_converter(converter)
         converters[converter.convert_type] = converter
       end
-
-      attr_reader :converters
     end
   end
 end

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -126,7 +126,7 @@ module Neo4j::Shared
       case
       when self.class.serialized_properties_keys.include?(attr)
         serialized_properties[attr]
-      when self.class.magic_typecase_properties_keys.include?(attr)
+      when self.class.magic_typecast_properties_keys.include?(attr)
         self.class.magic_typecast_properties[attr]
       else
         self.class._attribute_type(attr)

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -109,10 +109,9 @@ module Neo4j::Shared
 
     def convert_properties_to(medium, properties)
       converter = medium == :ruby ? :to_ruby : :to_db
-
-      properties.each_with_object({}) do |(attr, value), new_attributes|
-        next new_attributes if skip_conversion?(attr, value)
-        new_attributes[attr] = converted_property(primitive_type(attr.to_sym), value, converter)
+      properties.each_pair do |attr, value|
+        next if skip_conversion?(attr, value)
+        properties[attr] = converted_property(primitive_type(attr.to_sym), value, converter)
       end
     end
 
@@ -125,9 +124,9 @@ module Neo4j::Shared
     # If the attribute is to be typecast using a custom converter, which converter should it use? If no, returns the type to find a native serializer.
     def primitive_type(attr)
       case
-      when serialized_properties.key?(attr)
+      when self.class.serialized_properties_keys.include?(attr)
         serialized_properties[attr]
-      when magic_typecast_properties.key?(attr)
+      when self.class.magic_typecase_properties_keys.include?(attr)
         self.class.magic_typecast_properties[attr]
       else
         self.class._attribute_type(attr)

--- a/spec/unit/persistance_spec.rb
+++ b/spec/unit/persistance_spec.rb
@@ -32,9 +32,11 @@ describe Neo4j::ActiveNode::Persistence do
       Neo4j::Session.stub(:current).and_return(session)
     end
 
+    # TODO: This should be an e2e test. This stubbing...
     it 'creates a new node if not persisted before' do
       o = clazz.new(name: 'kalle', age: '42')
       o.stub(:serialized_properties).and_return({})
+      allow_any_instance_of(Object).to receive(:serialized_properties_keys).and_return([])
       clazz.stub(:cached_class?).and_return(false)
       clazz.should_receive(:neo4j_session).and_return(session)
       clazz.should_receive(:mapped_label_names).and_return(:MyClass)
@@ -57,6 +59,8 @@ describe Neo4j::ActiveNode::Persistence do
       o.name = 'sune'
       o.stub(:serialized_properties).and_return({})
       o.stub(:_persisted_obj).and_return(node)
+      allow_any_instance_of(Object).to receive(:serialized_properties_keys).and_return([])
+
       expect(node).to receive(:update_props).and_return(name: 'sune')
       o.save
     end
@@ -76,6 +80,8 @@ describe Neo4j::ActiveNode::Persistence do
         clazz.stub(:mapped_label_names).and_return(:MyClass)
         expect(session).to receive(:create_node).with(end_props, :MyClass).and_return(node)
         expect(o).to receive(:init_on_load).with(node, end_props)
+        allow_any_instance_of(Object).to receive(:serialized_properties_keys).and_return([])
+
         expect(node).to receive(:props).and_return(end_props)
 
         o.save

--- a/spec/unit/validation_spec.rb
+++ b/spec/unit/validation_spec.rb
@@ -44,6 +44,7 @@ describe Neo4j::ActiveNode::Validations do
         node.should_receive(:props).and_return(name: 'kalle2', age: '43')
         session.should_receive(:create_node).with({name: 'kalle', age: 42}, :MyClass).and_return(node)
         o.should_receive(:init_on_load).with(node, age: '43', name: 'kalle2')
+        allow(Object).to receive(:serialized_properties_keys).and_return([])
         o.save.should be true
       end
 
@@ -53,6 +54,7 @@ describe Neo4j::ActiveNode::Validations do
         o.stub(:_persisted_obj).and_return(node)
         o.stub(:serialized_properties).and_return({})
         node.should_receive(:update_props).and_return(name: 'sune')
+        allow(Object).to receive(:serialized_properties_keys).and_return([])
         o.save.should be true
       end
     end


### PR DESCRIPTION
Behold! The benchmark:

```ruby
300.times { Student.create(a: 'Chris', b: 'Lauren', c: 'Jasmine', d: 'Autolux') }
require 'benchmark/ips'
Student.first
Benchmark.ips do |x|
  x.config(time: 10)
  
  x.report do
    Student.all.limit(300).to_a
  end
end
```

Before: 10.400  (± 9.6%) i/s -    104.000
Stackprof's offenders:

```
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     14407  (16.5%)       14407  (16.5%)     MultiJson::Adapters::Oj#load
     43500  (49.9%)       14400  (16.5%)     block in ActiveAttr::Attributes#attributes
     14400  (16.5%)       14400  (16.5%)     ActiveAttr::Typecasting#typecaster_for
      8100   (9.3%)        5700   (6.5%)     Neo4j::Shared::TypeConverters#convert_properties_to
      3300   (3.8%)        1500   (1.7%)     #<Module:0x007f9a5c3842c8>.model_for_labels
      1500   (1.7%)        1500   (1.7%)     Neo4j::ActiveNode::HasN::ClassMethods#associations
     16500  (18.9%)        1500   (1.7%)     Neo4j::Shared::Property#validate_attributes!
      1500   (1.7%)        1500   (1.7%)     block in Hash#stringify_keys
      3000   (3.4%)        1500   (1.7%)     block in Hash#transform_keys
     44700  (51.3%)        1200   (1.4%)     ActiveAttr::Attributes#attributes_map
```

After:    14.037  (± 7.1%) i/s -    140.000 

New offenders:

```
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     14407  (22.2%)       14407  (22.2%)     MultiJson::Adapters::Oj#load
      9600  (14.8%)        9600  (14.8%)     ActiveAttr::Typecasting#typecaster_for
     29100  (44.8%)        9600  (14.8%)     block in ActiveAttr::Attributes#attributes
      6900  (10.6%)        5700   (8.8%)     Neo4j::Shared::TypeConverters#convert_properties_to
      3000   (4.6%)        1500   (2.3%)     block in Hash#transform_keys
      1500   (2.3%)        1500   (2.3%)     Neo4j::ActiveNode::HasN::ClassMethods#associations
      1500   (2.3%)        1500   (2.3%)     block in Hash#stringify_keys
      1200   (1.8%)        1200   (1.8%)     ActiveSupport::HashWithIndifferentAccess#default
     30000  (46.2%)         900   (1.4%)     ActiveAttr::Attributes#attributes_map
      1200   (1.8%)         600   (0.9%)     #<Module:0x007fc48c2459c0>#l
```