### PR TITLE
config options to handle model namespaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script:
   - "export CODECLIMATE_REPO_TOKEN=04853df625409de0a0f4e9126aee11bbee3428c81c20c27df6e6ab5c60bff2c8 && export JRUBY_OPTS='-X+O -J-Djruby.launch.inproc=false' && bundle exec rake neo4j:install[$NEO4J_VERSION] neo4j:start default --trace"
 language: ruby
 rvm:
-  - ruby-2.2-head
+  - ruby-2.2-2
   - 1.9.3
   - jruby-1.7.16
   # - jruby-19mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script:
   - "export CODECLIMATE_REPO_TOKEN=04853df625409de0a0f4e9126aee11bbee3428c81c20c27df6e6ab5c60bff2c8 && export JRUBY_OPTS='-X+O -J-Djruby.launch.inproc=false' && bundle exec rake neo4j:install[$NEO4J_VERSION] neo4j:start default --trace"
 language: ruby
 rvm:
-  - ruby-head
+  - ruby-2.2-head
   - 1.9.3
   - jruby-1.7.16
   # - jruby-19mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script:
   - "export CODECLIMATE_REPO_TOKEN=04853df625409de0a0f4e9126aee11bbee3428c81c20c27df6e6ab5c60bff2c8 && export JRUBY_OPTS='-X+O -J-Djruby.launch.inproc=false' && bundle exec rake neo4j:install[$NEO4J_VERSION] neo4j:start default --trace"
 language: ruby
 rvm:
-  - ruby-2.2-2
+  - ruby-2.2.2
   - 1.9.3
   - jruby-1.7.16
   # - jruby-19mode

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -14,12 +14,12 @@ Configuration
     If there is no value for this property on a node the node`s labels will be used to determine the `ActiveNode` class
 
     .. seealso:: :ref:`activenode-wrapping`
-    
+
   **include_root_in_json**
     **Default:** ``true``
 
     When serializing ``ActiveNode`` and ``ActiveRel`` objects, should there be a root in the JSON of the model name.
-    
+
     .. seealso:: http://api.rubyonrails.org/classes/ActiveModel/Serializers/JSON.html
 
   **transform_rel_type**
@@ -33,3 +33,19 @@ Configuration
       Causes the type to be downcased and preceded by a `#`
     ``:none``
       Uses the type as specified
+
+  **module_handling**
+    **Default:** ``:none``
+
+    **Available values:** ``:demodulize``, ``:none``, ``proc``
+
+    Determines what, if anything, should be done to module names when a model's class is set. By default, there is a direct mapping of model name to label, so `MyModule::MyClass` results in a label with the same name.
+
+    The `:demodulize` option uses ActiveSupport's method of the same name to strip off modules. If you use a `proc`, it will the class name as an argument and you should return a string that modifies it as you see fit.
+
+  **association_model_namespace**
+    **Default:** ``nil``
+
+    Associations defined in node models will try to match association names to classes. For example, `has_many :out, :student` will look for a `Student` class. To avoid having to use `model_class: 'MyModule::Student'`, this config option lets you specify the module that should be used globally for class name discovery.
+
+    Of course, even with this option set, you can always override it by calling `model_class: 'ClassName'`.

--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -21,7 +21,7 @@ module Neo4j
           case model_class
           when nil
             if @target_class_name_from_name
-              "::#{@target_class_name_from_name}"
+              "#{association_model_namespace}::#{@target_class_name_from_name}"
             else
               @target_class_name_from_name
             end
@@ -49,11 +49,13 @@ module Neo4j
         end
 
         def target_classes_or_nil
-          @target_classes_or_nil ||= if target_class_names
-                                       target_class_names.map(&:constantize).select do |constant|
-                                         constant.ancestors.include?(::Neo4j::ActiveNode)
-                                       end
-                                     end
+          @target_classes_or_nil ||= discovered_model if target_class_names
+        end
+
+        def discovered_model
+          target_class_names.map(&:constantize).select do |constant|
+            constant.ancestors.include?(::Neo4j::ActiveNode)
+          end
         end
 
         def target_class
@@ -122,6 +124,12 @@ module Neo4j
         end
 
         private
