### PR TITLE
fixes handling of Time type, undoes silent change to DateTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - QueryProxy associations accept `labels: false` option to prevent generated Cypher from using labels.
 
+### Changed
+- Properties explicitly set to type `Time` will no longer be converted to `DateTime`.
+
 ## [5.0.0.rc.3] - 2015-06-07
 
 ### Fixed

--- a/lib/neo4j/shared/declared_property.rb
+++ b/lib/neo4j/shared/declared_property.rb
@@ -34,10 +34,6 @@ module Neo4j::Shared
     # Tweaks properties
     def register_magic_properties
       options[:type] ||= DateTime if name.to_sym == :created_at || name.to_sym == :updated_at
-      # TODO: Custom typecaster to fix the stuff below
-      # ActiveAttr does not handle "Time", Rails and Neo4j.rb 2.3 did
-      # Convert it to DateTime in the interest of consistency
-      options[:type] = DateTime if options[:type] == Time
 
       register_magic_typecaster
       register_type_converter

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -57,6 +57,9 @@ module Neo4j::Shared
           Time
         end
 
+        def primitive_type
+          Integer
+        end
         # Converts the given DateTime (UTC) value to an Integer.
         # Only utc times are supported !
         def to_db(value)
@@ -70,6 +73,7 @@ module Neo4j::Shared
         def to_ruby(value)
           Time.at(value).utc
         end
+        alias_method :call, :to_ruby
       end
     end
 

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -335,9 +335,9 @@ describe 'Neo4j::ActiveNode' do
       expect(person.name).to eq('new name')
     end
 
-    it 'accepts Time type, converts to DateTime' do
+    it 'accepts Time type, does not convert to DateTime' do
       person = Person.create(start: Time.now)
-      person.start.class.should eq(DateTime)
+      expect(person.start).to be_a(Time)
     end
 
     it 'declared attribute can have type conversion' do

--- a/spec/unit/shared/property_spec.rb
+++ b/spec/unit/shared/property_spec.rb
@@ -55,9 +55,10 @@ describe Neo4j::Shared::Property do
         clazz.property :updated_at, type: Time
       end
 
-      it 'changes type to DateTime' do
-        expect(clazz.attributes[:created_at][:type]).to eq(DateTime)
-        expect(clazz.attributes[:updated_at][:type]).to eq(DateTime)
+      # ActiveAttr does not know what to do with Time, so it is stored as Int.
+      it 'tells ActiveAttr it is an Integer' do
+        expect(clazz.attributes[:created_at][:type]).to eq(Integer)
+        expect(clazz.attributes[:updated_at][:type]).to eq(Integer)
       end
     end
   end


### PR DESCRIPTION
Long, long ago, one of my first commits to the gem was to add support for the `Time` property type. `ActiveAttr`, which handles some of the type conversion within the gem, does not respect it, but we needed it. Without knowing how else to approach it, I set it to just change it to change properties to DateTime. The two types respond to a lot of the same methods so I thought it might be an ok fix.

Two-ish years later, I think that's a lousy workaround and know how to fix it in a way that works a bit better. So... that's what this is.