### PR TITLE
Even faster wrap

### DIFF
--- a/lib/neo4j/active_node/initialize.rb
+++ b/lib/neo4j/active_node/initialize.rb
@@ -9,10 +9,7 @@ module Neo4j::ActiveNode::Initialize
     self.class.extract_association_attributes!(properties)
     @_persisted_obj = persisted_node
     changed_attributes && changed_attributes.clear
-    @attributes ||= self.class.attributes_nil_hash.dup
-    stringify_attributes!(@attributes, properties)
-    self.default_properties = properties
-    @attributes = self.class.declared_property_manager.convert_properties_to(self, :ruby, @attributes)
+    @attributes = convert_and_assign_attributes(properties)
   end
 
   # Implements the Neo4j::Node#wrapper and Neo4j::Relationship#wrapper method
@@ -23,6 +20,13 @@ module Neo4j::ActiveNode::Initialize
   end
 
   private
+
+  def convert_and_assign_attributes(properties)
+    @attributes ||= self.class.attributes_nil_hash.dup
+    stringify_attributes!(@attributes, properties)
+    self.default_properties = properties
+    self.class.declared_property_manager.convert_properties_to(self, :ruby, @attributes)
+  end
 
   def stringify_attributes!(attr, properties)
     properties.each_pair do |k, v|

--- a/lib/neo4j/active_node/initialize.rb
+++ b/lib/neo4j/active_node/initialize.rb
@@ -9,12 +9,8 @@ module Neo4j::ActiveNode::Initialize
     self.class.extract_association_attributes!(properties)
     @_persisted_obj = persisted_node
     changed_attributes && changed_attributes.clear
-    attr = @attributes || self.class.attributes_nil_hash.dup
-    properties.each_pair do |k, v|
-      key = self.class.declared_property_manager.attributes_string_map[k] || k.to_s
-      attr[key] = v
-    end
-    @attributes = attr
+    @attributes ||= self.class.attributes_nil_hash.dup
+    stringify_attributes!(@attributes, properties)
     self.default_properties = properties
     @attributes = self.class.declared_property_manager.convert_properties_to(self, :ruby, @attributes)
   end
@@ -24,5 +20,14 @@ module Neo4j::ActiveNode::Initialize
   # @return self
   def wrapper
     self
+  end
+
+  private
+
+  def stringify_attributes!(attr, properties)
+    properties.each_pair do |k, v|
+      key = self.class.declared_property_manager.attributes_string_map[k] || k.to_s
+      attr[key] = v
+    end
   end
 end

--- a/lib/neo4j/active_node/initialize.rb
+++ b/lib/neo4j/active_node/initialize.rb
@@ -10,7 +10,11 @@ module Neo4j::ActiveNode::Initialize
     @_persisted_obj = persisted_node
     changed_attributes && changed_attributes.clear
     attr = @attributes || self.class.attributes_nil_hash.dup
-    @attributes = attr.merge!(properties).stringify_keys!
+    properties.each_pair do |k, v|
+      key = self.class.declared_property_manager.attributes_string_map[k] || k.to_s
+      attr[key] = v
+    end
+    @attributes = attr
     self.default_properties = properties
     @attributes = self.class.declared_property_manager.convert_properties_to(self, :ruby, @attributes)
   end

--- a/lib/neo4j/config.rb
+++ b/lib/neo4j/config.rb
@@ -5,6 +5,7 @@ module Neo4j
   #
   class Config
     DEFAULT_FILE = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'config', 'neo4j', 'config.yml'))
+    CLASS_NAME_PROPERTY_KEY = 'class_name_property'
 
     class << self
       # @return [Fixnum] The location of the default configuration file.
@@ -93,7 +94,7 @@ module Neo4j
       end
 
       def class_name_property
-        Neo4j::Config[:class_name_property] || :_classname
+        @_class_name_property = Neo4j::Config[CLASS_NAME_PROPERTY_KEY] || :_classname
       end
 
       def include_root_in_json

--- a/lib/neo4j/shared/declared_property_manager.rb
+++ b/lib/neo4j/shared/declared_property_manager.rb
@@ -10,6 +10,7 @@ module Neo4j::Shared
 
     def register(property)
       @_attributes_nil_hash = nil
+      @_attributes_string_map = nil
       registered_properties[property.name] = property
       register_magic_typecaster(property) if property.magic_typecaster
       declared_property_defaults[property.name] = property.default_value if property.default_value
@@ -29,6 +30,12 @@ module Neo4j::Shared
           val = prop_obj.default_value
           attr_hash[k.to_s] = val
         end
+      end.freeze
+    end
+
+    def attributes_string_map
+      @_attributes_string_map ||= {}.tap do |attr_hash|
+        attributes_nil_hash.each_key { |k| attr_hash[k.to_sym] = k }
       end.freeze
     end
 


### PR DESCRIPTION
This removes a loathed `symbolize_keys!` that was being called during every single node's wrap by using info the class should already have in its declared property manager. When loading a large group of nodes, it's something approaching 5% faster. It makes no difference whatsoever when loading just a few nodes but do it with a couple hundred at a time and it adds up. Loading unwrapped nodes is still 2x faster but I'm closing the gap.

It also removes a `to_s` that was occurring in Neo4j::Config when looking up the classname property name. That one isn't gonna change the world but it was easy, so might as well.