### PR TITLE
move faster node load methods from ActiveNode to shared to speed up a…

### DIFF
--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -35,6 +35,7 @@ require 'neo4j/shared/validations'
 require 'neo4j/shared/identity'
 require 'neo4j/shared/serialized_properties'
 require 'neo4j/shared/typecaster'
+require 'neo4j/shared/initialize'
 require 'neo4j/shared'
 
 require 'neo4j/active_rel/callbacks'

--- a/lib/neo4j/active_node/initialize.rb
+++ b/lib/neo4j/active_node/initialize.rb
@@ -1,5 +1,7 @@
 module Neo4j::ActiveNode::Initialize
   extend ActiveSupport::Concern
+  include Neo4j::Shared::Initialize
+
   attr_reader :called_by
 
   # called when loading the node from the database
@@ -10,28 +12,5 @@ module Neo4j::ActiveNode::Initialize
     @_persisted_obj = persisted_node
     changed_attributes && changed_attributes.clear
     @attributes = convert_and_assign_attributes(properties)
-  end
-
-  # Implements the Neo4j::Node#wrapper and Neo4j::Relationship#wrapper method
-  # so that we don't have to care if the node is wrapped or not.
-  # @return self
-  def wrapper
-    self
-  end
-
-  private
-
-  def convert_and_assign_attributes(properties)
-    @attributes ||= self.class.attributes_nil_hash.dup
-    stringify_attributes!(@attributes, properties)
-    self.default_properties = properties
-    self.class.declared_property_manager.convert_properties_to(self, :ruby, @attributes)
-  end
-
-  def stringify_attributes!(attr, properties)
-    properties.each_pair do |k, v|
-      key = self.class.declared_property_manager.string_key(k)
-      attr[key] = v
-    end
   end
 end

--- a/lib/neo4j/active_rel/property.rb
+++ b/lib/neo4j/active_rel/property.rb
@@ -21,8 +21,7 @@ module Neo4j::ActiveRel
 
     def initialize(attributes = {}, options = {})
       super(attributes, options)
-
-      send_props(@relationship_props) unless @relationship_props.nil?
+      send_props(@relationship_props) if _persisted_obj && !@relationship_props.nil?
     end
 
     module ClassMethods
@@ -34,6 +33,10 @@ module Neo4j::ActiveRel
             relationship_props[key] = attributes.delete(key) if [:from_node, :to_node].include?(key)
           end
         end
+      end
+
+      def id_property_name
+        false
       end
 
       %w(to_class from_class).each do |direction|

--- a/lib/neo4j/active_rel/rel_wrapper.rb
+++ b/lib/neo4j/active_rel/rel_wrapper.rb
@@ -2,7 +2,6 @@ class Neo4j::Relationship
   module Wrapper
     def wrapper
       props.symbolize_keys!
-      # return self unless props.is_a?(Hash)
       begin
         most_concrete_class = sorted_wrapper_classes
         wrapped_rel = most_concrete_class.constantize.new
@@ -21,7 +20,7 @@ class Neo4j::Relationship
     end
 
     def class_from_type
-      Neo4j::ActiveRel::Types::WRAPPED_CLASSES[rel_type] || rel_type.camelize
+      Neo4j::ActiveRel::Types::WRAPPED_CLASSES[rel_type] || Neo4j::ActiveRel::Types::WRAPPED_CLASSES[rel_type] = rel_type.camelize
     end
   end
 end

--- a/lib/neo4j/shared/initialize.rb
+++ b/lib/neo4j/shared/initialize.rb
@@ -1,0 +1,28 @@
+module Neo4j::Shared
+  module Initialize
+    extend ActiveSupport::Concern
+
+    # Implements the Neo4j::Node#wrapper and Neo4j::Relationship#wrapper method
+    # so that we don't have to care if the node is wrapped or not.
+    # @return self
+    def wrapper
+      self
+    end
+
+    private
+
+    def convert_and_assign_attributes(properties)
+      @attributes ||= self.class.attributes_nil_hash.dup
+      stringify_attributes!(@attributes, properties)
+      self.default_properties = properties
+      self.class.declared_property_manager.convert_properties_to(self, :ruby, @attributes)
+    end
+
+    def stringify_attributes!(attr, properties)
+      properties.each_pair do |k, v|
+        key = self.class.declared_property_manager.string_key(k)
+        attr[key] = v
+      end
+    end
+  end
+end


### PR DESCRIPTION
…ctiverel

Returning ActiveRel instances using:
```ruby
Benchmark.ips do |x|
  x.config(time: 10)
  x.report do
    Student.all.lessons(:l, :r, labels: false).limit(300).pluck(:r)
  end
end
```

Before: 21.3 i/s
After: 37.6 i/s

It's also a bit faster to load rels than nodes, incidentally.

You're unlikely to feel a difference when returning a small number of rels at a time but there is a noticeable improvement when returning larger numbers. 