+
+        def association_model_namespace
+          namespace = Neo4j::Config[:association_model_namespace]
+          return nil if namespace.nil?
+          "::#{namespace}"
+        end
 
         def direction_cypher(relationship_cypher, create, reverse = false)
           case get_direction(create, reverse)

--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -126,9 +126,7 @@ module Neo4j
         private
 
         def association_model_namespace
-          namespace = Neo4j::Config[:association_model_namespace]
-          return nil if namespace.nil?
-          "::#{namespace}"
+          Neo4j::Config.association_model_namespace_string
         end
 
         def direction_cypher(relationship_cypher, create, reverse = false)

--- a/lib/neo4j/active_rel/types.rb
+++ b/lib/neo4j/active_rel/types.rb
@@ -21,25 +21,37 @@ module Neo4j
       WRAPPED_CLASSES = {}
 
       included do
-        type self.name, true
+        type self.namespaced_model_name, true
       end
 
       module ClassMethods
         include Neo4j::Shared::RelTypeConverters
 
         def inherited(other)
-          other.type other.name, true
+          other.type other.namespaced_model_name, true
         end
 
         # @param type [String] sets the relationship type when creating relationships via this class
-        def type(given_type = self.name, auto = false)
+        def type(given_type = namespaced_model_name, auto = false)
           @rel_type = (auto ? decorated_rel_type(given_type) : given_type).tap do |type|
             add_wrapped_class type unless uses_classname?
           end
         end
 
-        # @return [String] a string representing the relationship type that will be created
+        def namespaced_model_name
+          case Neo4j::Config[:module_handling]
+          when :demodulize
+            self.name.demodulize
+          when Proc
+            proc.call(self.name)
+          else
+            self.name
+          end
+        end
+
         attr_reader :rel_type
+        # @return [String] a string representing the relationship type that will be created
+        # attr_reader :rel_type
         alias_method :_type, :rel_type # Should be deprecated
 
         def add_wrapped_class(type)

--- a/lib/neo4j/active_rel/types.rb
+++ b/lib/neo4j/active_rel/types.rb
@@ -43,7 +43,7 @@ module Neo4j
           when :demodulize
             self.name.demodulize
           when Proc
-            proc.call(self.name)
+            Neo4j::Config[:module_handling].call(self.name)
           else
             self.name
           end

--- a/lib/neo4j/config.rb
+++ b/lib/neo4j/config.rb
@@ -108,6 +108,12 @@ module Neo4j
       def association_model_namespace
         Neo4j::Config[:association_model_namespace] || nil
       end
+
+      def association_model_namespace_string
+        namespace = Neo4j::Config[:association_model_namespace]
+        return nil if namespace.nil?
+        "::#{namespace}"
+      end
     end
   end
 end

--- a/lib/neo4j/config.rb
+++ b/lib/neo4j/config.rb
@@ -53,7 +53,6 @@ module Neo4j
         nil
       end
 
-
       # Sets the value of a config entry.
       #
       # @param [Symbol] key the key to set the parameter for
@@ -62,13 +61,11 @@ module Neo4j
         configuration[key.to_s] = val
       end
 
-
       # @param [Symbol] key The key of the config entry value we want
       # @return the the value of a config entry
       def [](key)
         configuration[key.to_s]
       end
-
 
       # Remove the value of a config entry.
       #
@@ -78,14 +75,12 @@ module Neo4j
         configuration.delete(key)
       end
 
-
       # Remove all configuration. This can be useful for testing purpose.
       #
       # @return nil
       def delete_all
         @configuration = nil
       end
-
 
       # @return [Hash] The config as a hash.
       def to_hash
@@ -104,6 +99,14 @@ module Neo4j
       def include_root_in_json
         # we use ternary because a simple || will always evaluate true
         Neo4j::Config[:include_root_in_json].nil? ? true : Neo4j::Config[:include_root_in_json]
+      end
+
+      def module_handling
+        Neo4j::Config[:module_handling] || :none
+      end
+
+      def association_model_namespace
+        Neo4j::Config[:association_model_namespace] || nil
       end
     end
   end

--- a/lib/neo4j/shared/rel_type_converters.rb
+++ b/lib/neo4j/shared/rel_type_converters.rb
@@ -24,18 +24,19 @@ module Neo4j::Shared
       # @return [String] A string that conforms to the set rel type conversion setting.
       def decorated_rel_type(type)
         type = type.to_s
