### PR TITLE
ActiveRel#create and #create! three-arg syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleaed]
+
+### Added
+
+- Optional three-argument signature for `ActiveRel#create` and `#create!`, just like `initialize`.
+
 ## [6.0.0.alpha.11] - 11-3-2015
 
 ### Fixed

--- a/lib/neo4j/active_rel.rb
+++ b/lib/neo4j/active_rel.rb
@@ -56,15 +56,12 @@ module Neo4j
 
     module ClassMethods
       [:create, :create!].each do |meth|
-        define_method(meth) do |from_node_or_args = nil, to_node = nil, args = {}|
-          super_args = case from_node_or_args
-                       when Hash
-                         from_node_or_args
-                       else
-                         args_with_node!(:from_node, from_node_or_args, args)
-                         args_with_node!(:to_node, to_node, args)
-                       end
-          super(super_args)
+        define_method(meth) do |from_node_or_args = nil, to_node = nil, args = nil|
+          return super(from_node_or_args) if from_node_or_args.is_a?(Hash)
+          args_hash = args || {}
+          args_with_node!(:from_node, from_node_or_args, args_hash)
+          args_with_node!(:to_node, to_node, args_hash)
+          super(args_hash)
         end
       end
 

--- a/lib/neo4j/active_rel.rb
+++ b/lib/neo4j/active_rel.rb
@@ -53,5 +53,27 @@ module Neo4j
     def hash_or_nil(node_or_hash, hash_or_nil)
       node_or_hash.is_a?(Hash) ? node_or_hash : hash_or_nil
     end
+
+    module ClassMethods
+      [:create, :create!].each do |meth|
+        define_method(meth) do |from_node_or_args = nil, to_node = nil, args = {}|
+          super_args = case from_node_or_args
+                       when Hash
+                         from_node_or_args
+                       else
+                         args_with_node!(:from_node, from_node_or_args, args)
+                         args_with_node!(:to_node, to_node, args)
+                       end
+          super(super_args)
+        end
+      end
+
+      private
+
+      def args_with_node!(key, node, args)
+        args[key] = node if node.is_a?(Neo4j::ActiveNode)
+        args
+      end
+    end
   end
 end

--- a/lib/neo4j/active_rel/related_node.rb
+++ b/lib/neo4j/active_rel/related_node.rb
@@ -29,7 +29,7 @@ module Neo4j::ActiveRel
 
     # Loads a node from the database or returns the node if already laoded
     def loaded
-      fail NilRelatedNodeError, 'Node not set, cannot load' if @node.nil?
+      fail UnsetRelatedNodeError, 'Node not set, cannot load' if @node.nil?
       @node = @node.respond_to?(:neo_id) ? @node : Neo4j::Node.load(@node)
     end
 

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -90,10 +90,25 @@ describe 'ActiveRel' do
       end
     end
 
+    shared_context 'three-argument ActiveRel create/create!' do |meth|
+      it 'is valid syntax' do
+        rel = RelClassWithValidations.send(meth, from_node, to_node, score: 9000)
+        expect(rel).to be_persisted
+        expect(rel.from_node).to eq from_node
+        expect(rel.to_node).to eq to_node
+      end
+    end
+
+    describe '#create' do
+      it_behaves_like 'three-argument ActiveRel create/create!', :create
+    end
+
     describe '#create!' do
       it 'raises an error on invalid params' do
         expect { RelClassWithValidations.create!(from_node: from_node, to_node: to_node) }.to raise_error Neo4j::ActiveRel::Persistence::RelInvalidError
       end
+
+      it_behaves_like 'three-argument ActiveRel create/create!', :create!
     end
 
     describe '#save!' do

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -91,11 +91,26 @@ describe 'ActiveRel' do
     end
 
     shared_context 'three-argument ActiveRel create/create!' do |meth|
-      it 'is valid syntax' do
-        rel = RelClassWithValidations.send(meth, from_node, to_node, score: 9000)
+      def is_persisted_with_nodes(rel)
         expect(rel).to be_persisted
         expect(rel.from_node).to eq from_node
         expect(rel.to_node).to eq to_node
+      end
+
+      context 'node, node, hash' do
+        it { is_persisted_with_nodes(MyRelClass.send(meth, from_node, to_node, {})) }
+      end
+
+      context 'node, node, nil' do
+        it { is_persisted_with_nodes MyRelClass.send(meth, from_node, to_node, nil) }
+      end
+
+      context 'nil, nil, hash' do
+        it { is_persisted_with_nodes MyRelClass.send(meth, nil, nil, {from_node: from_node, to_node: to_node}) }
+      end
+
+      context 'hash, nil, nil' do
+        it { is_persisted_with_nodes MyRelClass.send(meth, {from_node: from_node, to_node: to_node}, nil ,nil) }
       end
     end
 

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -91,11 +91,13 @@ describe 'ActiveRel' do
     end
 
     shared_context 'three-argument ActiveRel create/create!' do |meth|
+      # rubocop:disable Style/PredicateName
       def is_persisted_with_nodes(rel)
         expect(rel).to be_persisted
         expect(rel.from_node).to eq from_node
         expect(rel.to_node).to eq to_node
       end
+      # rubocop:enable Style/PredicateName
 
       context 'node, node, hash' do
         it { is_persisted_with_nodes(MyRelClass.send(meth, from_node, to_node, {})) }
@@ -106,11 +108,11 @@ describe 'ActiveRel' do
       end
 
       context 'nil, nil, hash' do
-        it { is_persisted_with_nodes MyRelClass.send(meth, nil, nil, {from_node: from_node, to_node: to_node}) }
+        it { is_persisted_with_nodes MyRelClass.send(meth, nil, nil, from_node: from_node, to_node: to_node) }
       end
 
       context 'hash, nil, nil' do
-        it { is_persisted_with_nodes MyRelClass.send(meth, {from_node: from_node, to_node: to_node}, nil ,nil) }
+        it { is_persisted_with_nodes MyRelClass.send(meth, {from_node: from_node, to_node: to_node}, nil, nil) }
       end
     end
 

--- a/spec/unit/active_rel/related_node_spec.rb
+++ b/spec/unit/active_rel/related_node_spec.rb
@@ -32,6 +32,14 @@ describe Neo4j::ActiveRel::RelatedNode do
         r.loaded
         expect(r.instance_variable_get(:@node)).to eq node1
       end
+
+      context 'with @node unset' do
+        let(:r) { RelatedNode.new(nil) }
+
+        it 'raises' do
+          expect { r.loaded }.to raise_error Neo4j::ActiveRel::RelatedNode::UnsetRelatedNodeError
+        end
+      end
     end
 
     describe 'loaded?' do


### PR DESCRIPTION
Just like `initialize`, only a little less efficient (one allocation) because it's not often that someone needs to _create_ enough rels at once that it becomes an issue.