### PR TITLE
started separating property management logic

### DIFF
--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -26,6 +26,8 @@ require 'neo4j/type_converters'
 require 'neo4j/paginated'
 
 require 'neo4j/shared/callbacks'
+require 'neo4j/shared/declared_property'
+require 'neo4j/shared/declared_property_manager'
 require 'neo4j/shared/property'
 require 'neo4j/shared/persistence'
 require 'neo4j/shared/validations'

--- a/lib/neo4j/active_node/initialize.rb
+++ b/lib/neo4j/active_node/initialize.rb
@@ -1,6 +1,5 @@
 module Neo4j::ActiveNode::Initialize
   extend ActiveSupport::Concern
-  include Neo4j::Shared::TypeConverters
   attr_reader :called_by
 
   # called when loading the node from the database
@@ -13,7 +12,7 @@ module Neo4j::ActiveNode::Initialize
     attr = @attributes || self.class.attributes_nil_hash.dup
     @attributes = attr.merge!(properties).stringify_keys!
     self.default_properties = properties
-    @attributes = convert_properties_to :ruby, @attributes
+    @attributes = self.class.declared_property_manager.convert_properties_to(self, :ruby, @attributes)
   end
 
   # Implements the Neo4j::Node#wrapper and Neo4j::Relationship#wrapper method

--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -10,6 +10,7 @@ module Neo4j::ActiveNode
     end
 
     extend ActiveSupport::Concern
+    extend Forwardable
     include Neo4j::Shared::Persistence
 
     # Saves the model.
@@ -48,13 +49,11 @@ module Neo4j::ActiveNode
       create_magic_properties
       set_timestamps
       create_magic_properties
-      properties = convert_properties_to :db, props
+      properties = self.class.declared_property_manager.convert_properties_to(self, :db, props)
       node = _create_node(properties)
       init_on_load(node, node.props)
       send_props(@relationship_props) if @relationship_props
       @relationship_props = nil
-      # Neo4j::IdentityMap.add(node, self)
-      # write_changed_relationships
       true
     end
 

--- a/lib/neo4j/active_rel/initialize.rb
+++ b/lib/neo4j/active_rel/initialize.rb
@@ -1,7 +1,6 @@
 module Neo4j::ActiveRel
   module Initialize
     extend ActiveSupport::Concern
-    include Neo4j::Shared::TypeConverters
 
     attr_reader :_persisted_obj
 
@@ -17,7 +16,7 @@ module Neo4j::ActiveRel
       @attributes = attributes.merge(persisted_rel.props.stringify_keys)
       load_nodes(from_node_id, to_node_id)
       self.default_properties = persisted_rel.props
-      @attributes = convert_properties_to :ruby, @attributes
+      @attributes = self.class.declared_property_manager.convert_properties_to(self, :ruby, @attributes)
     end
 
     # Implements the Neo4j::Node#wrapper and Neo4j::Relationship#wrapper method

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -22,7 +22,7 @@ module Neo4j::ActiveRel
       validate_node_classes!
       create_magic_properties
       set_timestamps
-      properties = convert_properties_to :db, props
+      properties = self.class.declared_property_manager.convert_properties_to(self, :db, props)
       rel = _create_rel(from_node, to_node, properties)
       return self unless rel.respond_to?(:_persisted_obj)
       init_on_load(rel._persisted_obj, from_node, to_node, @rel_type)

--- a/lib/neo4j/shared.rb
+++ b/lib/neo4j/shared.rb
@@ -28,6 +28,7 @@ module Neo4j
 
     included do
       self.include_root_in_json = Neo4j::Config.include_root_in_json
+      @_declared_property_manager ||= Neo4j::Shared::DeclaredPropertyManager.new(self)
 
       def self.i18n_scope
         :neo4j

--- a/lib/neo4j/shared.rb
+++ b/lib/neo4j/shared.rb
@@ -34,5 +34,9 @@ module Neo4j
         :neo4j
       end
     end
+
+    def declared_property_manager
+      self.class.declared_property_manager
+    end
   end
 end

