### PR TITLE
use labels instead of is_a? to determine whether nodes are of appropriate type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased][unreleased]
 - Nothing yet, placeholder
 
+### Fixed
+- Longstanding bug that would prevent association changes (`<<` and ActiveRel.create) in Rails after `reload!` had been called, see https://github.com/neo4jrb/neo4j/pull/839
+
+### Changed
+- In the absense of a `model_class` key, associations defined in ActiveNode models will use `from_/to_class` defined in `rel_class` to find destination. (Huge thanks to @olance, #838) 
+- ActiveRel's DSL was made a bit friendlier by making the `type`, `from_class` and `to_class` methods return their set values when called without arguments.
+
+### Added
+- ActiveRel was given `find_or_create_by`, usable across single associations.
+
 ## [5.0.0] - 2015-06-18
 
 ### Fixed

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -192,7 +192,7 @@ module Neo4j
             (arg.is_a?(Integer) || arg.is_a?(String)) ? @model.find_by(@model.id_property_name => arg) : arg
           end.compact
 
-          if @model && other_nodes.any? { |other_node| !other_node.is_a?(@model) }
+          if @model && other_nodes.any? { |other_node| !other_node.class.mapped_label_names.include?(@model.mapped_label_name) }
             fail ArgumentError, "Node must be of the association's class when model is specified"
           end
 

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -60,8 +60,14 @@ module Neo4j::ActiveRel
 
         next if [:any, false].include?(type_class)
 
-        fail ModelClassInvalidError, "Node class was #{node.class}, expected #{type_class}" unless node.is_a?(type_class.to_s.constantize)
+        unless node.class.mapped_label_names.include?(type_class.to_s.constantize.mapped_label_name)
+          fail ModelClassInvalidError, type_validation_error_message(node, type_class)
+        end
       end
+    end
+
+    def type_validation_error_message(node, type_class)
+      "Node class was #{node.class} (#{node.class.object_id}), expected #{type_class} (#{type_class.object_id})"
     end
 
     def _create_rel(from_node, to_node, *args)
@@ -74,8 +80,6 @@ module Neo4j::ActiveRel
       end
       _rel_creation_query(from_node, to_node, props)
     end
-
-    private
 
     N1_N2_STRING = 'n1, n2'
     ACTIVEREL_NODE_MATCH_STRING = 'ID(n1) = {n1_neo_id} AND ID(n2) = {n2_neo_id}'


### PR DESCRIPTION
This solves https://github.com/neo4jrb/neo4j/issues/717.

Rails `reload!` method was bumping heads with the `@model` instance variable in QueryProxy. I can't totally pin down why, will need to look at it more another time. In the meantime, this skips around the problem by just using labels to determine whether nodes are of the appropriate type.

No new tests, this is too specific to Rails and it doesn't add anything new, it ends up in the same place using existing methods.