### PR TITLE
improve support for match_to with an array of nodes

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -95,11 +95,11 @@ module Neo4j
         # @param [#neo_id, String, Enumerable] node A node, a string representing a node's ID, or an enumerable of nodes or IDs.
         # @return [Neo4j::ActiveNode::Query::QueryProxy] A QueryProxy object upon which you can build.
         def match_to(node)
-          where_arg = if node.respond_to?(:neo_id)
-                        {neo_id: node.neo_id}
+          first_node = node.is_a?(Array) ? node.first : node
+          where_arg = if first_node.respond_to?(:neo_id)
+                        {neo_id: node.is_a?(Array) ? node.map(&:neo_id) : node}
                       elsif !node.nil?
-                        node = ids_array(node) if node.is_a?(Array)
-                        {association_id_key => node}
+                        {association_id_key => node.is_a?(Array) ? ids_array(node) : node}
                       else
                         # support for null object pattern
                         '1 = 2'

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -288,7 +288,7 @@ describe 'query_proxy_methods' do
           end
 
           it 'generates cypher using IN with the IDs of contained nodes' do
-            expect(@john.lessons.match_to([@history, @math]).to_cypher).to include('AND (result_lessons.uuid IN')
+            expect(@john.lessons.match_to([@history, @math]).to_cypher).to include('ID(result_lessons) IN')
             expect(@john.lessons.match_to([@history, @math]).to_a).to eq [@history]
             @john.lessons << @math
             expect(@john.lessons.match_to([@history, @math]).to_a.count).to eq 2


### PR DESCRIPTION
This ensures that if you give `match_to` an array of nodes, it'll use all of their neo ids. It has the nice bonus of accepting an array of wrapped and/or unwrapped nodes if you find yourself in that situation.