### PR TITLE
fixes after_find and after_initialize callbacks, tweak touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- Fixed `#after_initialize` and `#after_find` callbacks.
+- The `#touch` method should to raise errors when unsuccessful and avoid `#attributes` for performance.
+
 ## [5.2.12] - 10-25-2015
 
 ### Fixed

--- a/lib/neo4j/active_node/labels.rb
+++ b/lib/neo4j/active_node/labels.rb
@@ -90,7 +90,7 @@ module Neo4j
                       find_by_id(map_id.call(id))
                     end
           fail Neo4j::RecordNotFound if result.blank?
-          result
+          result.tap { |r| find_callbacks!(r) }
         end
 
         # Finds the first record matching the specified conditions. There is no implied ordering so if order matters, you should specify it yourself.
@@ -246,6 +246,17 @@ module Neo4j
         # rubocop:enable Style/AccessorMethodName
 
         private
+
+        def find_callbacks!(result)
+          case result
+          when Neo4j::ActiveNode
+            result.run_callbacks(:find)
+          when Array
+            result.each { |r| find_callbacks!(r) }
+          else
+            result
+          end
+        end
 
         def label_for_model
           (self.name.nil? ? object_id.to_s.to_sym : decorated_label_name)

--- a/lib/neo4j/shared/callbacks.rb
+++ b/lib/neo4j/shared/callbacks.rb
@@ -9,8 +9,13 @@ module Neo4j
 
       included do
         include ActiveModel::Validations::Callbacks
+        # after_find is triggered by the `find` method defined in lib/neo4j/active_node/id_property.rb
         define_model_callbacks :initialize, :find, only: :after
         define_model_callbacks :save, :create, :update, :destroy, :touch
+      end
+
+      def initialize(args = nil)
+        run_callbacks(:initialize) { super }
       end
 
       def destroy #:nodoc:
@@ -25,7 +30,7 @@ module Neo4j
         tx.close if tx
       end
 
-      def touch(*) #:nodoc:
+      def touch #:nodoc:
         run_callbacks(:touch) { super }
       end
 

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -83,8 +83,8 @@ module Neo4j::Shared
     end
 
     def touch
-      fail "Cannot touch on a new record object" unless persisted?
-      update_attribute(:updated_at, Time.now) if attributes.key?('updated_at')
+      fail 'Cannot touch on a new record object' unless persisted?
+      update_attribute!(:updated_at, Time.now) if respond_to?(:updated_at=)
     end
 
     # Returns +true+ if the record is persisted, i.e. it's not a new record and it was not destroyed

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -185,51 +185,69 @@ describe 'Neo4j::ActiveNode' do
   describe 'callbacks' do
     before(:each) do
       stub_active_node_class('Company') do
-        attr_accessor :update_called, :save_called, :destroy_called, :validation_called
+        %w(find create save update destroy validation).each do |verb|
+          attr_reader :"before_#{verb}_called", :"after_#{verb}_called"
+        end
+
+        attr_reader :after_find_called, :after_initialize_called
+
         property :name
 
-        before_save do
-          @save_called = true
-        end
+        after_initialize { @after_initialize_called = true }
+        after_find { @after_find_called = true }
 
-        before_update do
-          @update_called = true
-        end
-
-        before_destroy do
-          @destroy_called = true
-        end
-
-        before_validation do
-          @validation_called = true
-        end
+        before_create { @before_create_called = true }
+        after_create { @after_create_called = true }
+        before_save { @before_save_called = true }
+        after_save { @after_save_called = true }
+        before_update { @before_update_called = true }
+        after_update { @after_update_called = true }
+        before_destroy { @before_destroy_called = true }
+        after_destroy { @after_destroy_called = true }
+        before_validation { @before_validation_called = true }
+        after_validation { @after_validation_called = true }
       end
     end
 
-    it 'handles before_save callbacks' do
-      c = Company.new
-      c.save_called.should be_nil
-      c.save
-      c.save_called.should be true
+    def true_results?(node, verb)
+      [node.send("before_#{verb}_called"), node.send("after_#{verb}_called")].all? { |r| r == true }
     end
 
-    it 'handles before_update callbacks' do
-      c = Company.create
-      c.update(name: 'foo')
-      expect(c.update_called).to be true
+    context 'unpersited objects' do
+      let(:c) { Company.new }
+
+      it 'handles after_initialize callbacks' do
+        expect_any_instance_of(Company).to receive(:run_callbacks).with(:initialize)
+        c
+      end
+
+      it 'handles before_save callbacks' do
+        expect { c.save }.to change { true_results?(c, :save) }.from(false).to(true)
+      end
+
+      it 'handles before_validation callbacks' do
+        expect { c.valid? }.to change { true_results?(c, :validation) }.from(false).to(true)
+      end
     end
 
-    it 'handles before_destroy callbacks' do
-      c = Company.create
-      c.destroy
-      expect(c.destroy_called).to be true
+    context 'on persisted objects' do
+      let(:c) { Company.create }
+
+      # Because this stems from a class method, we demonstrate that it is called on objects resulting from Model.find
+      it 'handles found callbacks' do
+        expect(c.after_find_called).not_to eq true
+        expect(Company.find(c.id).after_find_called).to eq true
+      end
+
+      it 'handles update callbacks' do
+        expect { c.update(name: 'foo') }.to change { true_results?(c, :update) }
+      end
+
+      it 'handles destroy callbacks' do
+        expect { c.destroy }.to change { true_results?(c, :destroy) }
+      end
     end
 
