### PR TITLE
use active_attr typecasters branch to improve performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem 'neo4j-core', github: 'neo4jrb/neo4j-core', branch: 'master'
 # gem 'neo4j-core', path: '../neo4j-core'
 
-# gem 'active_attr', github: 'neo4jrb/active_attr', branch: 'performance'
+gem 'active_attr', github: 'neo4jrb/active_attr', branch: 'typecasters'
 # gem 'active_attr', path: '../active_attr'
 
 group 'test' do

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -233,7 +233,7 @@ module Neo4j::Shared
         converter = options[:serializer]
         return unless converter
         options[:type]        = converter.convert_type
-        options[:typecaster]  = ActiveAttr::Typecasting::ObjectTypecaster.new
+        options[:typecaster]  = ActiveAttr::Typecasting::ObjectTypecaster
         Neo4j::Shared::TypeConverters.register_converter(converter)
       end
 

--- a/spec/unit/shared/property_spec.rb
+++ b/spec/unit/shared/property_spec.rb
@@ -115,7 +115,7 @@ describe Neo4j::Shared::Property do
     end
 
     it 'sets active_attr typecaster to ObjectTypecaster' do
-      expect(clazz.attributes[:range][:typecaster]).to be_a(ActiveAttr::Typecasting::ObjectTypecaster)
+      expect(clazz.attributes[:range][:typecaster]).to eq(ActiveAttr::Typecasting::ObjectTypecaster)
     end
 
     it 'adds new converter' do


### PR DESCRIPTION
Gonna leave this here for now. Not merging yet. It results in a slight improvement over the existing `active_attr` master when loading a couple hundred objects at a time. Brian and I discussed and don't think we want to use this unless we release and maintain our own fork of `active_attr`, which isn't something I'm positive I want to do.

In the meantime, if anyone has any comments about whether this is something they want to use or if they want to experiment with it as a way to improve performance in Neo4j.rb, give it a shot. It's totally stable.