### PR TITLE
adds an extra `empty?` call when destroying dependent to prevent expe…

### DIFF
--- a/lib/neo4j/active_node/dependent/association_methods.rb
+++ b/lib/neo4j/active_node/dependent/association_methods.rb
@@ -32,11 +32,13 @@ module Neo4j
         end
 
         def dependent_destroy_callback(object)
-          object.association_query_proxy(name).each_for_destruction(object, &:destroy)
+          unique_query = object.association_query_proxy(name)
+          unique_query.each_for_destruction(object, &:destroy) if unique_query
         end
 
         def dependent_destroy_orphans_callback(object)
-          object.as(:self).unique_nodes(self, :self, :n, :other_rel).each_for_destruction(object, &:destroy)
+          unique_query = object.as(:self).unique_nodes(self, :self, :n, :other_rel)
+          unique_query.each_for_destruction(object, &:destroy) if unique_query
         end
 
         # End callback methods

--- a/lib/neo4j/active_node/dependent/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/dependent/query_proxy_methods.rb
@@ -28,7 +28,7 @@ module Neo4j
         # @return [Neo4j::ActiveNode::Query::QueryProxy]
         def unique_nodes(association, self_identifer, other_node, other_rel)
           fail 'Only supported by in QueryProxy chains started by an instance' unless source_object
-
+          return false if send(association.name).empty?
           unique_nodes_query(association, self_identifer, other_node, other_rel)
             .proxy_as(association.target_class, other_node)
         end

--- a/spec/e2e/association_dependency_spec.rb
+++ b/spec/e2e/association_dependency_spec.rb
@@ -87,6 +87,27 @@ describe 'association dependent delete/destroy' do
     @route2.stops << [@philadelphia, @manhattan, @boston]
   end
 
+  describe 'basic destruction' do
+    let(:node) { User.create }
+
+    context 'a node without relationships' do
+      it 'quits out of the process without performing an expensive match' do
+        expect_any_instance_of(Neo4j::ActiveNode::Query::QueryProxy).not_to receive(:unique_nodes_query)
+        node.destroy
+      end
+    end
+
+    context 'a node with relationshpis' do
+      let(:band) { Band.create }
+      before { node.bands << band }
+
+      it 'continues as normal' do
+        expect_any_instance_of(Neo4j::ActiveNode::Query::QueryProxy).to receive(:unique_nodes_query).and_call_original
+        node.destroy
+      end
+    end
+  end
+
   describe 'Grzesiek is booking a tour for his bands' do
     before(:each) do
       delete_db


### PR DESCRIPTION
…nsive match

The `dependent` association options can be expensive, so this adds an extra query to make sure there are nodes there to destroy.