### PR TITLE
`where` can use model type converters, more type conversion logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 gemspec
 
-# gem 'neo4j-core', github: 'neo4jrb/neo4j-core', branch: 'master'
+gem 'neo4j-core', github: 'neo4jrb/neo4j-core', branch: 'master'
 # gem 'neo4j-core', path: '../neo4j-core'
 
 # gem 'active_attr', github: 'neo4jrb/active_attr', branch: 'performance'

--- a/lib/neo4j/active_node/query/query_proxy_link.rb
+++ b/lib/neo4j/active_node/query/query_proxy_link.rb
@@ -29,10 +29,9 @@ module Neo4j
                 arg.each do |key, value|
                   if model && model.association?(key)
                     result += for_association(key, value, "n#{node_num}", model)
-
                     node_num += 1
                   else
-                    result << new(:where, ->(v, _) { {v => {key => value}} })
+                    result << new(:where, ->(v, _) { {v => {key => model.declared_property_manager.value_for_db(key, value)}} })
                   end
                 end
               elsif arg.is_a?(String)

--- a/lib/neo4j/shared/declared_property_manager.rb
+++ b/lib/neo4j/shared/declared_property_manager.rb
@@ -113,6 +113,16 @@ module Neo4j::Shared
       @upstream_primitives ||= {}
     end
 
+    def value_for_db(key, value)
+      return value unless registered_properties[key]
+      convert_property(key, value, :to_db)
+    end
+
+    def value_for_ruby(key, value)
+      return unless registered_properties[key]
+      convert_property(key, value, :to_ruby)
+    end
+
     protected
 
     # Prevents repeated calls to :_attribute_type, which isn't free and never changes.

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -55,6 +55,7 @@ module Neo4j::Shared
       hash.each { |key, value| self.send("#{key}=", value) }
     end
 
+
     protected
 
     # This method is defined in ActiveModel.

--- a/spec/integration/type_converters/type_converters_spec.rb
+++ b/spec/integration/type_converters/type_converters_spec.rb
@@ -49,6 +49,11 @@ describe Neo4j::Shared::TypeConverters do
     it 'returns the same value if there is no converter' do
       Neo4j::Shared::TypeConverters.to_other(:to_ruby, 42, Integer).should eq(42)
     end
+
+    it 'returns the same value if it is already of the expected type' do
+      timestamp = DateTime.now.to_i
+      expect(Neo4j::Shared::TypeConverters.to_other(:to_db, timestamp, DateTime)).to eq timestamp
+    end
   end
 
   describe Neo4j::Shared::TypeConverters::JSONConverter do


### PR DESCRIPTION
Part A makes QueryProxy's `where` method inspect the in-scope model for a matching key. If one is found, it will send the value given to the type converter. It means something like this is now valid:

```
class Student
  include Neo4j::ActiveNode
  property :created_at, type: DateTime
end

# Will run the value through `created_at`'s converter
student.where(created_at: DateTime.now - 10).first
```

If you match against an undeclared property, that's on you, you should convert it before performing the match. If you need custom conversion, there's a process for adding custom converters already in place.

"But Chris," you might be saying, "I often take a timestamp from a controller and immediately perform a match on a declared property. I don't want to have to convert it to a DateTime so it can just convert it back to an integer!" If so, you're in luck!

Part B makes type converters a bit smarter. Converters can now have a `db_type` method that returns the expected output type of conversion for interaction with Neo4j. If your `where` is an instance of this class, it will bypass conversion and just spit it back out.