### PR TITLE
methods to clear cached classes after `reload!` is called

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 gemspec
 
-# gem 'neo4j-core', github: 'neo4jrb/neo4j-core', branch: 'master'
+gem 'neo4j-core', github: 'neo4jrb/neo4j-core', branch: 'master'
 # gem 'neo4j-core', path: '../neo4j-core'
 
 # gem 'active_attr', github: 'neo4jrb/active_attr', branch: 'performance'

--- a/lib/neo4j/active_node/labels.rb
+++ b/lib/neo4j/active_node/labels.rb
@@ -80,6 +80,12 @@ module Neo4j
       module ClassMethods
         include Neo4j::ActiveNode::QueryMethods
 
+        def before_remove_const
+          associations.each_value(&:queue_model_refresh!)
+          MODELS_FOR_LABELS_CACHE.clear
+          WRAPPED_CLASSES.clear
+        end
+
         # Returns the object with the specified neo4j id.
         # @param [String,Integer] id of node to find
         def find(id)


### PR DESCRIPTION
This appears to correct the root cause of #717 and possibly https://github.com/neo4jrb/devise-neo4j/issues/16. It uses the `before_remove_const` method fired by ActiveSupport's `reload!` to wipe cached references to classes. It's possible others are still lurking but this will be a start.