### PR TITLE
Config methods for timestamps

### DIFF
--- a/lib/neo4j/active_node.rb
+++ b/lib/neo4j/active_node.rb
@@ -41,6 +41,8 @@ module Neo4j
     include Neo4j::ActiveNode::Scope
     include Neo4j::ActiveNode::Dependent
 
+    include Neo4j::Timestamps if Neo4j::Config.record_timestamps
+
     def neo4j_obj
       _persisted_obj || fail('Tried to access native neo4j object on a non persisted object')
     end

--- a/lib/neo4j/active_node.rb
+++ b/lib/neo4j/active_node.rb
@@ -41,8 +41,6 @@ module Neo4j
     include Neo4j::ActiveNode::Scope
     include Neo4j::ActiveNode::Dependent
 
-    include Neo4j::Timestamps if Neo4j::Config.record_timestamps
-
     def neo4j_obj
       _persisted_obj || fail('Tried to access native neo4j object on a non persisted object')
     end
@@ -57,6 +55,8 @@ module Neo4j
     end
 
     included do
+      include Neo4j::Timestamps if Neo4j::Config.record_timestamps
+
       def self.inherited(other)
         inherit_id_property(other)
         inherited_indexes(other) if self.respond_to?(:indexed_properties)

--- a/lib/neo4j/active_rel.rb
+++ b/lib/neo4j/active_rel.rb
@@ -15,8 +15,6 @@ module Neo4j
     include Neo4j::ActiveRel::Query
     include Neo4j::ActiveRel::Types
 
-    include Neo4j::Timestamps if Neo4j::Config.record_timestamps
-
     class FrozenRelError < StandardError; end
 
     def initialize(*args)
@@ -46,6 +44,8 @@ module Neo4j
     end
 
     included do
+      include Neo4j::Timestamps if Neo4j::Config.record_timestamps
+
       def self.inherited(other)
         super
       end

--- a/lib/neo4j/active_rel.rb
+++ b/lib/neo4j/active_rel.rb
@@ -15,6 +15,8 @@ module Neo4j
     include Neo4j::ActiveRel::Query
     include Neo4j::ActiveRel::Types
 
+    include Neo4j::Timestamps if Neo4j::Config.record_timestamps
+
     class FrozenRelError < StandardError; end
 
     def initialize(*args)

--- a/lib/neo4j/config.rb
+++ b/lib/neo4j/config.rb
@@ -2,8 +2,8 @@ module Neo4j
   # == Keeps configuration for neo4j
   #
   # == Configurations keys
-  #
   class Config
+    attr_writer :record_timestamps
     DEFAULT_FILE = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'config', 'neo4j', 'config.yml'))
     CLASS_NAME_PROPERTY_KEY = 'class_name_property'
 
@@ -93,6 +93,12 @@ module Neo4j
         configuration.to_yaml
       end
 
+      # @return [Boolean] The value of the config variable for including
+      # timestamps on all models.
+      def record_timestamps
+        @record_timestamps ||= false
+      end
+
       def class_name_property
         @_class_name_property = Neo4j::Config[CLASS_NAME_PROPERTY_KEY] || :_classname
       end
@@ -106,8 +112,6 @@ module Neo4j
         Neo4j::Config[:module_handling] || :none
       end
 
-      # Allows Integer or DateTime type to configured
-      # for timestamps.
       def timestamp_type
         Neo4j::Config[:timestamp_type] || DateTime
       end

--- a/lib/neo4j/config.rb
+++ b/lib/neo4j/config.rb
@@ -106,6 +106,12 @@ module Neo4j
         Neo4j::Config[:module_handling] || :none
       end
 
+      # Allows Integer or DateTime type to configured
+      # for timestamps.
+      def timestamp_type
+        Neo4j::Config[:timestamp_type] || DateTime
+      end
+
       def association_model_namespace
         Neo4j::Config[:association_model_namespace] || nil
       end

--- a/lib/neo4j/config.rb
+++ b/lib/neo4j/config.rb
@@ -3,11 +3,11 @@ module Neo4j
   #
   # == Configurations keys
   class Config
-    attr_writer :record_timestamps
     DEFAULT_FILE = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'config', 'neo4j', 'config.yml'))
     CLASS_NAME_PROPERTY_KEY = 'class_name_property'
 
     class << self
+      attr_writer :record_timestamps
       # @return [Fixnum] The location of the default configuration file.
       def default_file
         @default_file ||= DEFAULT_FILE

--- a/lib/neo4j/shared/declared_property.rb
+++ b/lib/neo4j/shared/declared_property.rb
@@ -33,10 +33,14 @@ module Neo4j::Shared
 
     # Tweaks properties
     def register_magic_properties
-      options[:type] ||= DateTime if name.to_sym == :created_at || name.to_sym == :updated_at
+      options[:type] ||= Neo4j::Config.timestamp_type if timestamp_prop?
 
       register_magic_typecaster
       register_type_converter
