### PR TITLE
Fix/775 skip conversion

### DIFF
--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -133,9 +133,9 @@ module Neo4j::Shared
       end
     end
 
-    # Returns true if the property isn't defined in the model or it's both nil and unchanged.
+    # Returns true if the property isn't defined in the model or if it is nil
     def skip_conversion?(obj, attr, value)
-      !obj.class.attributes[attr] || (value.nil? && !obj.changed_attributes[attr])
+      !obj.class.attributes[attr] || value.nil?
     end
 
     class << self

--- a/spec/integration/type_converters/type_converters_spec.rb
+++ b/spec/integration/type_converters/type_converters_spec.rb
@@ -108,7 +108,7 @@ describe Neo4j::Shared::TypeConverters do
   end
 
   describe Neo4j::Shared::TypeConverters::DateTimeConverter do
-    subject { Neo4j::Shared::TypeConverters::TimeConverter }
+    subject { Neo4j::Shared::TypeConverters::DateTimeConverter }
 
     before(:each) do
       @dt = 1_352_538_487


### PR DESCRIPTION
This PR involves two changes:

* While testing DateTimeConverter, subject used to be TimeConverter. Changed it to DateTimeConverter.

* Removed changed_properties check in skip_conversion method because nil DateTime value would not be skipped because `changed_properties[attr]` is not nil. See #775 
