### PR TITLE
Require that only those association options which are known about by …

### DIFF
--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -319,15 +319,20 @@ module Neo4j::ActiveNode
 
       private
 
-      # * TEST THESE!!!!
-      # * Make sure `rel_class` key sets the type for the association
-      # * Get info about model_class from ActiveRel if rel_class specified
+      VALID_ASSOCIATION_OPTION_KEYS = [:type, :origin, :model_class, :rel_class, :dependent, :before, :after]
+
       def validate_association_options!(association_name, options)
-        if options.values_at(:type, :origin, :rel_class).compact.size > 1
-          fail ArgumentError, "Only one of 'type', 'origin', or 'rel_class' options are allowed for associations (#{self.class}##{association_name})"
-        elsif !options.key?(:type) && (options.values_at(:origin, :rel_class).compact.empty?)
-          fail ArgumentError, "The 'type' option must be specified, even if it is `nil` (#{self.class}##{association_name})"
-        end
+        type_keys = (options.keys & [:type, :origin, :rel_class])
+        message = case
+                  when type_keys.size > 1
+                    "Only one of 'type', 'origin', or 'rel_class' options are allowed for associations (#{self.class}##{association_name})"
+                  when type_keys.empty?
+                    "The 'type' option must be specified( even if it is `nil`) or `origin`/`rel_class` must be specified (#{self.class}##{association_name})"
+                  when (unknown_keys = options.keys - VALID_ASSOCIATION_OPTION_KEYS).size > 0
+                    "Unknown option(s) specified: #{unknown_keys.join(', ')} (#{self.class}##{association_name})"
+                  end
+
+        fail ArgumentError, message if message
       end
 
       def define_has_many_methods(name)

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -10,7 +10,7 @@ describe 'has_many' do
 
       has_many :both, :friends, model_class: false, type: nil
       has_many :out, :knows, model_class: 'Person', type: nil
-      has_many :in, :knows_me, origin: :knows, model_class: 'Person', type: nil
+      has_many :in, :knows_me, origin: :knows, model_class: 'Person'
     end
   end
 
@@ -443,9 +443,19 @@ describe 'has_many' do
 
       it 'should only allow one of the the options :type, :origin, or :rel_class' do
         error_regex = /Only one of 'type', 'origin', or 'rel_class' options are allowed/
+        expect { empty_class.has_many :out, :bars, type: nil, origin: :foos }.to raise_error(ArgumentError, error_regex)
         expect { empty_class.has_many :out, :bars, type: :bar, origin: :foos }.to raise_error(ArgumentError, error_regex)
         expect { empty_class.has_many :out, :bars, type: :bar, rel_class: 'ARelClass' }.to raise_error(ArgumentError, error_regex)
         expect { empty_class.has_many :out, :bars, origin: :foos, rel_class: 'ARelClass' }.to raise_error(ArgumentError, error_regex)
+      end
+
+      it 'should raise an exception if an unknown option is specified' do
+        expect do
+          empty_class.has_many :out, :bars, type: :bar, unknown_key: true
+        end.to raise_error(ArgumentError, /Unknown option\(s\) specified: unknown_key/)
+        expect do
+          empty_class.has_many :out, :bars, type: :bar, unknown_key: true, unknown_key2: 'test'
+        end.to raise_error(ArgumentError, /Unknown option\(s\) specified: unknown_key, unknown_key2/)
       end
     end
 

--- a/spec/e2e/has_one_spec.rb
+++ b/spec/e2e/has_one_spec.rb
@@ -15,7 +15,7 @@ describe 'has_one' do
 
       stub_active_node_class('HasOneB') do
         property :name
-        has_one :in, :parent, type: nil, origin: :children, model_class: 'HasOneA'
+        has_one :in, :parent, origin: :children, model_class: 'HasOneA'
       end
     end
 

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -47,7 +47,7 @@ describe 'Query API' do
 
       has_many :both, :favorite_teachers, type: nil, model_class: 'Teacher'
       has_many :both, :hated_teachers, type: nil, model_class: 'Teacher'
-      has_many :in,   :winning_lessons, type: nil, model_class: 'Lesson', origin: :teachers_pet
+      has_many :in,   :winning_lessons, model_class: 'Lesson', origin: :teachers_pet
     end
 
     stub_active_node_class('Teacher') do


### PR DESCRIPTION
…the gem are used.  Also, fix a bug where using `nil` for `type` allowed users to specify more than one option (it probably didn't make a difference functionally, but it's good to be specific)

For issue #796 