### PR TITLE
QP type conversion edge cases

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy_link.rb
+++ b/lib/neo4j/active_node/query/query_proxy_link.rb
@@ -55,7 +55,7 @@ module Neo4j
                     elsif key == model.id_property_name && value.is_a?(Neo4j::ActiveNode)
                       value.id
                     else
-                      model.declared_property_manager.value_for_db(key, value)
+                      converted_value(model, key, value)
                     end
 
               new(:where, ->(v, _) { {v => {key => val}} })
@@ -75,7 +75,7 @@ module Neo4j
             def for_rel_where_clause(arg, _, association)
               arg.each_with_object([]) do |(key, value), result|
                 rel_class = association.relationship_class if association.relationship_class
-                val =  rel_class ? rel_class.declared_property_manager.value_for_db(key, value) : value
+                val =  rel_class ? converted_value(rel_class, key, value) : value
                 result << new(:where, ->(_, rel_var) { {rel_var => {key => val}} })
               end
             end
@@ -100,6 +100,10 @@ module Neo4j
               Link.for_clause(clause, arg, model, *args) || default
             rescue NoMethodError
               default
+            end
+
+            def converted_value(model, key, value)
+              model.declared_property_manager.value_for_where(key, value)
             end
           end
         end

--- a/lib/neo4j/shared/declared_property_manager.rb
+++ b/lib/neo4j/shared/declared_property_manager.rb
@@ -113,6 +113,13 @@ module Neo4j::Shared
       @upstream_primitives ||= {}
     end
 
+    EXCLUDED_TYPES = [Array, Range, Regexp]
+    def value_for_where(key, value)
+      return value unless prop = registered_properties[key]
+      return value_for_db(key, value) if prop.typecaster && prop.typecaster.convert_type == value.class
+      EXCLUDED_TYPES.include?(value.class) ? value : value_for_db(key, value)
+    end
+
     def value_for_db(key, value)
       return value unless registered_properties[key]
       convert_property(key, value, :to_db)

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -83,7 +83,7 @@ module Neo4j::Shared
         end
 
         def to_db(value)
-          value.is_a?(Regexp) ? value : value.to_s
+          value.to_s
         end
         alias_method :to_ruby, :to_db
       end

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -590,6 +590,7 @@ describe 'Neo4j::ActiveNode' do
 
   describe 'serialization' do
     let!(:chris) { Person.create(name: 'chris') }
+    let(:links) { {'neo4j' => 'http://www.neo4j.org', 'neotech' => 'http://www.neotechnology.com/'} }
 
     it 'correctly identifies properties for serialization' do
       expect(Person.serialized_properties).to include(:links)
@@ -597,28 +598,38 @@ describe 'Neo4j::ActiveNode' do
     end
 
     it 'successfully saves and returns hashes' do
-      links = {neo4j: 'http://www.neo4j.org', neotech: 'http://www.neotechnology.com/'}
       chris.links = links
       chris.save
       expect(chris.links).to eq links
-      expect(chris.links.class).to eq Hash
+      expect { chris.reload }.not_to change { chris.links }
     end
 
-    describe 'DateTime' do
-      before(:each) { Person.delete_all }
-
-      let(:datetime) { Time.new(2015, 1, 2, 3, 4, 5, '+06:00') }
-      let!(:person) { Person.create(name: 'DateTime', datetime: datetime) }
-
-      let(:datetime_db_value) do
-        Neo4j::Session.query.match(p: :Person)
-          .where(p: {neo_id: person.neo_id})
-          .pluck(p: :datetime).first
+    describe 'QueryProxy #where' do
+      before do
+        chris.links = links
+        chris.save
       end
 
-      it 'saves as date/time string by default' do
-        expect(datetime_db_value).to eq(1_420_146_245)
+      it 'serializes values given to #where' do
+        expect(Person.where(links: links).first.links).to eq links
       end
+    end
+  end
+
+  describe 'DateTime' do
+    before(:each) { Person.delete_all }
+
+    let(:datetime) { Time.new(2015, 1, 2, 3, 4, 5, '+06:00') }
+    let!(:person) { Person.create(name: 'DateTime', datetime: datetime) }
+
+    let(:datetime_db_value) do
+      Neo4j::Session.query.match(p: :Person)
+        .where(p: {neo_id: person.neo_id})
+        .pluck(p: :datetime).first
+    end
+
+    it 'saves as date/time string by default' do
+      expect(datetime_db_value).to eq(1_420_146_245)
     end
   end
 

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -658,6 +658,27 @@ describe 'Query API' do
             expect(Teacher.where(age: 1).to_cypher_with_params).to include(':result_teacher_age=>1')
           end
         end
+
+        context 'with Range values' do
+          before do
+            (1..10).each { |i| Student.create!(age: i) }
+          end
+
+          it 'does not convert' do
+            expect(Student.where(age: (2..5)).count).to eq 4
+          end
+        end
+
+        context 'with Array values' do
+          let(:today) { Date.today }
+
+          before { Teacher.create(date: today) }
+
+          it 'does not perform any conversion' do
+            expect(Teacher.where(date: [today]).count).to eq 0
+            expect(Teacher.where(date: [Time.utc(today.year, today.month, today.day).to_i]).count).to eq 1
+          end
+        end
       end
 
       context 'with properties not declared on the model' do

--- a/spec/e2e/typecasting_spec.rb
+++ b/spec/e2e/typecasting_spec.rb
@@ -33,15 +33,18 @@ describe 'custom type conversion' do
     end
   end
 
-  it 'registers the typecaster' do
+  it 'registers' do
     expect(Neo4j::Shared::TypeConverters.converters).to have_key(Range)
   end
 
-  it 'uses the custom typecaster' do
-    r = RangeConvertPerson.new
-    r.my_range = 1..30
-    r.save
-    r.reload
+  before { RangeConvertPerson.create!(my_range: 1..30) }
+  let(:r) { RangeConvertPerson.first }
+
+  it 'uses for persistence' do
     expect(r.my_range).to be_a(Range)
+  end
+
+  it 'uses for QueryProxy #where' do
+    expect(RangeConvertPerson.where(my_range: 1..30).first).to eq r
   end
 end


### PR DESCRIPTION
#963 pointed out that QueryProxy was attempting to convert `Regexp` to `String` and this made me realize it would have similar problems with `Range` and `Array`. There was an additional edge case: a user with a custom converter that could handle one of these types. 