### PR TITLE
Id prop index calls

### DIFF
--- a/lib/neo4j/active_node.rb
+++ b/lib/neo4j/active_node.rb
@@ -76,7 +76,7 @@ module Neo4j
 
       def self.inherit_id_property(other)
         Neo4j::Session.on_session_available do |_|
-          return unless self.id_property?
+          next if other.manual_id_property? || !self.id_property?
           id_prop = self.id_property_info
           conf = id_prop[:type].empty? ? {auto: :uuid} : id_prop[:type]
           other.id_property id_prop[:name], conf

--- a/lib/neo4j/active_node.rb
+++ b/lib/neo4j/active_node.rb
@@ -84,6 +84,7 @@ module Neo4j
       end
 
       Neo4j::Session.on_session_available do |_|
+        next if manual_id_property?
         id_property :uuid, auto: :uuid unless self.id_property?
 
         name = Neo4j::Config[:id_property]

--- a/lib/neo4j/active_node/id_property.rb
+++ b/lib/neo4j/active_node/id_property.rb
@@ -124,6 +124,8 @@ module Neo4j::ActiveNode
 
 
     module ClassMethods
+      attr_accessor :manual_id_property
+
       def find_by_neo_id(id)
         Neo4j::Node.load(id)
       end
@@ -137,12 +139,15 @@ module Neo4j::ActiveNode
       end
 
       def id_property(name, conf = {})
-        id_property_constraint(name)
-        @id_property_info = {name: name, type: conf}
-        TypeMethods.define_id_methods(self, name, conf)
-        constraint name, type: :unique unless conf[:constraint] == false
+        self.manual_id_property = true
+        Neo4j::Session.on_session_available do |_|
+          id_property_constraint(name)
+          @id_property_info = {name: name, type: conf}
+          TypeMethods.define_id_methods(self, name, conf)
+          constraint name, type: :unique unless conf[:constraint] == false
 
-        self.define_singleton_method(:find_by_id) { |key| self.where(name => key).first }
+          self.define_singleton_method(:find_by_id) { |key| self.where(name => key).first }
+        end
       end
 
       # rubocop:disable Style/PredicateName
@@ -163,6 +168,10 @@ module Neo4j::ActiveNode
 
       def id_property_name
         id_property_info[:name]
+      end
+
+      def manual_id_property?
+        !!manual_id_property
       end
 
       alias_method :primary_key, :id_property_name

--- a/lib/neo4j/active_node/id_property.rb
+++ b/lib/neo4j/active_node/id_property.rb
@@ -141,10 +141,9 @@ module Neo4j::ActiveNode
       def id_property(name, conf = {})
         self.manual_id_property = true
         Neo4j::Session.on_session_available do |_|
-          id_property_constraint(name)
           @id_property_info = {name: name, type: conf}
           TypeMethods.define_id_methods(self, name, conf)
-          constraint name, type: :unique unless conf[:constraint] == false
+          constraint(name, type: :unique) unless conf[:constraint] == false
 
           self.define_singleton_method(:find_by_id) { |key| self.where(name => key).first }
         end
@@ -182,7 +181,7 @@ module Neo4j::ActiveNode
         if id_property?
           unless mapped_label.uniqueness_constraints[:property_keys].include?([name])
             # Neo4j Embedded throws a crazy error when a constraint can't be dropped
-            drop_constraint(id_property_name, type: :unique)
+            drop_constraint(id_property_name, type: :unique) if constraint?(mapped_label_name, id_property_name)
           end
         end
       rescue Neo4j::Server::CypherResponse::ResponseError, Java::OrgNeo4jCypher::CypherExecutionException

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -191,6 +191,12 @@ module ActiveNodeRelStubHelpers
   end
 end
 
+def before_session
+  Neo4j::Session.current.close if Neo4j::Session.current
+  yield
+  create_session
+end
+
 RSpec.configure do |c|
   c.include Neo4jSpecHelpers
 


### PR DESCRIPTION
Just gonna copy and paste pieces from a conversation with @cheerfulstoic just now:

"I’ve gotta merge something that changes some behavior around uuids and id_property. It was creating a constraint on uuid every time the server started, which wasn’t a problem unless you try setting a custom generation method for uuid and want an index instead of a constraint.

So you’d do this:
```
class MyModel
  include Neo4j::ActiveNode
  id_property :uuid, auto: :uuid, constraint: false
  index :uuid
end
```
Or maybe you’d use a custom method, it doesn’t matter. What happens now is session starts, default behavior creates a constraint, then the index call drops the constraint and replaces it with an index. Next time the app starts, it repeats but it sees you already have an index, so it drops it to create the constraint, then drops the constraint to create the index.
It’s the ciiiiircle of liiiiife..."

Brian described it as the "circle of death of performance," which is both true and metal. :metal:

The change is two-fold:

* Allow manual calls to `id_property` register as pending events.
* Make `id_property` aware of Neo4j session status. It will give you "last-call-wins" behavior.

A few tests were updated to help confirm some of this behavior. It's a little tricky because it relies on interaction with new sessions, so there's a new helper method in `spec_helper` to make it a little less painful.