### PR TITLE
Fix String->Boolean type conversion

### DIFF
--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -97,13 +97,11 @@ module Neo4j::Shared
           convert_type.include?(value)
         end
 
-        def convert_type
-          [true, false]
-        end
-
         def db_type
           ActiveAttr::Typecasting::Boolean
         end
+
+        alias_method :convert_type, :db_type
 
         def to_db(value)
           return false if FALSE_VALUES.include?(value)

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -40,7 +40,8 @@ describe 'Query API' do
     stub_active_node_class('Student') do
       property :name
       property :age, type: Integer
-      property :likely_to_succeed, default: false
+
+      property :likely_to_succeed, type: ActiveAttr::Typecasting::Boolean, default: false
 
       has_many :out, :lessons, rel_class: 'IsEnrolledFor'
 

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -40,6 +40,7 @@ describe 'Query API' do
     stub_active_node_class('Student') do
       property :name
       property :age, type: Integer
+      property :likely_to_succeed, default: false
 
       has_many :out, :lessons, rel_class: 'IsEnrolledFor'
 
@@ -648,6 +649,7 @@ describe 'Query API' do
           expect(Teacher.where(datetime: datetime).to_cypher_with_params).to include(converted_datetime.to_s)
           expect(Teacher.where(time: time).to_cypher_with_params).to include(converted_time.to_s)
           expect(Teacher.where(age: '1').to_cypher_with_params).to include(':result_teacher_age=>1')
+          expect(Student.where(likely_to_succeed: 'false').to_cypher_with_params).to include(':result_student_likely_to_succeed=>false')
         end
 
         context '...and values already in the destination format' do
@@ -656,6 +658,7 @@ describe 'Query API' do
             expect(Teacher.where(datetime: converted_datetime).to_cypher_with_params).to include(converted_datetime.to_s)
             expect(Teacher.where(time: converted_time).to_cypher_with_params).to include(converted_time.to_s)
             expect(Teacher.where(age: 1).to_cypher_with_params).to include(':result_teacher_age=>1')
+            expect(Student.where(likely_to_succeed: false).to_cypher_with_params).to include(':result_student_likely_to_succeed=>false')
           end
         end
 


### PR DESCRIPTION
Following from #951, String to Boolean conversion is not working. After prodding around, I think the issue is that `Neo4j::Shared::TypeConverters#converters` has all class keys except `[true, false]` for bools. When you declare a property's `type` as `Boolean`, the `converted_property` method cannot locate the `BooleanConverter`.

This PR makes it so the `ActiveAttr::TypeCasting::Boolean` is registered as a converter by making `BooleanConverter#convert_type` return that class.

- [x] add failing spec
- [x] fix converter