### PR TITLE
Activerel class array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Support for Array arguments to ActiveRel's `from_class` and `to_class`.
+
+### Changed
+
+- Deprecated all methods in ActiveRel's Query module except for those that allow finding by id.
+
 ## [5.2.6] - 09-16-2015
 
 ### Fixed

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -60,11 +60,21 @@ module Neo4j::ActiveRel
         type = from_node == node ? :_from_class : :_to_class
         type_class = self.class.send(type)
 
-        next if [:any, false].include?(type_class)
-
-        unless node.class.mapped_label_names.include?(type_class.to_s.constantize.mapped_label_name)
+        unless valid_type?(type_class, node)
           fail ModelClassInvalidError, type_validation_error_message(node, type_class)
         end
+      end
+    end
+
+    def valid_type?(type_object, node)
+      case type_object
+      when false, :any
+        true
+      when Array
+        type_object.each { |c| return false unless valid_type?(c, node) }
+        true
+      else
+        node.class.mapped_label_names.include?(type_object.to_s.constantize.mapped_label_name)
       end
     end
 

--- a/lib/neo4j/active_rel/query.rb
+++ b/lib/neo4j/active_rel/query.rb
@@ -7,12 +7,14 @@ module Neo4j::ActiveRel
       # @param [String,Integer] id of node to find
       # @param [Neo4j::Session] session optional
       def find(id, session = self.neo4j_session)
+        deprecation_warning!
         fail "Unknown argument #{id.class} in find method (expected String or Integer)" if !(id.is_a?(String) || id.is_a?(Integer))
         find_by_id(id, session)
       end
 
       # Loads the relationship using its neo_id.
       def find_by_id(key, session = Neo4j::Session.current!)
+        deprecation_warning!
         session.query.match('()-[r]-()').where('ID(r)' => key.to_i).limit(1).return(:r).first.r
       end
 
@@ -41,11 +43,17 @@ module Neo4j::ActiveRel
 
       private
 
+      def deprecation_warning!
+        ActiveSupport::Deprecation.warn 'The Neo4j::ActiveRel::Query module has been deprecated and will be removed in a future version of the gem.', caller
+      end
+
       def where_query
+        deprecation_warning!
         Neo4j::Session.query.match("#{cypher_string(:outbound)}-[r1:`#{self._type}`]->#{cypher_string(:inbound)}")
       end
 
       def all_query
+        deprecation_warning!
         Neo4j::Session.query.match("#{cypher_string}-[r1:`#{self._type}`]->#{cypher_string(:inbound)}")
       end
 

--- a/lib/neo4j/active_rel/query.rb
+++ b/lib/neo4j/active_rel/query.rb
@@ -71,6 +71,8 @@ module Neo4j::ActiveRel
           given_class.constantize
         when Symbol
           given_class.to_s.constantize
+        when Array
+          fail "ActiveRel query methods are being deprecated and do not support Array (from|to)_class options. Current value: #{given_class}"
         else
           given_class
         end

--- a/lib/neo4j/active_rel/query.rb
+++ b/lib/neo4j/active_rel/query.rb
@@ -7,14 +7,12 @@ module Neo4j::ActiveRel
       # @param [String,Integer] id of node to find
       # @param [Neo4j::Session] session optional
       def find(id, session = self.neo4j_session)
-        deprecation_warning!
         fail "Unknown argument #{id.class} in find method (expected String or Integer)" if !(id.is_a?(String) || id.is_a?(Integer))
         find_by_id(id, session)
       end
 
       # Loads the relationship using its neo_id.
       def find_by_id(key, session = Neo4j::Session.current!)
-        deprecation_warning!
         session.query.match('()-[r]-()').where('ID(r)' => key.to_i).limit(1).return(:r).first.r
       end
 

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -236,6 +236,12 @@ describe 'ActiveRel' do
   end
 
   describe 'objects and queries' do
+    around do |ex|
+      ActiveSupport::Deprecation.silenced = true
+      ex.run
+      ActiveSupport::Deprecation.silenced = false
+    end
+
     let!(:rel1) { MyRelClass.create(from_node: from_node, to_node: to_node, score: 99) }
     let!(:rel2) { MyRelClass.create(from_node: from_node, to_node: to_node, score: 49) }
 

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -11,8 +11,6 @@ describe 'ActiveRel' do
 
     stub_active_node_class('FromClass') do
       has_many :out, :others, model_class: 'ToClass', rel_class: 'MyRelClass'
-
-      def foo; end
     end
 
     stub_active_node_class('ToClass') do


### PR DESCRIPTION
* Brings array options to `ActiveRel`'s `(from|to)_class`
* Deprecates all `ActiveRel` query methods.

Because query methods are deprecated, I did not modify them to support Array from/to. 

If you are using these methods and want to disable the deprecation warning, set `ActiveSupport::Deprecation.silenced = true`.