### PR TITLE
Rel uniqueness sync

### DIFF
--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -135,12 +135,18 @@ module Neo4j
         end
 
         def unique?
+          return relationship_class.unique? if rel_class?
           @origin ? origin_association.unique? : !!@unique
         end
 
         def create_method
           unique? ? :create_unique : :create
         end
+
+        def relationship_class?
+          !!relationship_class
+        end
+        alias_method :rel_class?, :relationship_class?
 
         private
 

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -56,6 +56,10 @@ module Neo4j::ActiveRel
           obj.save!
         end
       end
+
+      def create_method
+        creates_unique? ? :create_unique : :create
+      end
     end
 
     private
@@ -96,7 +100,7 @@ module Neo4j::ActiveRel
     end
 
     def create_method
-      self.class.creates_unique? ? :create_unique : :create
+      self.class.create_method
     end
   end
 end

--- a/lib/neo4j/active_rel/property.rb
+++ b/lib/neo4j/active_rel/property.rb
@@ -15,7 +15,7 @@ module Neo4j::ActiveRel
     alias_method :end_node,   :to_node
 
     %w(start_node end_node).each do |direction|
-      define_method("#{direction}_neo_id") { direction.neo_id if direction }
+      define_method("#{direction}_neo_id") { send(direction).neo_id if direction }
     end
     alias_method :from_node_neo_id, :start_node_neo_id
     alias_method :to_node_neo_id,   :end_node_neo_id

--- a/lib/neo4j/active_rel/property.rb
+++ b/lib/neo4j/active_rel/property.rb
@@ -14,6 +14,12 @@ module Neo4j::ActiveRel
     alias_method :start_node, :from_node
     alias_method :end_node,   :to_node
 
+    %w(start_node end_node).each do |direction|
+      define_method("#{direction}_neo_id") { direction.neo_id if direction }
+    end
+    alias_method :from_node_neo_id, :start_node_neo_id
+    alias_method :to_node_neo_id,   :end_node_neo_id
+
     # @return [String] a string representing the relationship type that will be created
     def type
       self.class._type
@@ -74,6 +80,7 @@ WARNING
       def creates_unique?
         !!@creates_unique
       end
+      alias_method :unique?, :creates_unique?
     end
 
     private

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -197,16 +197,13 @@ describe 'ActiveRel' do
   end
 
   describe 'objects and queries' do
-    before do
-      Neo4j::Config[:cache_class_names] = true
-      @rel1 = MyRelClass.create(from_node: from_node, to_node: to_node, score: 99)
-      @rel2 = MyRelClass.create(from_node: from_node, to_node: to_node, score: 49)
-    end
+    let!(:rel1) { MyRelClass.create(from_node: from_node, to_node: to_node, score: 99) }
+    let!(:rel2) { MyRelClass.create(from_node: from_node, to_node: to_node, score: 49) }
 
-    after { [@rel1, @rel2].each(&:destroy) }
+    after { [rel1, rel2].each(&:destroy) }
 
     describe 'related nodes' do
-      let(:reloaded) { MyRelClass.find(@rel1.neo_id) }
+      let(:reloaded) { MyRelClass.find(rel1.neo_id) }
 
       # We only run this test in the Server environment. Embedded's loading of
       # relationships works differently, so we aren't as concerned with whether
@@ -222,11 +219,18 @@ describe 'ActiveRel' do
       it 'delegates respond_to?' do
         expect(reloaded.from_node.respond_to?(:id)).to be_truthy
       end
+
+      describe 'neo id queries' do
+        it 'aliases #{related_node}_neo_id to #{related_node}.neo_id' do
+          expect(rel1.from_node_neo_id).to eq rel1.from_node.neo_id
+          expect(rel1.to_node_neo_id).to eq rel1.to_node.neo_id
+        end
+      end
     end
 
     describe 'where' do
       it 'returns the matching objects' do
