### PR TITLE
Fix missing unique option

### DIFF
--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -316,7 +316,7 @@ module Neo4j::ActiveNode
       end
 
       private
-      
+
       def define_has_many_methods(name)
         define_method(name) do |node = nil, rel = nil, options = {}|
           return [].freeze unless self._persisted_obj
@@ -422,9 +422,9 @@ module Neo4j::ActiveNode
         begin
           association = Neo4j::ActiveNode::HasN::Association.new(macro, direction, name, options)
         rescue ArgumentError => e
-          fail ArgumentError, "#{e.message} (#{self.class}##{name})"
+          raise ArgumentError, "#{e.message} (#{self.class}##{name})"
         end
-        
+
         associations_keys << name
 
         @associations ||= {}

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -417,19 +417,18 @@ module Neo4j::ActiveNode
       end
 
       def build_association(macro, direction, name, options)
-        # Create association and re-raise any ArgumentError exception with added
-        # class name and association name to make sure error message is useful
-        begin
-          association = Neo4j::ActiveNode::HasN::Association.new(macro, direction, name, options)
-        rescue ArgumentError => e
-          raise ArgumentError, "#{e.message} (#{self.class}##{name})"
+        Neo4j::ActiveNode::HasN::Association.new(macro, direction, name, options).tap do |association|
+          @associations ||= {}
+          @associations[name] = association
+          create_reflection(macro, name, association, self)
         end
 
         associations_keys << name
 
-        @associations ||= {}
-        @associations[name] = association
-        create_reflection(macro, name, association, self)
+      # Re-raise any exception with added class name and association name to
+      # make sure error message is helpful
+      rescue StandardError => e
+        raise e.class, "#{e.message} (#{self.class}##{name})"
       end
     end
   end

--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -202,7 +202,9 @@ module Neo4j
           check_valid_type_and_dir(type, direction)
         end
 
-        VALID_ASSOCIATION_OPTION_KEYS = [:type, :origin, :model_class, :rel_class, :dependent, :before, :after]
+        VALID_ASSOCIATION_OPTION_KEYS = [:type, :origin, :model_class, 
+                                         :rel_class, :dependent, :before, 
+                                         :after, :unique]
 
         def validate_association_options!(association_name, options)
           type_keys = (options.keys & [:type, :origin, :rel_class])

--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -8,8 +8,8 @@ module Neo4j
         include Neo4j::ActiveNode::Dependent::AssociationMethods
         attr_reader :type, :name, :relationship, :direction, :dependent
 
-        def initialize(type, direction, name, options = {})
-          validate_init_arguments(type, direction, options)
+        def initialize(type, direction, name, options = { type: nil })
+          validate_init_arguments(type, direction, name, options)
           @type = type.to_sym
           @name = name
           @direction = direction.to_sym
@@ -195,10 +195,29 @@ module Neo4j
           "#{type} #{direction.inspect}, #{name.inspect}"
         end
 
-        def validate_init_arguments(type, direction, options)
+        def validate_init_arguments(type, direction, name, options)
+          validate_association_options!(name, options)
           validate_option_combinations(options)
           validate_dependent(options[:dependent].try(:to_sym))
           check_valid_type_and_dir(type, direction)
+        end
+
+        VALID_ASSOCIATION_OPTION_KEYS = [:type, :origin, :model_class, :rel_class, :dependent, :before, :after]
+
+        def validate_association_options!(association_name, options)
+          type_keys = (options.keys & [:type, :origin, :rel_class])
+          message = case
+                      when type_keys.size > 1
+                        "Only one of 'type', 'origin', or 'rel_class' options are allowed for associations"
+                      when type_keys.empty?
+                        "The 'type' option must be specified( even if it is `nil`) or `origin`/`rel_class` must be specified"
+                      when (unknown_keys = options.keys - VALID_ASSOCIATION_OPTION_KEYS).size > 0
+                        "Unknown option(s) specified: #{unknown_keys.join(', ')}"
+                      else
+                        nil
+                    end
+
+          fail ArgumentError, message if message
         end
 
         def check_valid_type_and_dir(type, direction)

