### PR TITLE
add an inherited method to shared property module

### DIFF
--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -125,6 +125,13 @@ module Neo4j::Shared
 
       def_delegators :declared_property_manager, :serialized_properties, :serialized_properties=, :serialize, :declared_property_defaults
 
+      def inherited(other)
+        self.declared_property_manager.registered_properties.each_pair do |prop_key, prop_def|
+          other.property(prop_key, prop_def.options)
+        end
+        super
+      end
+
       # Defines a property on the class
       #
       # See active_attr gem for allowed options, e.g which type

--- a/lib/neo4j/shared/serialized_properties.rb
+++ b/lib/neo4j/shared/serialized_properties.rb
@@ -14,5 +14,17 @@ module Neo4j::Shared
     def serializable_hash(*args)
       super.merge(id: id)
     end
+
+
+    module ClassMethods
+      def inherited(other)
+        inherit_serialized_properties(other) if self.respond_to?(:serialized_properties)
+        super
+      end
+
+      def inherit_serialized_properties(other)
+        other.serialized_properties = self.serialized_properties
+      end
+    end
   end
 end

--- a/spec/e2e/property_management_spec.rb
+++ b/spec/e2e/property_management_spec.rb
@@ -79,6 +79,33 @@ describe 'declared property classes' do
       expect(dpm.attributes_nil_hash).to have_key('bar')
     end
 
+    describe 'inheritance' do
+      before do
+        clazz = Class.new do
+          include Neo4j::ActiveNode
+          property :foo
+          property :bar, type: String, default: 'foo'
+        end
+
+        stub_const('MyModel', clazz)
+
+        clazz = Class.new(MyModel) do
+          include Neo4j::ActiveNode
+        end
+
+        stub_const('MyInheritedClass', clazz)
+      end
+
+      let(:dpm) { MyModel.declared_property_manager }
+      let(:inherited_dpm) { MyInheritedClass.declared_property_manager }
+
+      it 'applies the ancestor\'s props' do
+        dpm.registered_properties.each_key do |k|
+          expect(inherited_dpm.registered_properties).to have_key(k)
+        end
+      end
+    end
+
     # This mimics the behavior of active_attr's default property values
     describe 'default property values' do
       let(:node) { MyModel.new }


### PR DESCRIPTION
This ensures that default values and magic typecasters work with inherited classes. Fixes #842.