### PR TITLE
Activerel inspect

### DIFF
--- a/lib/neo4j/active_rel.rb
+++ b/lib/neo4j/active_rel.rb
@@ -27,16 +27,13 @@ module Neo4j
       attribute_descriptions = attribute_pairs.join(', ')
       separator = ' ' unless attribute_descriptions.empty?
 
-      cypher_representation = "#{node_cypher_representation(from_node)}-[:#{type}]->#{node_cypher_representation(to_node)}"
+      cypher_representation = "#{node_cypher_representation(:from)}-[:#{type}]->#{node_cypher_representation(:to)}"
       "#<#{self.class.name} #{cypher_representation}#{separator}#{attribute_descriptions}>"
     end
 
-    def node_cypher_representation(node)
-      node_class = node.class
-      id_name = node_class.id_property_name
-      labels = ':' + node_class.mapped_label_names.join(':')
-
-      "(#{labels} {#{id_name}: #{node.id.inspect}})"
+    def node_cypher_representation(direction)
+      node = send(:"#{direction}_node")
+      node.cypher_representation(self.class.send(:"#{direction}_class"))
     end
 
     def neo4j_obj

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -220,6 +220,18 @@ describe 'ActiveRel' do
         end
       end
     end
+
+    context 'with set, unloaded from_node/to_node' do
+      let(:new_rel) { MyRelClass.create(from_node: from_node, to_node: to_node) }
+      let(:reloaded) { Neo4j::Relationship.load(new_rel.id) }
+      let(:inspected) { reloaded.inspect }
+
+      it 'notes the ids of the nodes' do
+        [from_node.neo_id, to_node.neo_id].each do |id|
+          expect(inspected).to include("(Node with neo_id #{id})")
+        end
+      end
+    end
   end
 
   describe 'objects and queries' do

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -196,6 +196,32 @@ describe 'ActiveRel' do
     end
   end
 
+  describe '#inspect' do
+    context 'with unset from_node/to_node' do
+      let(:new_rel) { MyRelClass.new }
+
+      it 'does not raise an error' do
+        expect(new_rel.from_node).not_to receive(:loaded)
+        expect(new_rel.to_node).not_to receive(:loaded)
+        expect { new_rel.inspect }.not_to raise_error
+      end
+
+      context 'single from/to class' do
+        it 'inserts the class names in String' do
+          expect(new_rel.inspect).to include('(FromClass)-[:rel_class_type]->(ToClass)')
+        end
+      end
+
+      context 'array of from/to class' do
+        before { MyRelClass.from_class([FromClass, ToClass]) }
+
+        it 'joins with ||' do
+          expect(new_rel.inspect).to include('(FromClass || ToClass)-[:rel_class_type]->(ToClass)')
+        end
+      end
+    end
+  end
+
   describe 'objects and queries' do
     let!(:rel1) { MyRelClass.create(from_node: from_node, to_node: to_node, score: 99) }
     let!(:rel2) { MyRelClass.create(from_node: from_node, to_node: to_node, score: 49) }

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -226,7 +226,9 @@ describe 'ActiveRel' do
       let(:reloaded) { Neo4j::Relationship.load(new_rel.id) }
       let(:inspected) { reloaded.inspect }
 
+      # Neo4j Embedded always returns nodes with rels. This is only possible in Server mode.
       it 'notes the ids of the nodes' do
+        next if Neo4j::Session.current.db_type == :embedded_db
         [from_node.neo_id, to_node.neo_id].each do |id|
           expect(inspected).to include("(Node with neo_id #{id})")
         end


### PR DESCRIPTION
This will fix https://github.com/neo4jrb/neo4j/issues/1024 and prevent extra queries to load node information during `#inspect`. It will provide as many details as it can: if the nodes are present, it uses them; if it only knows the neo_ids, it uses those; otherwise, it lists the permissible classes.