--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -8,7 +8,7 @@ module Neo4j
         include Neo4j::ActiveNode::Dependent::AssociationMethods
         attr_reader :type, :name, :relationship, :direction, :dependent
 
-        def initialize(type, direction, name, options = { type: nil })
+        def initialize(type, direction, name, options = {type: nil})
           validate_init_arguments(type, direction, name, options)
           @type = type.to_sym
           @name = name
@@ -202,21 +202,19 @@ module Neo4j
           check_valid_type_and_dir(type, direction)
         end
 
-        VALID_ASSOCIATION_OPTION_KEYS = [:type, :origin, :model_class, 
-                                         :rel_class, :dependent, :before, 
+        VALID_ASSOCIATION_OPTION_KEYS = [:type, :origin, :model_class,
+                                         :rel_class, :dependent, :before,
                                          :after, :unique]
 
-        def validate_association_options!(association_name, options)
+        def validate_association_options!(_association_name, options)
           type_keys = (options.keys & [:type, :origin, :rel_class])
           message = case
-                      when type_keys.size > 1
-                        "Only one of 'type', 'origin', or 'rel_class' options are allowed for associations"
-                      when type_keys.empty?
-                        "The 'type' option must be specified( even if it is `nil`) or `origin`/`rel_class` must be specified"
-                      when (unknown_keys = options.keys - VALID_ASSOCIATION_OPTION_KEYS).size > 0
-                        "Unknown option(s) specified: #{unknown_keys.join(', ')}"
-                      else
-                        nil
+                    when type_keys.size > 1
+                      "Only one of 'type', 'origin', or 'rel_class' options are allowed for associations"
+                    when type_keys.empty?
+                      "The 'type' option must be specified( even if it is `nil`) or `origin`/`rel_class` must be specified"
+                    when (unknown_keys = options.keys - VALID_ASSOCIATION_OPTION_KEYS).size > 0
+                      "Unknown option(s) specified: #{unknown_keys.join(', ')}"
                     end
 
           fail ArgumentError, message if message

--- a/spec/unit/association_spec.rb
+++ b/spec/unit/association_spec.rb
@@ -4,12 +4,16 @@ class Default
 end
 
 describe Neo4j::ActiveNode::HasN::Association do
-  let(:options) { {} }
+  let(:options) { { type: nil } }
   let(:name) { :default }
   let(:direction) { :out }
 
-  let(:association) { Neo4j::ActiveNode::HasN::Association.new(type, direction, name, options) }
-  subject { association }
+  let(:association) do
+    Neo4j::ActiveNode::HasN::Association.new(type, direction, name, options)
+  end
+  subject do
+    association
+  end
 
   context 'type = :invalid' do
     let(:type) { :invalid }
@@ -136,7 +140,7 @@ describe Neo4j::ActiveNode::HasN::Association do
 
       context 'specified model class' do
         context 'specified as string' do
-          let(:options) { {model_class: 'Bizzl'} }
+          let(:options) { { type: :foo, model_class: 'Bizzl'} }
 
           it { should == ['::Bizzl'] }
         end
@@ -146,7 +150,7 @@ describe Neo4j::ActiveNode::HasN::Association do
             stub_const 'Fizzl', Class.new { include Neo4j::ActiveNode }
           end
 
-          let(:options) { {model_class: 'Fizzl'} }
+          let(:options) { { type: :foo, model_class: 'Fizzl'} }
 
           it { should == ['::Fizzl'] }
         end
@@ -186,13 +190,16 @@ describe Neo4j::ActiveNode::HasN::Association do
 
     describe 'unique' do
       context 'true' do
-        let(:options) { {unique: true} }
+        let(:options) { { type: :foo, unique: true} }
 
-        it { expect(subject).to be_unique }
+        it do
+          expect(subject).to be_unique
+        end
       end
 
       context 'false' do
-        let(:options) { {unique: false} }
+        let(:type) { :has_many }
+        let(:options) { { type: :foo, unique: false} }
 
         it { expect(subject).not_to be_unique }
       end

--- a/spec/unit/association_spec.rb
+++ b/spec/unit/association_spec.rb
@@ -4,7 +4,7 @@ class Default
 end
 
 describe Neo4j::ActiveNode::HasN::Association do
-  let(:options) { { type: nil } }
+  let(:options) { {type: nil} }
   let(:name) { :default }
   let(:direction) { :out }
 
@@ -140,7 +140,7 @@ describe Neo4j::ActiveNode::HasN::Association do
 
       context 'specified model class' do
         context 'specified as string' do
-          let(:options) { { type: :foo, model_class: 'Bizzl'} }
+          let(:options) { {type: :foo, model_class: 'Bizzl'} }
 
           it { should == ['::Bizzl'] }
         end
@@ -150,7 +150,7 @@ describe Neo4j::ActiveNode::HasN::Association do
             stub_const 'Fizzl', Class.new { include Neo4j::ActiveNode }
           end
 
-          let(:options) { { type: :foo, model_class: 'Fizzl'} }
+          let(:options) { {type: :foo, model_class: 'Fizzl'} }
 
           it { should == ['::Fizzl'] }
         end
@@ -190,7 +190,7 @@ describe Neo4j::ActiveNode::HasN::Association do
 
     describe 'unique' do
       context 'true' do
-        let(:options) { { type: :foo, unique: true} }
+        let(:options) { {type: :foo, unique: true} }
 
         it do
           expect(subject).to be_unique
@@ -199,7 +199,7 @@ describe Neo4j::ActiveNode::HasN::Association do
 
       context 'false' do
         let(:type) { :has_many }
-        let(:options) { { type: :foo, unique: false} }
+        let(:options) { {type: :foo, unique: false} }
 
         it { expect(subject).not_to be_unique }
       end


### PR DESCRIPTION
PR originating from [this discussion](https://github.com/neo4jrb/neo4j/commit/a88eb055cb531c1015c5cdd42c2559f64753248e#diff-17f68f769f3e31e7e8d67a4f4e2e66bdR322) on a missing option in the valid options array for `has_n` relationships.

Its purpose is to fix two problems:
**Problem 1:** The `:unique` option is (incorrectly) not considered a valid option anymore on `has_many`/`has_one` relationships.

**Problem 2:** The tests have not failed in spite of this regression.

## Fixing problem 1
This was just as easy as adding `:unique` to the array of valid options

## Fixing problem 2
This was a bit more tricky, so I hope my solution will be suitable.

The tests haven't picked up this regression because they create associations using `Neo4j::ActiveNode::HasN::Association.new` directly, and options validations are performed at a higher level in `Neo4j::ActiveNode::HasN::ClassMethods#has_many` and `#has_one`.

So I have moved these validations down at the `Neo4j::ActiveNode::HasN::Association` level, which has had some consequences:

* `:type` is now required in the options hash of `Neo4j::ActiveNode::HasN::Association#initialize`. I changed the default value of the `options` argument from `{}` to `{ type: nil }` to keep it easy to create an association that way without any option. However I had to change some specs in `association_specs` to make sure they include a `:type` key in the options they use.

* The error messages from the validation are quite helpful as they indicate the name of the failing association and its owning class. This was possible when checking within `Neo4j::ActiveNode::HasN::ClassMethods` because the module is included inside the model class that would declare the association. As this is not the case with `Neo4j::ActiveNode::HasN::Association`, I have kept the behavior like so:  

  * When an option validation error occurs, `Neo4j::ActiveNode::HasN::Association` will raise the same `ArgumentError` exceptions as before but without the "(ClassName#association_name)" part
  * Within `Neo4j::ActiveNode::HasN::ClassMethods#build_association` (which actually creates the `HasN::Association` instance), `ArgumentError` exceptions are caught and re-raised with the same message, enhanced with the "(ClassName#association_name)" that we are able to get at this level.

* There are tests checking the content of the above error messages. These tests are run against the `has_many`/`has_one` methods. Maybe they should move to the association specs?

Fortunately, the end result is that no other tests have failed due to these changes but the ones that were using the `:unique` option when it was not considered valid anymore.

So I do hope these changes will make it to the codebase :)