### PR TITLE
Hash[] is faster than hash.dup when loading nodes

### DIFF
--- a/lib/neo4j/active_node/property.rb
+++ b/lib/neo4j/active_node/property.rb
@@ -5,7 +5,7 @@ module Neo4j::ActiveNode
 
     def initialize(attributes = {}, options = {})
       super(attributes, options)
-      @attributes ||= self.class.attributes_nil_hash.dup
+      @attributes ||= Hash[self.class.attributes_nil_hash]
       send_props(@relationship_props) if _persisted_obj && !@relationship_props.nil?
     end
 

--- a/lib/neo4j/shared/initialize.rb
+++ b/lib/neo4j/shared/initialize.rb
@@ -12,7 +12,7 @@ module Neo4j::Shared
     private
 
     def convert_and_assign_attributes(properties)
-      @attributes ||= self.class.attributes_nil_hash.dup
+      @attributes ||= Hash[self.class.attributes_nil_hash]
       stringify_attributes!(@attributes, properties)
       self.default_properties = properties
       self.class.declared_property_manager.convert_properties_to(self, :ruby, @attributes)


### PR DESCRIPTION
Improves load performance by around 5-6% when loading large numbers of nodes.