+    end
+
+    def timestamp_prop?
+      name.to_sym == :created_at || name.to_sym == :updated_at
     end
 
     def register_magic_typecaster

--- a/lib/neo4j/timestamps/created.rb
+++ b/lib/neo4j/timestamps/created.rb
@@ -3,9 +3,7 @@ module Neo4j
     # This mixin includes a created_at timestamp property
     module Created
       extend ActiveSupport::Concern
-      included do
-        property :created_at, type: DateTime
-      end
+      included { property :created_at }
     end
   end
 end

--- a/lib/neo4j/timestamps/updated.rb
+++ b/lib/neo4j/timestamps/updated.rb
@@ -3,9 +3,7 @@ module Neo4j
     # This mixin includes a updated_at timestamp property
     module Updated
       extend ActiveSupport::Concern
-      included do
-        property :updated_at, type: DateTime
-      end
+      included { property :updated_at }
     end
   end
 end

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -147,6 +147,41 @@ describe 'Neo4j::ActiveNode' do
     end
   end
 
+  describe 'global timestamps config' do
+    context 'default' do
+      before do
+        stub_active_node_class('NoTimestampsClass')
+        stub_active_node_class('ClassWithTimestampsIncluded') do
+          include Neo4j::Timestamps
+        end
+      end
+
+      it 'does not include timestamp properites on all models' do
+        node = NoTimestampsClass.new
+        expect(node).not_to be_a(Neo4j::Timestamps)
+      end
+
+      it 'allows timestamps to be manually included' do
+        node = ClassWithTimestampsIncluded.new
+        expect(node).to be_a(Neo4j::Timestamps)
+      end
+    end
+
+    context 'when record_timestamps is enabled' do
+      before do
+        Neo4j::Config.record_timestamps = true
+        stub_active_node_class('TimestampedClass')
+      end
+
+      after(:all) { Neo4j::Config.record_timestamps = false }
+
+      it 'includes timestamp properties on all models' do
+        node = TimestampedClass.new
+        expect(node).to be_a(Neo4j::Timestamps)
+      end
+    end
+  end
+
 
   describe 'callbacks' do
     before(:each) do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -96,5 +96,17 @@ describe Neo4j::Config do
         expect(Neo4j::Config.include_root_in_json).to be_falsey
       end
     end
+
+    describe 'timestamp_type' do
+      after(:all) { Neo4j::Config[:timestamp_type] = nil }
+      it 'defaults to DateTime' do
+        expect(Neo4j::Config.timestamp_type).to eq(DateTime)
+      end
+
+      it 'respects config' do
+        Neo4j::Config[:timestamp_type] = Integer
+        expect(Neo4j::Config.timestamp_type).to eq(Integer)
+      end
+    end
   end
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -83,6 +83,28 @@ describe Neo4j::Config do
         expect(Neo4j::Config.configuration).to eq('my_conf' => 'My value')
       end
     end
+
+    describe 'record_timestamps' do
+      let(:bool) { [true, false] }
+
+      it 'returns a boolean indicating if timestamps are included on all models' do
+        expect(bool.include?(Neo4j::Config.record_timestamps)).to be_truthy
+      end
+
+      it 'defaults to false' do
+        expect(Neo4j::Config.record_timestamps).to be_falsey
+      end
+    end
+
+    describe 'record_timestamps=' do
+      after(:all) { Neo4j::Config.record_timestamps = false }
+
+      it 'allows configuration of record_timestamps variable' do
+        expect(Neo4j::Config.record_timestamps).to be_falsey
+        Neo4j::Config.record_timestamps = true
+        expect(Neo4j::Config.record_timestamps).to be_truthy
+      end
+    end
   end
 
   describe 'options' do

--- a/spec/unit/shared/property_spec.rb
+++ b/spec/unit/shared/property_spec.rb
@@ -25,15 +25,28 @@ describe Neo4j::Shared::Property do
   end
 
   describe 'types for timestamps' do
-    context 'when type is undefined' do
+    context 'when type is undefined inline' do
       before do
         clazz.property :created_at
         clazz.property :updated_at
       end
 
-      it 'sets type to DateTime' do
+      it 'defaults to DateTime' do
         expect(clazz.attributes[:created_at][:type]).to eq(DateTime)
         expect(clazz.attributes[:updated_at][:type]).to eq(DateTime)
+      end
+
+      context '...and specified in config' do
+        before do
+          Neo4j::Config[:timestamp_type] = Integer
+          clazz.property :created_at
+          clazz.property :updated_at
+        end
+
+        it 'uses type set in config' do
+          expect(clazz.attributes[:created_at][:type]).to eq(Integer)
+          expect(clazz.attributes[:updated_at][:type]).to eq(Integer)
+        end
       end
     end
 


### PR DESCRIPTION
Hey there! In working with @subvertallchris at our day job, we realized one should be able to configure default timestamps globally from the config file. This PR makes it happen.

There are actually very few changes, since `DeclaredProperty#register_magic_property` already has a bit of timestamp-y logic. The default action is as it was before; timestamps will be `DateTime` unless told otherwise.