--- a/lib/neo4j/shared/declared_property.rb
+++ b/lib/neo4j/shared/declared_property.rb
@@ -1,0 +1,62 @@
+module Neo4j::Shared
+  # Contains methods related to the management
+  class DeclaredProperty
+    class IllegalPropertyError < StandardError; end
+
+    ILLEGAL_PROPS = %w(from_node to_node start_node end_node)
+    attr_reader :name, :name_string, :name_sym, :options, :magic_typecaster
+
+    def initialize(name, options)
+      fail IllegalPropertyError, "#{name} is an illegal property" if ILLEGAL_PROPS.include?(name.to_s)
+      @name = @name_sym = name
+      @name_string = name.to_s
+      @options = options
+    end
+
+    def register
+      register_magic_properties
+    end
+
+    def type
+      options[:type]
+    end
+
+    def typecaster
+      options[:typecaster]
+    end
+
+    def default_value
+      options[:default]
+    end
+
+    private
+
+    # Tweaks properties
+    def register_magic_properties
+      options[:type] ||= DateTime if name.to_sym == :created_at || name.to_sym == :updated_at
+      # TODO: Custom typecaster to fix the stuff below
+      # ActiveAttr does not handle "Time", Rails and Neo4j.rb 2.3 did
+      # Convert it to DateTime in the interest of consistency
+      options[:type] = DateTime if options[:type] == Time
+
+      register_magic_typecaster
+      register_type_converter
+    end
+
+    def register_magic_typecaster
+      found_typecaster = Neo4j::Shared::TypeConverters.typecaster_for(options[:type])
+      return unless found_typecaster && found_typecaster.respond_to?(:primitive_type)
+      options[:typecaster] = found_typecaster
+      @magic_typecaster = options[:type]
+      options[:type] = found_typecaster.primitive_type
+    end
+
+    def register_type_converter
+      converter = options[:serializer]
+      return unless converter
+      options[:type]        = converter.convert_type
+      options[:typecaster]  = ActiveAttr::Typecasting::ObjectTypecaster.new
+      Neo4j::Shared::TypeConverters.register_converter(converter)
+    end
+  end
+end

--- a/lib/neo4j/shared/declared_property.rb
+++ b/lib/neo4j/shared/declared_property.rb
@@ -6,7 +6,7 @@ module Neo4j::Shared
     ILLEGAL_PROPS = %w(from_node to_node start_node end_node)
     attr_reader :name, :name_string, :name_sym, :options, :magic_typecaster
 
-    def initialize(name, options)
+    def initialize(name, options = {})
       fail IllegalPropertyError, "#{name} is an illegal property" if ILLEGAL_PROPS.include?(name.to_s)
       @name = @name_sym = name
       @name_string = name.to_s

