### PR TITLE
prevents instance query_as from using labels

### DIFF
--- a/lib/neo4j/active_node/query.rb
+++ b/lib/neo4j/active_node/query.rb
@@ -39,7 +39,9 @@ module Neo4j
         #   # Generates: MATCH (person:Person), person-[:owned]-car WHERE person.age > 30 RETURN car.registration_number
         #   Person.query_as(:person).where('person.age > 30').match('person-[:owned]-car').return(car: :registration_number)
         #
-        # @param var [Symbol, String] The variable name to specify in the query
+        # @param [Symbol, String] var The variable name to specify in the query
+        # @param [Boolean] with_labels Should labels be used to build the match? There are situations (neo_id used to filter,
+        # an early Cypher match has already filtered results) where including labels will degrade performance.
         # @return [Neo4j::Core::Query]
         def query_as(var, with_labels = true)
           query_proxy.query_as(var, with_labels)

--- a/lib/neo4j/active_node/query.rb
+++ b/lib/neo4j/active_node/query.rb
@@ -16,7 +16,7 @@ module Neo4j
       # @param var [Symbol, String] The variable name to specify in the query
       # @return [Neo4j::Core::Query]
       def query_as(node_var)
-        self.class.query_as(node_var).where("ID(#{node_var})" => self.neo_id)
+        self.class.query_as(node_var, false).where("ID(#{node_var})" => self.neo_id)
       end
 
       # Starts a new QueryProxy with the starting identifier set to the given argument and QueryProxy caller set to the node instance.
@@ -41,8 +41,8 @@ module Neo4j
         #
         # @param var [Symbol, String] The variable name to specify in the query
         # @return [Neo4j::Core::Query]
-        def query_as(var)
-          query_proxy.query_as(var)
+        def query_as(var, with_labels = true)
+          query_proxy.query_as(var, with_labels)
         end
 
         Neo4j::ActiveNode::Query::QueryProxy::METHODS.each do |method|

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -263,6 +263,8 @@ module Neo4j
           _query.send(@match_type, _match_arg(var, with_labels))
         end
 
+        # @param [String, Symbol] var The Cypher identifier to use within the match string
+        # @param [Boolean] with_labels Send "true" to include model labels where possible.
         def _match_arg(var, with_labels)
           if @model && with_labels != false
             labels = @model.respond_to?(:mapped_label_names) ? _model_label_string : @model

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -86,8 +86,8 @@ module Neo4j
         # and work with it from the more powerful (but less friendly) Neo4j::Core::Query.
         # @param [String,Symbol] var The identifier to use for node at this link of the QueryProxy chain.
         #   student.lessons.query_as(:l).with('your cypher here...')
-        def query_as(var)
-          result_query = @chain.inject(base_query(var).params(@params)) do |query, link|
+        def query_as(var, with_label = true)
+          result_query = @chain.inject(base_query(var, with_label).params(@params)) do |query, link|
             args = link.args(var, rel_var)
 
             if args.is_a?(Array)
@@ -100,19 +100,18 @@ module Neo4j
           result_query.tap { |query| query.proxy_chain_level = _chain_level }
         end
 
-        def base_query(var)
+        def base_query(var, with_labels = true)
           if @association
             chain_var = _association_chain_var
             (_association_query_start(chain_var) & _query).send(@match_type,
                                                                 "#{chain_var}#{_association_arrow}(#{var}#{_model_label_string})")
           else
-            starting_query ? (starting_query & _query_model_as(var)) : _query_model_as(var)
+            starting_query ? (starting_query & _query_model_as(var, with_labels)) : _query_model_as(var, with_labels)
           end
         end
 
         def _model_label_string
           return if !@model
-
           @model.mapped_label_names.map { |label_name| ":`#{label_name}`" }.join
         end
 
@@ -260,12 +259,12 @@ module Neo4j
           @chain += links
         end
 
-        def _query_model_as(var)
-          _query.send(@match_type, _match_arg(var))
+        def _query_model_as(var, with_labels = true)
+          _query.send(@match_type, _match_arg(var, with_labels))
         end
 
-        def _match_arg(var)
-          if @model
+        def _match_arg(var, with_labels)
+          if @model && with_labels != false
             labels = @model.respond_to?(:mapped_label_names) ? _model_label_string : @model
             {var => labels}
           else

--- a/spec/unit/query_spec.rb
+++ b/spec/unit/query_spec.rb
@@ -29,7 +29,7 @@ describe Neo4j::ActiveNode::Query do
   end
 
   describe '.query_as' do
-    it 'generates a basic query' do
+    it 'generates a basic query with labels' do
       @class_a.query_as(:q).to_cypher.should == 'MATCH (q:`Person`)'
     end
 
@@ -39,12 +39,12 @@ describe Neo4j::ActiveNode::Query do
   end
 
   describe '#query_as' do
-    it 'generates a basic query' do
-      @class_a.new.query_as(:q).to_cypher.should == 'MATCH (q:`Person`) WHERE (ID(q) = {ID_q})'
+    it 'generates a basic query with labels' do
+      @class_a.new.query_as(:q).to_cypher.should == 'MATCH q WHERE (ID(q) = {ID_q})'
     end
 
     it 'can be built upon' do
-      @class_a.new.query_as(:q).match('q--p').return(p: :name).to_cypher.should == 'MATCH (q:`Person`), q--p WHERE (ID(q) = {ID_q}) RETURN p.name'
+      @class_a.new.query_as(:q).match('q--p').return(p: :name).to_cypher.should == 'MATCH q, q--p WHERE (ID(q) = {ID_q}) RETURN p.name'
     end
   end
 end


### PR DESCRIPTION
`query_as` called on an instance method results in `MATCH (result:Label) WHERE ID(result) = {neo_id}`. Including the label check there hurts performance because the use of neo_id guarantees we'll get the node we're looking for if it exists.

This makes a very simple change: the `query_as` class method accepts an optional second argument. When given `false`, it will omit the node labels. It defaults to true, so `Student.query_as(:s)` will have labels, `Student.first.query_as(:s)` will not.