### PR TITLE
Return cached result for has_one relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- `has_one` associations are now properly cached (like `has_many` associations)
+
 ## [5.1.2] - 08-20-2015
 
 ### Fixed

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -380,7 +380,7 @@ module Neo4j::ActiveNode
           if options[:rel_length] && !options[:rel_length].is_a?(Fixnum)
             results
           else
-            results.first
+            results.result.first
           end
         end
       end

--- a/spec/e2e/has_one_spec.rb
+++ b/spec/e2e/has_one_spec.rb
@@ -40,6 +40,39 @@ describe 'has_one' do
       a.children.to_a.should =~ [b, c]
     end
 
+    it 'caches the result of has_one accessor' do
+      a = HasOneA.create(name: 'a')
+      b = HasOneB.create(name: 'b')
+      a.children << b
+
+      b = HasOneB.find(b.id)
+
+      expect_queries(1) do
+        b.parent.should eq(a)
+        b.parent.should eq(a)
+      end
+    end
+
+    it 'clears the cached result of a has_one accessor on reload' do
+      a = HasOneA.create(name: 'a')
+      b = HasOneB.create(name: 'b')
+      a.children << b
+
+      b = HasOneB.find(b.id)
+
+      expect_queries(1) do
+        b.parent.should eq(a)
+        b.parent.should eq(a)
+      end
+
+      b.reload
+
+      expect_queries(1) do
+        b.parent.should eq(a)
+        b.parent.should eq(a)
+      end
+    end
+
     it 'can create a relationship via the has_one accessor' do
       a = HasOneA.create(name: 'a')
       b = HasOneB.create(name: 'b')


### PR DESCRIPTION
We'll see if Travis tests pass - ideally I'd like to add a test to check if cached results are used, but I haven't figured out the test setup yet.

Before this PR:

```ruby
b = Book.find(book_id)
b.author # queries the database
b.author # queries the database again
```

After this PR:

```ruby
b = Book.find(book_id)
b.author # queries the database
b.author # returns the cached copy of the author

b.reload # reloads the book from the database
b.author # queries the database
b.author # returns the cached copy of the author
```