### PR TITLE
break out of extract_association_attributes! early

### DIFF
--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -95,6 +95,10 @@ module Neo4j::ActiveNode
         @associations ||= {}
       end
 
+      def associations_keys
+        @associations_keys ||= []
+      end
+
       # make sure the inherited classes inherit the <tt>_decl_rels</tt> hash
       def inherited(klass)
         klass.instance_variable_set(:@associations, associations.clone)
@@ -265,6 +269,7 @@ module Neo4j::ActiveNode
       end
 
       def build_association(macro, direction, name, options)
+        associations_keys << name
         Neo4j::ActiveNode::HasN::Association.new(macro, direction, name, options).tap do |association|
           @associations ||= {}
           @associations[name] = association

--- a/lib/neo4j/active_node/property.rb
+++ b/lib/neo4j/active_node/property.rb
@@ -12,9 +12,17 @@ module Neo4j::ActiveNode
       # Extracts keys from attributes hash which are associations of the model
       # TODO: Validate separately that relationships are getting the right values?  Perhaps also store the values and persist relationships on save?
       def extract_association_attributes!(attributes)
+        return unless contains_association?(attributes)
         attributes.each_with_object({}) do |(key, _), result|
           result[key] = attributes.delete(key) if self.association?(key)
         end
+      end
+
+      private
+
+      def contains_association?(attributes)
+        attributes.each_key { |key| return true if associations_keys.include?(key) }
+        false
       end
     end
   end

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -28,6 +28,11 @@ describe 'has_many' do
     end
   end
 
+  describe 'associations_keys' do
+    subject { clazz_a.associations_keys }
+    it { is_expected.to include(:friends, :knows, :knows_me) }
+  end
+
   describe 'non-persisted node' do
     let(:unsaved_node) { clazz_a.new }
     it 'returns an empty array' do


### PR DESCRIPTION
Pretty simple. It makes each association register itself upon declaration, then it makes it easy to determine whether a hash contains keys that are association names. This gets called twice during init for some reason, so it saves two hashes per node when loading.