### PR TITLE
Boolean fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- `updated_at` properties were not being added up `update` events, only updated.
+- Default values of Boolean properties were not being set when `default: false`
+- `props_for_update` was using String keys instead of Symbols, like `props_for_update`
+- `props_for_create` and `props_for_update` were not adding default property values to the hash.
+- ActiveNode's `merge` and `find_or_create` methods were not setting default values of declared properties when `ON CREATE` was triggered. The code now uses `props_for_create`.
+
 ## [5.2.3] - 09-07-2015
 
 Added bugfixes from 5.1.4 and 5.1.5 that were missed in earlier 5.2.x releases:

--- a/lib/neo4j/shared/declared_property_manager.rb
+++ b/lib/neo4j/shared/declared_property_manager.rb
@@ -24,7 +24,7 @@ module Neo4j::Shared
       @_attributes_string_map = nil
       registered_properties[property.name] = property
       register_magic_typecaster(property) if property.magic_typecaster
-      declared_property_defaults[property.name] = property.default_value if property.default_value
+      declared_property_defaults[property.name] = property.default_value if !property.default_value.nil?
     end
 
     # The :default option in Neo4j::ActiveNode#property class method allows for setting a default value instead of

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -193,7 +193,7 @@ module Neo4j::Shared
     end
 
     def update_magic_properties
-      self.updated_at = DateTime.now if respond_to?(:updated_at=) && changed? && !updated_at_changed?
+      self.updated_at = DateTime.now if respond_to?(:updated_at=) && (updated_at.nil? || (changed? && !updated_at_changed?))
     end
 
     # Inserts the _classname property into an object's properties during object creation.

--- a/spec/e2e/property_management_spec.rb
+++ b/spec/e2e/property_management_spec.rb
@@ -51,6 +51,7 @@ describe 'declared property classes' do
         include Neo4j::ActiveNode
         property :foo
         property :bar, type: String, default: 'foo'
+        property :baz, type: ActiveAttr::Typecasting::Boolean, default: false
       end
 
       stub_const('MyModel', clazz)
@@ -114,26 +115,37 @@ describe 'declared property classes' do
         expect(node.bar).to eq 'foo'
       end
 
+      context 'with type: Boolean and default: false' do
+        it 'sets as expected' do
+          expect(node.baz).to eq false
+        end
+      end
+
       describe 'with changed values' do
         before do
           node.bar = value
+          node.baz = bool_value
           node.save
           node.reload
         end
 
         context 'on reload when prop was changed to nil' do
           let(:value) { nil }
+          let(:bool_value) { nil }
 
           it 'resets nil default properties on reload' do
             expect(node.bar).to eq 'foo'
+            expect(node.baz).to eq false
           end
         end
 
         context 'on reload when prop was set' do
           let(:value) { 'bar' }
+          let(:bool_value) { true }
 
           it 'does not reset to default' do
             expect(node.bar).to eq 'bar'
+            expect(node.baz).to eq true
           end
         end
       end

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -53,6 +53,7 @@ describe 'Query API' do
     stub_active_node_class('Teacher') do
       property :name
       property :age
+      property :status, default: 'active'
       property :created_at
       property :updated_at
 
@@ -254,12 +255,17 @@ describe 'Query API' do
         it 'also sets properties' do
           Teacher.find_or_create(name: 'Dr. Harold Samuels')
           expect(Teacher.count).to eq(1)
-          expect(Teacher.first.name).to eq('Dr. Harold Samuels')
-          expect(Teacher.first.age).to eq(nil)
+          samuels = Teacher.first
+          expect(samuels.name).to eq('Dr. Harold Samuels')
+          expect(samuels.age).to eq(nil)
+          expect(samuels.status).to eq('active')
+          expect(samuels._persisted_obj.props[:status]).to eq 'active'
+
           Teacher.find_or_create({name: 'Dr. Harold Samuels'}, age: 34)
           expect(Teacher.count).to eq(1)
-          expect(Teacher.first.name).to eq('Dr. Harold Samuels')
-          expect(Teacher.first.age).to eq(34)
+          samuels = Teacher.first
+          expect(samuels.name).to eq('Dr. Harold Samuels')
+          expect(samuels.age).to eq(34)
         end
 
         it 'sets the id property method' do

--- a/spec/integration/node_persistence_spec.rb
+++ b/spec/integration/node_persistence_spec.rb
@@ -106,7 +106,7 @@ describe 'Neo4j::ActiveNode' do
       thing = MyThing.create(a: 'foo', x: 44)
 
       # only change X
-      node.should_receive(:update_props).with('x' => 32)
+      node.should_receive(:update_props).with(x: 32)
       thing.x = 32
       thing.send(:update_model)
     end
@@ -115,7 +115,7 @@ describe 'Neo4j::ActiveNode' do
       session.should_receive(:create_node).with({a: 'foo', x: 44, uuid: 'secure123'}, [:MyThing]).and_return(node)
       thing = MyThing.create(a: 'foo', x: 44)
 
-      node.should_receive(:update_props).with('x' => nil)
+      node.should_receive(:update_props).with(x: nil)
       thing.x = nil
       thing.send(:update_model)
     end

--- a/spec/shared_examples/timestamped_model.rb
+++ b/spec/shared_examples/timestamped_model.rb
@@ -38,6 +38,14 @@ shared_examples_for 'timestamped model' do
         lambda { subject.update_attributes!(a: 1, b: 2) }.should change(subject, :updated_at)
       end
 
+      context 'with missing updated_at' do
+        it 'creates the property' do
+          subject._persisted_obj.remove_property('updated_at'.freeze)
+          subject.reload
+          expect { subject.save! }.to change { subject.updated_at }
+        end
+      end
+
       context 'with explicitly changed updated_at property' do
         it 'does not overwrite updated_at property' do
           subject.updated_at = Time.now

--- a/spec/shared_examples/timestamped_model.rb
+++ b/spec/shared_examples/timestamped_model.rb
@@ -40,7 +40,7 @@ shared_examples_for 'timestamped model' do
 
       context 'with missing updated_at' do
         it 'creates the property' do
-          subject._persisted_obj.remove_property('updated_at'.freeze)
+          Neo4j::Transaction.run { subject._persisted_obj.remove_property('updated_at'.freeze) }
           subject.reload
           expect { subject.save! }.to change { subject.updated_at }
         end


### PR DESCRIPTION
This fixes problems related to default values of `ActiveAttr::Typecasting::Boolean` properties. Along the way, I found that `updated_at` was not being added to nodes outside of `create` actions and `props_for_update` was using String keys while `props_for_create` had symbol keys.