-        case rel_transformer
-        when :upcase
-          type.underscore.upcase
-        when :downcase
-          type.underscore.downcase
-        when :legacy
-          "##{type.underscore.downcase}"
-        when :none
-          type
-        else
-          type.underscore.upcase
-        end
+        decorated_type =  case rel_transformer
+                          when :upcase
+                            type.underscore.upcase
+                          when :downcase
+                            type.underscore.downcase
+                          when :legacy
+                            "##{type.underscore.downcase}"
+                          when :none
+                            type
+                          else
+                            type.underscore.upcase
+                          end
+        decorated_type.tap { |s| s.gsub!('/', '::') if type.include?('::') }
       end
     end
   end

--- a/spec/e2e/module_handling.rb
+++ b/spec/e2e/module_handling.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe 'Module handling from config: :module_handling option' do
+  let(:clazz) do
+    Class.new do
+      include Neo4j::ActiveNode
+    end
+  end
+
+  before { stub_const 'ModuleTest::Student', clazz }
+  after do
+    Neo4j::Config[:association_model_namespace] = nil
+    Neo4j::Config[:module_handling] = nil
+  end
+
+  describe 'labels' do
+    context 'with config unspecified or neither :demodulize nor a proc' do
+      it 'are set using the full module and class name' do
+        expect(ModuleTest::Student.mapped_label_name).to eq :'ModuleTest::Student'
+      end
+    end
+
+    context 'with config set to :demodulize' do
+      before { Neo4j::Config[:module_handling] = :demodulize }
+
+      it 'strips module names from labels' do
+        expect(ModuleTest::Student.mapped_label_name).to eq :Student
+      end
+    end
+
+    context 'with a proc' do
+      before do
+        Neo4j::Config[:module_handling] = proc do |name|
+          module_name = name.deconstantize
+          name.gsub(module_name, 'Foo')
+        end
+      end
+
+      it 'lets you modify the name as you see fit' do
+        expect(ModuleTest::Student.mapped_label_name).to eq :'Foo::Student'
+      end
+    end
+  end
+
+  describe 'association model locations' do
+    let(:discovered_model) { clazz.associations[:students].instance_variable_get(:@target_class_option) }
+
+    context 'with config set to :none or unspecified' do
+      before { clazz.has_many :out, :students }
+
+      it 'expects a class with the singular version of the association' do
+        expect(discovered_model).to eq '::Student'
+      end
+    end
+
+    context ' with :association_model_namespace set' do
+      before do
+        Neo4j::Config[:association_model_namespace] = 'ModuleTest'
+        clazz.has_many :out, :students
+      end
+
+      it 'expects namespacing and looks for a model in the same namespace as the source' do
+        expect(discovered_model).to eq '::ModuleTest::Student'
+        node1 = ModuleTest::Student.create
+        node2 = ModuleTest::Student.create
+        node1.students << node2
+        expect(node1.students.to_a).to include node2
+      end
+    end
+  end
+end

--- a/spec/e2e/module_handling.rb
+++ b/spec/e2e/module_handling.rb
@@ -7,8 +7,8 @@ describe 'Module handling from config: :module_handling option' do
     end
   end
 
-  before { stub_const 'ModuleTest::Student', clazz }
-  after do
+  before do
+    stub_const 'ModuleTest::Student', clazz
     Neo4j::Config[:association_model_namespace] = nil
     Neo4j::Config[:module_handling] = nil
   end
@@ -84,6 +84,20 @@ describe 'Module handling from config: :module_handling option' do
       ModuleTest::Student.first
       expect(cache).not_to be_empty
       expect(cache[[:Student]]).to eq ModuleTest::Student
+    end
+  end
+
+  describe 'ActiveRel' do
+    Neo4j::Config[:module_handling] = :demodulize
+    # ActiveRel types are misbehaving when using stub_const, will have to fix later
+    module ModuleTest
+      class RelClass
+        include Neo4j::ActiveRel
+      end
+    end
+
+    it 'respects the option when setting rel type' do
+      expect(ModuleTest::RelClass._type).to eq 'REL_CLASS'
     end
   end
 end