--- a/lib/neo4j/shared/declared_property_manager.rb
+++ b/lib/neo4j/shared/declared_property_manager.rb
@@ -1,0 +1,94 @@
+module Neo4j::Shared
+  class DeclaredPropertyManager
+    include Neo4j::Shared::TypeConverters
+
+    attr_reader :klass
+
+    def initialize(klass)
+      @klass = klass
+    end
+
+    def register(property)
+      @_attributes_nil_hash = nil
+      registered_properties[property.name] = property
+      register_magic_typecaster(property) if property.magic_typecaster
+      declared_property_defaults[property.name] = property.default_value if property.default_value
+    end
+
+    def declared_property_defaults
+      @_default_property_values ||= {}
+    end
+
+    def registered_properties
+      @_registered_properties ||= {}
+    end
+
+    def attributes_nil_hash
+      @_attributes_nil_hash ||= {}.tap { |attr_hash| registered_properties.each_pair { |k, _v| attr_hash[k.to_s] = nil } }.freeze
+    end
+
+    def unregister(name)
+      # might need to be include?(name.to_s)
+      fail ArgumentError, "Argument `#{name}` not an attribute" if not registered_properties[name]
+      declared_prop = registered_properties[name]
+      registered_properties.delete(declared_prop)
+      unregister_magic_typecaster(name)
+      unregister_property_default(name)
+    end
+
+    def serialize(name, coder = JSON)
+      @serialize ||= {}
+      @serialize[name] = coder
+    end
+
+    def serialized_properties=(serialize_hash)
+      @serialized_property_keys = nil
+      @serialize = serialize_hash.clone
+    end
+
+    def serialized_properties
+      @serialize ||= {}
+    end
+
+    def serialized_properties_keys
+      @serialized_property_keys ||= serialized_properties.keys
+    end
+
+    def magic_typecast_properties_keys
+      @magic_typecast_properties_keys ||= magic_typecast_properties.keys
+    end
+
+    def magic_typecast_properties
+      @magic_typecast_properties ||= {}
+    end
+
+    # The known mappings of declared properties and their primitive types.
+    def upstream_primitives
+      @upstream_primitives ||= {}
+    end
+
+    protected
+
+    # Prevents repeated calls to :_attribute_type, which isn't free and never changes.
+    def fetch_upstream_primitive(attr)
+      upstream_primitives[attr] || upstream_primitives[attr] = klass._attribute_type(attr)
+    end
+
+    private
+
+    def unregister_magic_typecaster(property)
+      magic_typecast_properties.delete(property)
+      @magic_typecast_properties_keys = nil
+    end
+
+    def unregister_property_default(property)
+      declared_property_defaults.delete(property)
+      @_default_property_values = nil
+    end
+
+    def register_magic_typecaster(property)
+      magic_typecast_properties[property.name] = property.magic_typecaster
+      @magic_typecast_properties_keys = nil
+    end
+  end
+end

--- a/lib/neo4j/shared/serialized_properties.rb
+++ b/lib/neo4j/shared/serialized_properties.rb
@@ -14,25 +14,5 @@ module Neo4j::Shared
     def serializable_hash(*args)
       super.merge(id: id)
     end
-
-    module ClassMethods
-      def serialized_properties
-        @serialize ||= {}
-      end
-
-      def serialized_properties_keys
-        @serialized_property_keys ||= serialized_properties.keys
-      end
-
-      def serialized_properties=(serialize_hash)
-        @serialized_property_keys = nil
-        @serialize = serialize_hash.clone
-      end
-
-      def serialize(name, coder = JSON)
-        @serialize ||= {}
-        @serialize[name] = coder
-      end
-    end
   end
 end

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -509,6 +509,15 @@ describe Neo4j::ActiveNode do
       expect(School.where(name: 'The College of New Jersey').child_of.to_a).to be_empty
     end
 
+    describe 'default property values' do
+      before { Person.property(:default_prop, default: 'Chopper') }
+      let(:guy) { Person.create(name: 'Guy Foo') }
+
+      it 'sets the default value if nil on persistence' do
+        expect(guy.default_prop).to eq 'Chopper'
+      end
+    end
+
     describe 'multiparameter attributes' do
       it 'converts to Date' do
         person = Person.create('date(1i)' => '2014', 'date(2i)' => '7', 'date(3i)' => '13')
@@ -653,7 +662,6 @@ describe Neo4j::ActiveNode do
       i.each { |count| Person.create(name: "Billy-#{i}", age: count) }
     end
 
-    after(:all) { Person.delete_all }
     let(:t) { Person.where }
     let(:p) { Neo4j::Paginated.create_from(t, 2, 5) }
 