-    it 'handles before_validation callbacks' do
-      #      skip
-      c = Company.create
-      expect(c.validation_called).to be true
-    end
 
     context 'that raise errors' do
       before do
@@ -237,39 +255,41 @@ describe 'Neo4j::ActiveNode' do
       end
 
       it 'rolls back node creation' do
-        starting_count = Company.count
-        expect { Company.create }.not_to raise_error
-        expect(Company.count).not_to eq starting_count
-        starting_count += 1
+        expect do
+          expect { Company.create }.not_to raise_error
+        end.to change { Company.count }
 
         Company.after_create { fail }
-        expect { Company.create }.to raise_error
-        expect(Company.count).to eq starting_count
+        expect do
+          expect { Company.create }.to raise_error
+        end.not_to change { Company.count }
       end
 
       it 'rolls back node update' do
         c = Company.create(name: 'Daylight Dies')
         expect(c.name).to eq 'Daylight Dies'
         c.name = 'Katatonia'
-        expect { c.save }.not_to raise_error
-        expect(c.name).to eq 'Katatonia'
+        expect do
+          expect { c.save }.not_to raise_error
+        end.not_to change { c.name }.from('Katatonia')
+
         Company.after_update { fail }
 
         c.name = 'October Tide'
-        expect { c.save }.to raise_error
-        c.reload
-        expect(c.name).to eq 'Katatonia'
+        expect do
+          expect { c.save }.to raise_error
+          c.reload
+        end.to change { c.name }.from('October Tide').to('Katatonia')
       end
 
       it 'rolls back node destroy' do
         c = Company.create(name: 'Foo')
-        expect(c).to be_persisted
-        expect { c.destroy }.not_to raise_error
-        expect(c).not_to be_persisted
+        expect { expect { c.destroy }.not_to raise_error }.to change { c.persisted? }.from(true).to(false)
+
         Company.after_destroy { fail }
         c = Company.create(name: 'Foo')
-        expect { c.destroy }.to raise_error
-        expect(c).to be_persisted
+
+        expect { expect { c.destroy }.to raise_error }.not_to change { c.persisted? }.from(true)
         expect(c).not_to be_frozen
         expect(c).not_to be_changed
       end

--- a/spec/unit/active_rel/callbacks_spec.rb
+++ b/spec/unit/active_rel/callbacks_spec.rb
@@ -5,47 +5,45 @@ describe Neo4j::ActiveRel::Callbacks do
   let(:node1) { double('Node1') }
   let(:node2) { double('Node2') }
 
-  before do
-    @session = double('Mock Session')
-    Neo4j::Session.stub(:current).and_return(@session)
-    clazz.stub(:neo4j_session).and_return(session)
-  end
-
   class Foo
+    def initialize(_args = nil); end
+
     def save(*)
       true
     end
   end
 
-  let(:clazz) do
-    class MyBar < Foo
-      include Neo4j::ActiveRel::Callbacks
-    end
+  class Bar < Foo
+    include Neo4j::ActiveRel::Callbacks
   end
 
   describe 'save' do
-    let(:rel) { clazz.new }
+    let(:rel) { Bar.new }
 
     before do
-      clazz.any_instance.stub(:_persisted_obj).and_return(nil)
-      clazz.any_instance.stub_chain('errors.full_messages').and_return([])
+      @session = double('Mock Session')
+      Neo4j::Session.stub(:current).and_return(@session)
+      Bar.stub(:neo4j_session).and_return(session)
+
+      Bar.any_instance.stub(:_persisted_obj).and_return(nil)
+      Bar.any_instance.stub_chain('errors.full_messages').and_return([])
     end
 
     it 'raises an error if unpersisted and outbound is not valid' do
-      clazz.any_instance.stub_chain('to_node.neo_id')
-      clazz.any_instance.stub_chain('from_node').and_return(nil)
+      Bar.any_instance.stub_chain('to_node.neo_id')
+      Bar.any_instance.stub_chain('from_node').and_return(nil)
       expect { rel.save }.to raise_error(Neo4j::ActiveRel::Persistence::RelInvalidError)
     end
 
     it 'raises an error if unpersisted and inbound is not valid' do
-      clazz.any_instance.stub_chain('from_node.neo_id')
-      clazz.any_instance.stub_chain('to_node').and_return(nil)
+      Bar.any_instance.stub_chain('from_node.neo_id')
+      Bar.any_instance.stub_chain('to_node').and_return(nil)
       expect { rel.save }.to raise_error(Neo4j::ActiveRel::Persistence::RelInvalidError)
     end
 
     it 'does not raise an error if inbound and outbound are valid' do
-      clazz.any_instance.stub_chain('from_node.neo_id')
-      clazz.any_instance.stub_chain('to_node.neo_id')
+      Bar.any_instance.stub_chain('from_node.neo_id')
+      Bar.any_instance.stub_chain('to_node.neo_id')
       expect { rel.save }.not_to raise_error
     end
   end


### PR DESCRIPTION
Fixes #997. The only changes to `touch` are the use of `update_attributes!` so it raises an error and using `respond_to?` instead of ActiveAttr's expensive `attributes`.