### PR TITLE
Actually require the Neo4j::Timestamps mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- Fixed a bug where the `Neo4j::Timestamps` mixin was not able to be included
+
 ## [5.1.0.rc.3] - 08-17-2015
 
 ### Fixed

--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -26,6 +26,10 @@ require 'neo4j/shared/rel_type_converters'
 require 'neo4j/type_converters'
 require 'neo4j/paginated'
 
+require 'neo4j/timestamps/created'
+require 'neo4j/timestamps/updated'
+require 'neo4j/timestamps'
+
 require 'neo4j/shared/callbacks'
 require 'neo4j/shared/declared_property'
 require 'neo4j/shared/declared_property_manager'


### PR DESCRIPTION
So, I was stupid and forgot to require the timestamps mixin classes in my PR #915 - this fixes that.