### PR TITLE
set default property values after init and again before save

### DIFF
--- a/lib/neo4j/shared/declared_properties.rb
+++ b/lib/neo4j/shared/declared_properties.rb
@@ -155,6 +155,13 @@ module Neo4j::Shared
       convert_property(key, value, :to_ruby)
     end
 
+    def inject_defaults!(object, props)
+      declared_property_defaults.each_pair do |k, v|
+        props[k.to_sym] = v if object.send(k).nil?
+      end
+      props
+    end
+
     protected
 
     # Prevents repeated calls to :_attribute_type, which isn't free and never changes.

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -25,9 +25,9 @@ module Neo4j::Shared
     # @return [Hash]
     def props_for_create
       inject_timestamps!
-      converted_props = props_for_db(props)
+      props_with_defaults = inject_defaults!(props)
+      converted_props = props_for_db(props_with_defaults)
       inject_classname!(converted_props)
-      inject_defaults!(converted_props)
       return converted_props unless self.class.respond_to?(:default_property_values)
       inject_primary_key!(converted_props)
     end

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -37,8 +37,8 @@ module Neo4j::Shared
       update_magic_properties
       changed_props = attributes.select { |k, _| changed_attributes.include?(k) }
       changed_props.symbolize_keys!
-      props_for_db(changed_props)
       inject_defaults!(changed_props)
+      props_for_db(changed_props)
     end
 
     # Convenience method to set attribute and #save at the same time
@@ -204,12 +204,7 @@ module Neo4j::Shared
       self.updated_at ||= now if respond_to?(:updated_at=)
     end
 
-    def inject_defaults!(properties)
-      self.class.declared_properties.declared_property_defaults.each_pair do |k, v|
-        properties[k.to_sym] = v if send(k).nil?
-      end
-      properties
-    end
+
 
     def set_timestamps
       warning = 'This method has been replaced with `inject_timestamps!` and will be removed in a future version'.freeze

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -19,11 +19,16 @@ module Neo4j::Shared
     def initialize(attributes = nil)
       attributes = process_attributes(attributes)
       @relationship_props = self.class.extract_association_attributes!(attributes)
-      writer_method_props = extract_writer_methods!(attributes)
-      validate_attributes!(attributes)
+      modded_attributes = inject_defaults!(attributes)
+      validate_attributes!(modded_attributes)
+      writer_method_props = extract_writer_methods!(modded_attributes)
       send_props(writer_method_props)
-
       @_persisted_obj = nil
+    end
+
+    def inject_defaults!(starting_props)
+      return starting_props if self.class.declared_properties.declared_property_defaults.empty?
+      self.class.declared_properties.inject_defaults!(self, starting_props || {})
     end
 
     # Returning nil when we get ActiveAttr::UnknownAttributeError from ActiveAttr
@@ -36,7 +41,7 @@ module Neo4j::Shared
 
     def send_props(hash)
       return hash if hash.blank?
-      hash.each { |key, value| self.send("#{key}=", value) }
+      hash.each { |key, value| send("#{key}=", value) }
     end
 
     protected
@@ -53,6 +58,7 @@ module Neo4j::Shared
 
     # Changes attributes hash to remove relationship keys
     # Raises an error if there are any keys left which haven't been defined as properties on the model
+    # TODO: use declared_properties instead of self.attributes
     def validate_attributes!(attributes)
       return attributes if attributes.blank?
       invalid_properties = attributes.keys.map(&:to_s) - self.attributes.keys

--- a/spec/e2e/property_management_spec.rb
+++ b/spec/e2e/property_management_spec.rb
@@ -152,12 +152,12 @@ describe 'declared property classes' do
         it { should eq false }
 
         context 'model from new with attributes' do
-          let(:node) { n = nil; trace_execution(8) { n = MyModel.new }; n }
+          let(:node) { MyModel.new }
           it { should eq false }
         end
 
         context 'model from new with attributes' do
-          let(:node) { n = nil; trace_execution(8) { n = MyModel.new(foo: 'foo') }; n }
+          let(:node) { MyModel.new(foo: 'foo') }
           it { should eq false }
         end
 
@@ -190,24 +190,21 @@ describe 'declared property classes' do
       context 'with changed values' do
         before do
           node.bar = value
-          node.baz = bool_value
-          node.save
+          node.baz = true
+          node.save!
           node.reload
         end
 
         context 'on reload when prop was changed to nil' do
           let(:value) { nil }
-          let(:bool_value) { nil }
 
           it 'resets nil default properties on reload' do
             expect(node.bar).to eq 'foo'
-            expect(node.baz).to eq false
           end
         end
 
         context 'on reload when prop was set' do
           let(:value) { 'bar' }
-          let(:bool_value) { true }
 
           it 'does not reset to default' do
             expect(node.bar).to eq 'bar'

--- a/spec/unit/active_rel/callbacks_spec.rb
+++ b/spec/unit/active_rel/callbacks_spec.rb
@@ -13,37 +13,37 @@ describe Neo4j::ActiveRel::Callbacks do
     end
   end
 
-  class Bar < Foo
+  class CallbackBar < Foo
     include Neo4j::ActiveRel::Callbacks
   end
 
   describe 'save' do
-    let(:rel) { Bar.new }
+    let(:rel) { CallbackBar.new }
 
     before do
       @session = double('Mock Session')
       Neo4j::Session.stub(:current).and_return(@session)
-      Bar.stub(:neo4j_session).and_return(session)
+      CallbackBar.stub(:neo4j_session).and_return(session)
 
-      Bar.any_instance.stub(:_persisted_obj).and_return(nil)
-      Bar.any_instance.stub_chain('errors.full_messages').and_return([])
+      CallbackBar.any_instance.stub(:_persisted_obj).and_return(nil)
+      CallbackBar.any_instance.stub_chain('errors.full_messages').and_return([])
     end
 
     it 'raises an error if unpersisted and outbound is not valid' do
-      Bar.any_instance.stub_chain('to_node.neo_id')
-      Bar.any_instance.stub_chain('from_node').and_return(nil)
+      CallbackBar.any_instance.stub_chain('to_node.neo_id')
+      CallbackBar.any_instance.stub_chain('from_node').and_return(nil)
       expect { rel.save }.to raise_error(Neo4j::ActiveRel::Persistence::RelInvalidError)
     end
 
     it 'raises an error if unpersisted and inbound is not valid' do
-      Bar.any_instance.stub_chain('from_node.neo_id')
-      Bar.any_instance.stub_chain('to_node').and_return(nil)
+      CallbackBar.any_instance.stub_chain('from_node.neo_id')
+      CallbackBar.any_instance.stub_chain('to_node').and_return(nil)
       expect { rel.save }.to raise_error(Neo4j::ActiveRel::Persistence::RelInvalidError)
     end
 
     it 'does not raise an error if inbound and outbound are valid' do
-      Bar.any_instance.stub_chain('from_node.neo_id')
-      Bar.any_instance.stub_chain('to_node.neo_id')
+      CallbackBar.any_instance.stub_chain('from_node.neo_id')
+      CallbackBar.any_instance.stub_chain('to_node.neo_id')
       expect { rel.save }.not_to raise_error
     end
   end


### PR DESCRIPTION
Fixes failing specs RE: defaults not set when initializing with hash.

Before, we were only setting default values during save. Missing keys or nil values were automatically set.

Now, we perform that check once during init and then again before save. The first ensures that validations work, the second is a sanity check in case defaults were changed to `nil` at some point.

There is still one failing spec that is related to Neo4j 2.3.0.