--- a/spec/e2e/property_management_spec.rb
+++ b/spec/e2e/property_management_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe 'declared property classes' do
+  describe Neo4j::Shared::DeclaredProperty do
+    before do
+      clazz = Class.new do
+        def primitive_type; end
+      end
+
+      stub_const('MyTypeCaster', clazz)
+    end
+
+    let(:clazz) { Neo4j::Shared::DeclaredProperty }
+
+    describe Neo4j::Shared::DeclaredProperty do
+      context 'illegal property names' do
+        it 'raises an error' do
+          expect { clazz.new(:from_node) }.to raise_error { Neo4j::Shared::DeclaredProperty::IllegalPropertyError }
+        end
+      end
+
+      describe 'options' do
+        let(:prop) { clazz.new(:my_prop, type: String, typecaster: MyTypeCaster, default: 'foo') }
+
+        it 'controls method responses' do
+          expect(prop.type).to eq String
+          expect(prop.typecaster).to eq MyTypeCaster
+          expect(prop.default_value).to eq 'foo'
+        end
+      end
+
+      describe 'magic properties' do
+        let(:created) { clazz.new(:created_at) }
+        let(:updated) { clazz.new(:updated_at) }
+
+        it 'automatically sets type for created_at and updated_at if unset' do
+          expect(created.type).to be_nil
+          expect(updated.type).to be_nil
+          [created, updated].each(&:register)
+
+          expect(created.type).to eq DateTime
+          expect(updated.type).to eq DateTime
+        end
+      end
+    end
+  end
+
+  describe Neo4j::Shared::DeclaredPropertyManager do
+    before do
+      clazz = Class.new do
+        include Neo4j::ActiveNode
+        property :foo
+        property :bar, type: String, default: 'foo'
+      end
+
+      stub_const('MyModel', clazz)
+    end
+
+    let(:model) { MyModel }
+    let(:dpm)   { MyModel.declared_property_manager }
+
+    it 'is included on each class' do
+      expect(model.declared_property_manager).to be_a(Neo4j::Shared::DeclaredPropertyManager)
+    end
+
+    it 'has a convenience method on each instance' do
+      inst = model.new
+      expect(inst.declared_property_manager.object_id).to eq model.declared_property_manager.object_id
+    end
+
+    it 'contains information about each declared property' do
+      [:foo, :bar].each do |key|
+        expect(dpm.registered_properties[key]).to be_a(Neo4j::Shared::DeclaredProperty)
+      end
+    end
+
+    it 'keeps a default hash of nil values for use in initial object wrapping' do
+      expect(dpm.attributes_nil_hash).to eq('foo' => nil, 'bar' => nil)
+    end
+  end
+end

--- a/spec/unit/shared/property_spec.rb
+++ b/spec/unit/shared/property_spec.rb
@@ -5,8 +5,8 @@ describe Neo4j::Shared::Property do
 
   describe ':property class method' do
     it 'raises an error when passing illegal properties' do
-      Neo4j::Shared::Property::ILLEGAL_PROPS.push 'foo'
-      expect { clazz.property :foo }.to raise_error(Neo4j::Shared::Property::IllegalPropertyError)
+      Neo4j::Shared::DeclaredProperty::ILLEGAL_PROPS.push 'foo'
+      expect { clazz.property :foo }.to raise_error(Neo4j::Shared::DeclaredProperty::IllegalPropertyError)
     end
   end
 
@@ -129,12 +129,12 @@ describe Neo4j::Shared::Property do
 
     it 'uses type converter to serialize node' do
       instance.range = range
-      expect(instance.convert_properties_to(:db, instance.props)[:range]).to eq(range.to_s)
+      expect(instance.class.declared_property_manager.convert_properties_to(instance, :db, instance.props)[:range]).to eq(range.to_s)
     end
 
     it 'uses type converter to deserialize node' do
       instance.range = range.to_s
-      expect(instance.convert_properties_to(:ruby, instance.props)[:range]).to eq(range)
+      expect(instance.class.declared_property_manager.convert_properties_to(instance, :ruby, instance.props)[:range]).to eq(range)
     end
   end
 end


### PR DESCRIPTION
Up until now, all of the logic related to setting and managing properties was in modules included in `Neo4j::Shared`, but this moves it into two new classes: `DeclaredPropertyManager` and `DeclaredProperty`. The classes themselves are pretty basic and straightforward.

There's still a bit more to add. Needs tests for the new classes but nothing breaks and it fixes the property default issue that popped up after deemphasizing `active_attr`. There is a test for that one. Additionally, index management should probably happen in one of the new classes and I need to look into the `default_properties` stuff that still lives in `ActiveNode::Property`.