### PR TITLE
Add Timestamps mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - On `QueryProxy` objects you can now use an `:id` key in `where` and `find_by` methods to refer to the property from `id_property` (`uuid` by default)
 - Added `ActiveRel.creates_unique` and deprecated `ActiveRel.creates_unique_rel`
 - Added #inspect method to ActiveRel to show Cypher-style representation of from node, to node, and relationship type
+- Added `Neo4j::Timestamps`, `Neo4j::Timestamps::Created`, and `Neo4j::Timestamps::Updated` mixins to add timestamp properties to `ActiveNode` or `ActiveRel` classes
 
 ### Changed
 

--- a/lib/neo4j/timestamps.rb
+++ b/lib/neo4j/timestamps.rb
@@ -1,0 +1,8 @@
+module Neo4j
+  # This mixin includes timestamps in the included class
+  module Timestamps
+    extend ActiveSupport::Concern
+    include Created
+    include Updated
+  end
+end

--- a/lib/neo4j/timestamps/created.rb
+++ b/lib/neo4j/timestamps/created.rb
@@ -1,0 +1,11 @@
+module Neo4j
+  module Timestamps
+    # This mixin includes a created_at timestamp property
+    module Created
+      extend ActiveSupport::Concern
+      included do
+        property :created_at, type: DateTime
+      end
+    end
+  end
+end

--- a/lib/neo4j/timestamps/updated.rb
+++ b/lib/neo4j/timestamps/updated.rb
@@ -1,0 +1,11 @@
+module Neo4j
+  module Timestamps
+    # This mixin includes a updated_at timestamp property
+    module Updated
+      extend ActiveSupport::Concern
+      included do
+        property :updated_at, type: DateTime
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the following mixins (a la mongoid) for including timestamp properties in an easy way:

```ruby
class Student
  include Neo4j::ActiveNode
  include Neo4j::Timestamps
end

class Student
  include Neo4j::ActiveNode
  include Neo4j::Timestamps::Created
end

class Student
  include Neo4j::ActiveNode
  include Neo4j::Timestamps::Updated
end

class EnrolledIn
  include Neo4j::ActiveRel
  include Neo4j::Timestamps
end

class EnrolledIn
  include Neo4j::ActiveRel
  include Neo4j::Timestamps::Created
end

class EnrolledIn
  include Neo4j::ActiveRel
  include Neo4j::Timestamps::Updated
end
```

`Neo4j::Timestamps` includes both `Created` and `Updated`.

Closes #861.