### PR TITLE
Add missing require statement for cypher session

### DIFF
--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -11,6 +11,7 @@ require 'neo4j/version'
 
 require 'neo4j-core'
 require 'neo4j/core/query'
+require 'neo4j/core/cypher_session'
 require 'active_model'
 require 'active_support/concern'
 require 'active_support/core_ext/class/attribute.rb'


### PR DESCRIPTION
When I ran the specs on my machine I was getting  an uninitialized error:

```
       uninitialized constant Neo4j::Core::CypherSession
```

Fixes #999 for just neo4j 2.2x. If I use neo4j 2.3 there are 3-4 failing tests.

