### PR TITLE
Wraps QueryProxy association= and association << in transactions

### DIFF
--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -195,7 +195,7 @@ module Neo4j::ActiveNode
 
         define_method("#{name}=") do |other_nodes|
           clear_association_cache
-          association_query_proxy(name).replace_with(other_nodes)
+          Neo4j::Transaction.run { association_query_proxy(name).replace_with(other_nodes) }
         end
 
         define_class_method(name) do |node = nil, rel = nil, previous_query_proxy = nil, options = {}|
@@ -215,7 +215,7 @@ module Neo4j::ActiveNode
         define_method("#{name}=") do |other_node|
           validate_persisted_for_association!
           clear_association_cache
-          association_query_proxy(name).replace_with(other_node)
+          Neo4j::Transaction.run { association_query_proxy(name).replace_with(other_node) }
         end
 
         define_class_method(name) do |node = nil, rel = nil, previous_query_proxy = nil, options = {}|

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -193,13 +193,17 @@ module Neo4j::ActiveNode
           association_query_proxy(name, {node: node, rel: rel, source_object: self}.merge(options))
         end
 
-        define_method("#{name}=") do |other_nodes|
-          clear_association_cache
-          Neo4j::Transaction.run { association_query_proxy(name).replace_with(other_nodes) }
-        end
+        define_has_many_setter(name)
 
         define_class_method(name) do |node = nil, rel = nil, previous_query_proxy = nil, options = {}|
           association_query_proxy(name, {node: node, rel: rel, previous_query_proxy: previous_query_proxy}.merge(options))
+        end
+      end
+
+      def define_has_many_setter(name)
+        define_method("#{name}=") do |other_nodes|
+          clear_association_cache
+          Neo4j::Transaction.run { association_query_proxy(name).replace_with(other_nodes) }
         end
       end
 
@@ -212,14 +216,18 @@ module Neo4j::ActiveNode
                                      self.class.reflect_on_association(__method__)) { result.first }
         end
 
+        define_has_one_setter(name)
+
+        define_class_method(name) do |node = nil, rel = nil, previous_query_proxy = nil, options = {}|
+          association_query_proxy(name, {previous_query_proxy: previous_query_proxy, node: node, rel: rel}.merge(options))
+        end
+      end
+
+      def define_has_one_setter(name)
         define_method("#{name}=") do |other_node|
           validate_persisted_for_association!
           clear_association_cache
           Neo4j::Transaction.run { association_query_proxy(name).replace_with(other_node) }
-        end
-
-        define_class_method(name) do |node = nil, rel = nil, previous_query_proxy = nil, options = {}|
-          association_query_proxy(name, {previous_query_proxy: previous_query_proxy, node: node, rel: rel}.merge(options))
         end
       end
 

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -90,11 +90,7 @@ module Neo4j
           result_query = @chain.inject(base_query(var, with_label).params(@params)) do |query, link|
             args = link.args(var, rel_var)
 
-            if args.is_a?(Array)
-              query.send(link.clause, *args)
-            else
-              query.send(link.clause, link.args(var, rel_var))
-            end
+            args.is_a?(Array) ? query.send(link.clause, *args) : query.send(link.clause, args)
           end
 
           result_query.tap { |query| query.proxy_chain_level = _chain_level }

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -177,18 +177,18 @@ module Neo4j
             fail ArgumentError, "Node must be of the association's class when model is specified"
           end
 
-          other_nodes.each do |other_node|
-            # Neo4j::Transaction.run do
-            other_node.save unless other_node.neo_id
+          Neo4j::Transaction.run do
+            other_nodes.each do |other_node|
+              other_node.save unless other_node.neo_id
 
-            return false if @association.perform_callback(@start_object, other_node, :before) == false
+              return false if @association.perform_callback(@start_object, other_node, :before) == false
 
-            @start_object.clear_association_cache
+              @start_object.clear_association_cache
 
-            _create_relationship(other_node, properties)
+              _create_relationship(other_node, properties)
 
-            @association.perform_callback(@start_object, other_node, :after)
-            # end
+              @association.perform_callback(@start_object, other_node, :after)
+            end
           end
         end
 


### PR DESCRIPTION
Solves #766 
It was necessary to ensure `<<` happens inside transactions because it supports arrays. Now, all actions must complete or the entire action will roll back.