### PR TITLE
Return true on successful save! calls

### DIFF
--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -40,7 +40,7 @@ module Neo4j::ActiveNode
     # @see Neo4j::Rails::Validations Neo4j::Rails::Validations - for the :validate parameter
     # @see Neo4j::Rails::Callbacks Neo4j::Rails::Callbacks - for callbacks
     def save!(*args)
-      fail RecordInvalidError, self unless save(*args)
+      save(*args) || fail(RecordInvalidError, self)
     end
 
     # Creates a model with values matching those of the instance attributes and returns its id.

--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -40,7 +40,7 @@ module Neo4j::ActiveNode
     # @see Neo4j::Rails::Validations Neo4j::Rails::Validations - for the :validate parameter
     # @see Neo4j::Rails::Callbacks Neo4j::Rails::Callbacks - for callbacks
     def save!(*args)
-      save(*args) || fail(RecordInvalidError, self)
+      save(*args) or fail(RecordInvalidError, self) # rubocop:disable Style/AndOr
     end
 
     # Creates a model with values matching those of the instance attributes and returns its id.

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -12,7 +12,7 @@ module Neo4j::ActiveRel
     end
 
     def save!(*args)
-      fail RelInvalidError, self unless save(*args)
+      save(*args) || fail(RelInvalidError, self)
     end
 
     def create_model

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -12,7 +12,7 @@ module Neo4j::ActiveRel
     end
 
     def save!(*args)
-      save(*args) || fail(RelInvalidError, self)
+      save(*args) or fail(RelInvalidError, self) # rubocop:disable Style/AndOr
     end
 
     def create_model

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -200,7 +200,6 @@ describe 'Neo4j::ActiveNode' do
     end
   end
 
-
   describe 'callbacks' do
     before(:each) do
       stub_active_node_class('Company') do
@@ -380,7 +379,7 @@ describe 'Neo4j::ActiveNode' do
     end
   end
 
-  describe 'basic persistance' do
+  describe 'basic persistence' do
     it 'generate accessors for declared attribute' do
       person = Person.new(name: 'hej')
       expect(person.name).to eq('hej')

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -61,16 +61,21 @@ describe 'ActiveRel' do
       end
     end
 
-    describe '.create!' do
+    describe '#create!' do
       it 'raises an error on invalid params' do
         expect { RelClassWithValidations.create!(from_node: from_node, to_node: to_node) }.to raise_error Neo4j::ActiveRel::Persistence::RelInvalidError
       end
     end
 
-    describe '.save!' do
+    describe '#save!' do
       it 'raises an error on invalid params' do
         invalid_rel = RelClassWithValidations.new(from_node: from_node, to_node: to_node)
         expect { invalid_rel.save! }.to raise_error Neo4j::ActiveRel::Persistence::RelInvalidError
+      end
+
+      it 'returns true on success' do
+        rel = RelClassWithValidations.new(from_node: from_node, to_node: to_node, score: 2)
+        expect(rel.save!).to be true
       end
     end
 


### PR DESCRIPTION
For [consistency with ActiveRecord](http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-save-21), I've made it so ActiveNode and ActiveRel return `true` when `save!` does not error out.

## TODO

- [x] Not sure if it's worth fighting Rubocop for `or` instead of `||` -- is there a magic cookie?