-        expect(MyRelClass.where(score: 99)).to eq [@rel1]
+        expect(MyRelClass.where(score: 99)).to eq [rel1]
       end
 
       it 'has the appropriate from and to nodes' do
@@ -238,7 +242,7 @@ describe 'ActiveRel' do
       context 'with a string' do
         it 'returns the matching rels' do
           query = MyRelClass.where('r1.score > 48')
-          expect(query).to include(@rel1, @rel2)
+          expect(query).to include(rel1, rel2)
         end
       end
     end
@@ -246,34 +250,34 @@ describe 'ActiveRel' do
     describe 'all' do
       it 'returns all rels' do
         query = MyRelClass.all
-        expect(query).to include(@rel1, @rel2)
+        expect(query).to include(rel1, rel2)
       end
     end
 
     describe 'find' do
       it 'returns the rel' do
-        expect(MyRelClass.find(@rel1.neo_id)).to eq @rel1
+        expect(MyRelClass.find(rel1.neo_id)).to eq rel1
       end
     end
 
     describe 'first, last' do
       it 'returns the first-ish result' do
-        expect(MyRelClass.first).to eq @rel1
+        expect(MyRelClass.first).to eq rel1
       end
 
       it 'returns the last-ish result' do
-        expect(MyRelClass.last).to eq @rel2
+        expect(MyRelClass.last).to eq rel2
       end
 
       context 'with from_class and to_class as strings and constants' do
         it 'converts the strings to constants and runs the query' do
           MyRelClass.from_class 'FromClass'
           MyRelClass.to_class 'ToClass'
-          expect(MyRelClass.where(score: 99)).to eq [@rel1]
+          expect(MyRelClass.where(score: 99)).to eq [rel1]
 
           MyRelClass.from_class :FromClass
           MyRelClass.to_class :ToClass
-          expect(MyRelClass.where(score: 99)).to eq [@rel1]
+          expect(MyRelClass.where(score: 99)).to eq [rel1]
         end
       end
     end

--- a/spec/unit/association_spec.rb
+++ b/spec/unit/association_spec.rb
@@ -359,7 +359,16 @@ describe Neo4j::ActiveNode::HasN::Association do
     describe 'relationship_class' do
       it 'returns the value of @relationship_class' do
         association.instance_variable_set(:@relationship_class, :foo)
-        expect(association.send(:relationship_class)).to eq :foo
+        expect(association.relationship_class).to eq :foo
+      end
+    end
+
+    describe 'rel_class?' do
+      it 'returns truthiness from rel_class?' do
+        association.instance_variable_set(:@relationship_class, :foo)
+        expect(association.rel_class?).to be_truthy
+        association.instance_variable_set(:@relationship_class, nil)
+        expect(association.rel_class?).to be_falsey
       end
     end
 
@@ -377,6 +386,20 @@ describe Neo4j::ActiveNode::HasN::Association do
         let(:options) { {type: :foo, unique: false} }
 
         it { expect(subject).not_to be_unique }
+      end
+
+      context 'with a rel class' do
+        let(:rel_stub) { double('A Rel Class') }
+        before { association.instance_variable_set(:@relationship_class, rel_stub) }
+        it 'defers to the rel class' do
+          expect(rel_stub).to receive(:unique?)
+          association.unique?
+        end
+
+        it 'follows instructions from the rel class' do
+          expect(rel_stub).to receive(:unique?).and_return true
+          expect(association.create_method).to eq :create_unique
+        end
       end
     end
   end


### PR DESCRIPTION
A few small changes. It...

* makes associations `:unique?` defer to rel_class if set
* adds `rel_class?` and `relationship_class?` methods to associations
* adds `create_method` class method to ActiveRel
* adds `#{related_node}_neo_id` method to ActiveRel instances to match CypherRelationship instances
* adds `unique?` to ActiveRel to match association method

I also removed some instance variables in ActiveRel tests.