### PR TITLE
Add #to_ary to play nice with Active Model Seralizers

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -221,6 +221,8 @@ module Neo4j
           to_a.map { |o| o.read_attribute_for_serialization(*args) }
         end
 
+        delegate :to_ary, to: :to_a
+
         # QueryProxy objects act as a representation of a model at the class level so we pass through calls
         # This allows us to define class functions for reusable query chaining or for end-of-query aggregation/summarizing
         def method_missing(method_name, *args, &block)

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -77,6 +77,15 @@ describe 'Query API' do
 
       lesson.students.pluck(:uuid).should eq([student.uuid])
     end
+
+    it 'responds to to_ary' do
+      lesson = Lesson.create
+      student = Student.create
+      student.lessons << lesson
+
+      expect(student.lessons.to_ary).to be_instance_of(Array)
+      expect(student.lessons.to_ary).to eq(student.lessons.to_a)
+    end
   end
 
   describe 'association validation' do


### PR DESCRIPTION
This resolves #744.

Before: 
```ruby
render json: Model.all, serializer: ActiveModel::Serializer::ArraySerializer
```

After: 
```ruby
render json: Model.all
```