--- a/spec/e2e/module_handling.rb
+++ b/spec/e2e/module_handling.rb
@@ -17,6 +17,7 @@ describe 'Module handling from config: :module_handling option' do
     context 'with config unspecified or neither :demodulize nor a proc' do
       it 'are set using the full module and class name' do
         expect(ModuleTest::Student.mapped_label_name).to eq :'ModuleTest::Student'
+        expect(ModuleTest::Student.send(:decorated_label_name)).to eq :'ModuleTest::Student'
       end
     end
 
@@ -25,6 +26,7 @@ describe 'Module handling from config: :module_handling option' do
 
       it 'strips module names from labels' do
         expect(ModuleTest::Student.mapped_label_name).to eq :Student
+        expect(ModuleTest::Student.send(:decorated_label_name)).to eq :Student
         node = ModuleTest::Student.create
         expect(ModuleTest::Student.first.neo_id).to eq node.neo_id
       end
@@ -40,6 +42,7 @@ describe 'Module handling from config: :module_handling option' do
 
       it 'lets you modify the name as you see fit' do
         expect(ModuleTest::Student.mapped_label_name).to eq :'Foo::Student'
+        expect(ModuleTest::Student.send(:decorated_label_name)).to eq :'Foo::Student'
       end
     end
   end
@@ -105,6 +108,7 @@ describe 'Module handling from config: :module_handling option' do
 
       it 'respects the option when setting rel type' do
         expect(ModuleTest::RelClass._type).to eq 'REL_CLASS'
+        expect(ModuleTest::RelClass.namespaced_model_name).to eq 'RelClass'
       end
     end
 
@@ -113,6 +117,7 @@ describe 'Module handling from config: :module_handling option' do
 
       it 'uses the full Module::Class name' do
         expect(ModuleTest::RelClass._type).to eq 'MODULE_TEST::REL_CLASS'
+        expect(ModuleTest::RelClass.namespaced_model_name).to eq 'ModuleTest::RelClass'
       end
     end
 
@@ -124,6 +129,7 @@ describe 'Module handling from config: :module_handling option' do
 
       it 'modifies the type as expected' do
         expect(ModuleTest::RelClass._type).to eq 'MODULE_TEST_FOO_REL_CLASS'
+        expect(ModuleTest::RelClass.namespaced_model_name).to eq 'ModuleTest_FOO_RelClass'
       end
     end
   end

--- a/spec/e2e/module_handling.rb
+++ b/spec/e2e/module_handling.rb
@@ -25,6 +25,8 @@ describe 'Module handling from config: :module_handling option' do
 
       it 'strips module names from labels' do
         expect(ModuleTest::Student.mapped_label_name).to eq :Student
+        node = ModuleTest::Student.create
+        expect(ModuleTest::Student.first.neo_id).to eq node.neo_id
       end
     end
 
@@ -66,6 +68,22 @@ describe 'Module handling from config: :module_handling option' do
         node1.students << node2
         expect(node1.students.to_a).to include node2
       end
+    end
+  end
+
+  describe 'node wrapping' do
+    before do
+      Neo4j::Config[:module_handling] = :demodulize
+      Neo4j::ActiveNode::Labels::MODELS_FOR_LABELS_CACHE.clear
+    end
+    let(:cache) { Neo4j::ActiveNode::Labels::MODELS_FOR_LABELS_CACHE }
+
+    it 'saves the map of label to class correctly when labels do not match class' do
+      expect(cache).to be_empty
+      ModuleTest::Student.create
+      ModuleTest::Student.first
+      expect(cache).not_to be_empty
+      expect(cache[[:Student]]).to eq ModuleTest::Student
     end
   end
 end


### PR DESCRIPTION
Inspired by #753, this adds two config options:

#### `Neo4j::Config[:module_handling]`

In your app's config file:

```
neo4j.config.module_handling = option
```

`option` can be `:demodulize`, which will strip module names from the model's name using ActiveSupport's `demodulize` method, or a proc that will receive `model.name` as an arg and you can decorate it however you want. Anything else will just get ignored.

#### `Neo4j::Config[:association_model_namespace]`

In config:

```
neo4j.config.association_model_namespace = 'ModuleName'
```

This will prefix the models associations look for when `model_class` is omitted with whatever value you give it. It's useful if all of your models are part of the same module, just set once and it'll take care of the rest.

Examples are in specs. I need to test that it can load correctly when these options are set.