### PR TITLE
improve ActiveRel dsl RE: from_class, to_class, type

### DIFF
--- a/lib/neo4j/active_rel/property.rb
+++ b/lib/neo4j/active_rel/property.rb
@@ -37,7 +37,11 @@ module Neo4j::ActiveRel
       end
 
       %w(to_class from_class).each do |direction|
-        define_method("#{direction}") { |argument| instance_variable_set("@#{direction}", argument) }
+        define_method("#{direction}") do |argument = nil|
+          return self.instance_variable_get("@#{direction}") if argument.nil?
+          instance_variable_set("@#{direction}", argument)
+        end
+
         define_method("_#{direction}") { instance_variable_get "@#{direction}" }
       end
 

--- a/lib/neo4j/active_rel/types.rb
+++ b/lib/neo4j/active_rel/types.rb
@@ -31,10 +31,13 @@ module Neo4j
           subclass.type subclass.namespaced_model_name, true
         end
 
-        # @param type [String] sets the relationship type when creating relationships via this class
-        def type(given_type = namespaced_model_name, auto = false)
+        # @param [String] given_type sets the relationship type when creating relationships via this class
+        # @param [Boolean] auto Should the given_type be changed in compliance with the gem's rel decorator setting?
+        # This option is used internally, users will usually ignore it.
+        def type(given_type = nil, auto = false)
+          return rel_type if given_type.nil?
           @rel_type = (auto ? decorated_rel_type(given_type) : given_type).tap do |type|
-            add_wrapped_class type unless uses_classname?
+            add_wrapped_class(type) unless uses_classname?
           end
         end
 
@@ -49,9 +52,11 @@ module Neo4j
           end
         end
 
-        attr_reader :rel_type
+        def rel_type
+          @rel_type || type(namespaced_model_name, true)
+        end
+
         # @return [String] a string representing the relationship type that will be created
-        # attr_reader :rel_type
         alias_method :_type, :rel_type # Should be deprecated
 
         def add_wrapped_class(type)

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -104,9 +104,14 @@ describe 'ActiveRel' do
     class ActiveRelSpecTypesInheritedRelClass < ActiveRelSpecTypesAutomaticRelType
     end
 
+    it 'returns the existing type if arguments are omitted' do
+      MyRelClass.type('MY_NEW_TYPE')
+      expect(MyRelClass.type).to eq 'MY_NEW_TYPE'
+    end
 
-    it 'allows omission of `type`' do
-      expect(ActiveRelSpecTypesAutomaticRelType._type).to eq 'ACTIVE_REL_SPEC_TYPES_AUTOMATIC_REL_TYPE'
+    it 'returns the automatic type if `type` is never called or nil' do
+      MyRelClass.instance_variable_set(:'@rel_type', nil)
+      expect(MyRelClass.type).to eq 'MY_REL_CLASS'
     end
 
     it 'uses `type` to override the default type' do

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -19,8 +19,8 @@ describe 'ActiveRel' do
     end
 
     stub_active_rel_class('MyRelClass') do
-      from_class 'FromClass'
-      to_class 'ToClass'
+      from_class FromClass
+      to_class ToClass
       type 'rel_class_type'
 
       property :score
@@ -31,6 +31,23 @@ describe 'ActiveRel' do
 
   let(:from_node) { FromClass.create }
   let(:to_node) { ToClass.create }
+
+  describe 'from_class, to_class' do
+    it 'spits back the current variable if no argument is given' do
+      expect(MyRelClass.from_class).to eq FromClass
+      expect(MyRelClass.to_class).to eq ToClass
+    end
+
+    it 'sets the value with the argument given' do
+      expect(MyRelClass.from_class).not_to eq Object
+      expect(MyRelClass.from_class(Object)).to eq Object
+      expect(MyRelClass.from_class).to eq Object
+
+      expect(MyRelClass.to_class).not_to eq Object
+      expect(MyRelClass.to_class(Object)).to eq Object
+      expect(MyRelClass.to_class).to eq Object
+    end
+  end
 
   describe 'creation' do
     context 'from_node is not persisted' do


### PR DESCRIPTION
ActiveRel's `from_class` and `to_class` have always irked me a little.

```
class MyRelClass
  from_class FromClass
  to_class ToClass
end
```

Right now, to get the current values of `from_class` and `to_class`, you have to call `_from_class` or `_to_class`. It's ugly and unintuitive. This PR changes it so either of those methods without an argument will return the current value. Calling the methods with an argument will reset it.

While making the setter `self.from_class = FromClass` is more _correct_, I think it hurts the user experience and makes models uglier. This feels like a good compromise.