### PR TITLE
Default values for model_class when using ActiveRel class

### DIFF
--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -20,11 +20,10 @@ module Neo4j
         def derive_model_class
           return @model_class unless @model_class.nil?
 
-          unless relationship_class.nil?
-            # TODO: change `#_to_class` to `#to_class` when #837 is merged
-            return false if relationship_class._to_class.to_s.to_sym == :any
-            relationship_class._to_class
-          end
+          return nil if relationship_class.nil?
+          # TODO: change `#_to_class` to `#to_class` when #837 is merged
+          return false if relationship_class._to_class.to_s.to_sym == :any
+          relationship_class._to_class
         end
 
         def target_class_option(model_class)

--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -22,7 +22,8 @@ module Neo4j
 
           unless relationship_class.nil?
             # TODO: change `#_to_class` to `#to_class` when #837 is merged
-            return false if relationship_class._to_class.to_sym == :any
+            return false if relationship_class._to_class.to_s.to_sym == :any
+            relationship_class._to_class
           end
         end
 

--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -21,9 +21,8 @@ module Neo4j
           return @model_class unless @model_class.nil?
 
           return nil if relationship_class.nil?
-          # TODO: change `#_to_class` to `#to_class` when #837 is merged
-          return false if relationship_class._to_class.to_s.to_sym == :any
-          relationship_class._to_class
+          return false if relationship_class.to_class.to_s.to_sym == :any
+          relationship_class.to_class
         end
 
         def target_class_option(model_class)

--- a/spec/unit/association_spec.rb
+++ b/spec/unit/association_spec.rb
@@ -175,6 +175,15 @@ describe Neo4j::ActiveNode::HasN::Association do
           it { should be_nil }
         end
 
+        context 'targeting a specific class' do
+          before(:each) do
+            stub_const 'Fizzl', Class.new { include Neo4j::ActiveNode }
+            TheRel.to_class(Fizzl)
+          end
+
+          it { should == ['::Fizzl'] }
+        end
+
       end
     end
 

--- a/spec/unit/association_spec.rb
+++ b/spec/unit/association_spec.rb
@@ -155,6 +155,27 @@ describe Neo4j::ActiveNode::HasN::Association do
           it { should == ['::Fizzl'] }
         end
       end
+
+      context 'with specified rel_class' do
+        before(:each) do
+          stub_const('TheRel',
+                     Class.new do
+                       include Neo4j::ActiveRel
+                       from_class :any
+                     end)
+        end
+
+        let(:options) { { rel_class: 'TheRel' } }
+
+        context 'targeting any class' do
+          before(:each) do
+            TheRel.to_class(:any)
+          end
+
+          it { should be_nil }
+        end
+
+      end
     end
 
     describe 'target_class' do

--- a/spec/unit/association_spec.rb
+++ b/spec/unit/association_spec.rb
@@ -160,7 +160,9 @@ describe Neo4j::ActiveNode::HasN::Association do
         before(:each) do
           stub_const('TheRel',
                      Class.new do
-                       def self.name; 'TheRel' end
+                       def self.name
+                         'TheRel'
+                       end
                        include Neo4j::ActiveRel
                        from_class :any
                      end)

--- a/spec/unit/association_spec.rb
+++ b/spec/unit/association_spec.rb
@@ -165,7 +165,7 @@ describe Neo4j::ActiveNode::HasN::Association do
                      end)
         end
 
-        let(:options) { { rel_class: 'TheRel' } }
+        let(:options) { {rel_class: 'TheRel'} }
 
         context 'targeting any class' do
           before(:each) do
@@ -183,7 +183,6 @@ describe Neo4j::ActiveNode::HasN::Association do
 
           it { should == ['::Fizzl'] }
         end
-
       end
     end
 

--- a/spec/unit/association_spec.rb
+++ b/spec/unit/association_spec.rb
@@ -160,6 +160,7 @@ describe Neo4j::ActiveNode::HasN::Association do
         before(:each) do
           stub_const('TheRel',
                      Class.new do
+                       def self.name; 'TheRel' end
                        include Neo4j::ActiveRel
                        from_class :any
                      end)


### PR DESCRIPTION
As discussed on Gitter, this PR makes the `model_class` option a bit "smarter" by taking an `ActiveRel` class into account when one is used on the association.

When `RelClass._to_class == :any`, `model_class` is defaulted to `false` to avoid having to declare it explicitly (without it, an NameError exception will be raised when calling the association method).

When `RelClass._to_class` is any other value and the `:model_class` option has not been set, it is defaulted to the value of `RelClass._to_class`.

Note: When #837 gets merged, the code should be changed not to use `#_to_class` anymore.