### PR TITLE
simplifies node and rel persistence methods

### DIFF
--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -21,15 +21,17 @@ module Neo4j::ActiveRel
       fail RelInvalidError, self unless save(*args)
     end
 
-    def create_model(*)
+    def create_model
       validate_node_classes!
-      create_magic_properties
-      set_timestamps
-      properties = self.class.declared_property_manager.convert_properties_to(self, :db, props)
-      rel = _create_rel(from_node, to_node, properties)
+      rel = _create_rel(from_node, to_node, props_for_create)
       return self unless rel.respond_to?(:_persisted_obj)
       init_on_load(rel._persisted_obj, from_node, to_node, @rel_type)
       true
+    end
+
+    def props_for_create
+      set_timestamps
+      self.class.declared_property_manager.convert_properties_to(self, :db, props)
     end
 
     module ClassMethods

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -4,13 +4,19 @@ module Neo4j::Shared
 
     USES_CLASSNAME = []
 
+    def props_for_persistence
+      _persisted_obj ? props_for_update : props_for_create
+    end
+
     def update_model
       return if !changed_attributes || changed_attributes.empty?
-
-      changed_props = attributes.select { |k, _| changed_attributes.include?(k) }
-      changed_props = self.class.declared_property_manager.convert_properties_to(self, :db, changed_props)
-      _persisted_obj.update_props(changed_props)
+      _persisted_obj.update_props(props_for_update)
       changed_attributes.clear
+    end
+
+    def props_for_update
+      changed_props = attributes.select { |k, _| changed_attributes.include?(k) }
+      self.class.declared_property_manager.convert_properties_to(self, :db, changed_props)
     end
 
     # Convenience method to set attribute and #save at the same time
@@ -161,9 +167,6 @@ module Neo4j::Shared
 
     def model_cache_key
       self.class.model_name.cache_key
-    end
-
-    def create_magic_properties
     end
 
     def update_magic_properties


### PR DESCRIPTION
I think this is kind of nice. It breaks up the create and update processes in such a way that it's easy to get your hands on the node or rel's properties as they would be if sent to the database for each persistence event. It's useful if you want to instantiate an instance of a class, manipulate it within the app, but then handle the DB interaction yourself.

```ruby
props = User.new(name: 'Chris', age: 31, occupation: 'Developer', location: 'Brooklyn').props_for_create

Neo4j::Session.current.query
  .match(i: 'Instrument', l: 'ProgrammingLanguage')
  .where(i: { name: 'Guitar'}, l: { name: 'Ruby' })
  .break
  .create('(i)<-[:PLAYS]-(u:User {user_props})-[:WORKS_WITH]->(l)')
  .params(user_props: props)
  .pluck(:u)
```

Out of curiosity, I compared the speed of this VS multiple queries.

```
Comparison:
                 one:      248.4 i/s
                many:       64.8 i/s - 3.84x slower
```

If you find some of the method names a little weird, I'm with you. `props_for_create` started as `creation_props`, but the parallel for update would just be `update_props`, and `update_props` in Neo4j-core is meant like a verb, "update these props." Calling `_persisted_obj.update_props(update_props)` just felt wrong. This was the best I could think to do in a way that keeps things consistent for both operations. Another method, `props_for_persistence`, will call the method that's appropriate for the given state of the node or rel.

Gonna write a few tests before merging but wanted to get it up here so I'd stop forgetting to finish it.