### PR TITLE
Dotenv for specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ coverage
 
 docs_site/
 /docs/_build
+
+# dotenv
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,5 @@ group 'test' do
   gem 'test-unit'
   gem 'overcommit'
   gem 'colored'
+  gem 'dotenv'
 end

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,10 @@
+## Configuration
+
+The specs are configured to run against `http://localhost:7474` by default. In order to change this in your local setup you can set the `NEO4J_URL` environment variable on your system to suit your needs.
+
+To make this easier, the neo4j spec suite allows you to add a `.env` file locally to configure this. For example, to set the `NEO4J_URL` you simply need to add a `.env` file that looks like this:
+
+```
+NEO4J_URL=http://localhost:7475
+```
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 # To run coverage via travis
 require 'simplecov'
+require 'dotenv'
+
+Dotenv.load
+
 SimpleCov.start
 if ENV['CI'] == 'true'
   require 'codecov'


### PR DESCRIPTION
## Description
When I first forked the repository I was confused as to how to setup my local environment to run the specs. I already had a server configured on `7474` and didn't want to change that. I noticed that the `spec_helper` was using environment variables to allow you to override so I thought it might be easy to utilize the `dotenv` gem to make this configuration easier for contributors.

## What I've Done
* added the `dotenv` gem to the test `Gemfile`
* added `.env` to the `.gitignore` so no one checks it in accidentally
* added a `README.md` in the `spec/` folder to explain a little bit about how to create one 

As always, feedback welcome!