### PR TITLE
More speed

### DIFF
--- a/lib/neo4j/active_node/initialize.rb
+++ b/lib/neo4j/active_node/initialize.rb
@@ -10,7 +10,8 @@ module Neo4j::ActiveNode::Initialize
     self.class.extract_association_attributes!(properties)
     @_persisted_obj = persisted_node
     changed_attributes && changed_attributes.clear
-    @attributes = attributes.merge!(properties.stringify_keys)
+    attr = @attributes || self.class.attributes_nil_hash.dup
+    @attributes = attr.merge!(properties.stringify_keys)
     self.default_properties = properties
     @attributes = convert_properties_to :ruby, @attributes
   end

--- a/lib/neo4j/active_node/initialize.rb
+++ b/lib/neo4j/active_node/initialize.rb
@@ -11,7 +11,7 @@ module Neo4j::ActiveNode::Initialize
     @_persisted_obj = persisted_node
     changed_attributes && changed_attributes.clear
     attr = @attributes || self.class.attributes_nil_hash.dup
-    @attributes = attr.merge!(properties.stringify_keys)
+    @attributes = attr.merge!(properties).stringify_keys!
     self.default_properties = properties
     @attributes = convert_properties_to :ruby, @attributes
   end

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -17,7 +17,7 @@ module Neo4j::Shared
 
     attr_reader :_persisted_obj
 
-    def initialize(attributes = {}, options = {})
+    def initialize(attributes = {}, _options = nil)
       attributes = process_attributes(attributes) unless attributes.empty?
       @relationship_props = self.class.extract_association_attributes!(attributes)
       writer_method_props = extract_writer_methods!(attributes)
@@ -26,7 +26,7 @@ module Neo4j::Shared
 
       @_persisted_obj = nil
 
-      super(attributes, options)
+      # super(attributes, options)
     end
 
     # Returning nil when we get ActiveAttr::UnknownAttributeError from ActiveAttr

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -203,6 +203,10 @@ module Neo4j::Shared
         end
       end
 
+      def attributes_nil_hash
+        @_attributes_nil_hash ||= {}.tap { |attr_hash| attribute_names.each { |k, _v| attr_hash[k.to_s] = nil } }.freeze
+      end
+
       def magic_typecast_properties
         @magic_typecast_properties ||= {}
       end

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -129,13 +129,25 @@ module Neo4j::Shared
       when self.class.magic_typecast_properties_keys.include?(attr)
         self.class.magic_typecast_properties[attr]
       else
-        self.class._attribute_type(attr)
+        self.class.fetch_upstream_primitive(attr)
       end
     end
 
     # Returns true if the property isn't defined in the model or it's both nil and unchanged.
     def skip_conversion?(attr, value)
       !self.class.attributes[attr] || (value.nil? && !changed_attributes[attr])
+    end
+
+    module ClassMethods
+
+      # Prevents repeated calls to :_attribute_type, which isn't free and never changes.
+      def fetch_upstream_primitive(attr)
+        upstream_primitives[attr] || upstream_primitives[attr] = self._attribute_type(attr)
+      end
+
+      def upstream_primitives
+        @upstream_primitives ||= {}
+      end
     end
 
     class << self

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -139,7 +139,6 @@ module Neo4j::Shared
     end
 
     module ClassMethods
-
       # Prevents repeated calls to :_attribute_type, which isn't free and never changes.
       def fetch_upstream_primitive(attr)
         upstream_primitives[attr] || upstream_primitives[attr] = self._attribute_type(attr)

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -144,6 +144,7 @@ module Neo4j::Shared
         upstream_primitives[attr] || upstream_primitives[attr] = self._attribute_type(attr)
       end
 
+      # The known mappings of declared properties and their primitive types.
       def upstream_primitives
         @upstream_primitives ||= {}
       end

--- a/spec/unit/persistance_spec.rb
+++ b/spec/unit/persistance_spec.rb
@@ -11,6 +11,10 @@ describe Neo4j::ActiveNode::Persistence do
 
       property :name
       property :age, type: Integer
+
+      def self.fetch_upstream_primitive(_)
+        nil
+      end
     end
   end
 

--- a/spec/unit/validation_spec.rb
+++ b/spec/unit/validation_spec.rb
@@ -23,6 +23,10 @@ describe Neo4j::ActiveNode::Validations do
       def self.model_name
         ActiveModel::Name.new(self, nil, 'MyClass')
       end
+
+      def self.fetch_upstream_primitive(_attr)
+        nil
+      end
     end
   end
 


### PR DESCRIPTION
This brings performance of my "Load 300 nodes with 15 defined properties" test from around 18 i/s to 30 i/s.

The most significant performance gains were from https://github.com/neo4jrb/neo4j/commit/115d6788a70c8d1f35243a476393f717e903aa4e and https://github.com/neo4jrb/neo4j/commit/d393f0d5700dba9d187e36dafab2d1321a08e59b. They both aim to replace or skip the slowest methods in `active_attr`. I'm gonna do one more commit with some comments in code to explain new methods.