### PR TITLE
Neo4j does not always return rels in the same order that they were set

### DIFF
--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -92,11 +92,14 @@ describe 'Association Proxy' do
 
   describe 'issue reported by @andrewhavens in #881' do
     it 'does not break' do
-      l1 = Lesson.create.tap { |l| l.exams_given = [Exam.create] }
-      l2 = Lesson.create.tap { |l| l.exams_given = [Exam.create, Exam.create] }
-      student = Student.create.tap { |s| s.lessons = [l1, l2] }
+      l1 = Lesson.create!.tap { |l| l.exams_given = [Exam.create!] }
+      l2 = Lesson.create!.tap { |l| l.exams_given = [Exam.create!, Exam.create!] }
+      student = Student.create!.tap { |s| s.lessons = [l1, l2] }
+      totals = {l1.id => l1.exams_given.count, l2.id => l2.exams_given.count}
 
-      expect(student.lessons.map { |l| l.exams_given.count }).to eq([1, 2])
+      student.lessons.each do |l|
+        expect(totals[l.id]).to eq l.exams_given.count
+      end
     end
   end
 


### PR DESCRIPTION
Fixes tests failing occasionally in Neo4j 2.3.0.