### PR TITLE
QueryProxy#<< w/ActiveRel set will use create!

### DIFF
--- a/lib/neo4j/active_node/has_n/association/rel_factory.rb
+++ b/lib/neo4j/active_node/has_n/association/rel_factory.rb
@@ -28,7 +28,7 @@ module Neo4j::ActiveNode::HasN
       def _create_relationship_with_rel_class
         Array(other_node_or_nodes).each do |other_node|
           node_props = _nodes_for_create(other_node, :from_node, :to_node)
-          association.relationship_class.create(properties.merge(node_props))
+          association.relationship_class.create!(properties.merge(node_props))
         end
       end
 

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -33,7 +33,7 @@ module Neo4j::ActiveRel
     end
 
     def save!(*args)
-      save(*args) or fail(RelInvalidError, self) # rubocop:disable Style/AndOr
+      save(*args) or fail(RelInvalidError, inspect) # rubocop:disable Style/AndOr
     end
 
     def create_model


### PR DESCRIPTION
Closes #1045 but I'm not sure that this is the way to go. Users need to know if their relationships are failing, but it should probably return a Boolean so you can look for it instead of having to rescue from an error. Maybe we should have a config setting that will use `create!` every time, if that's what the user wants. @cheerfulstoic, thoughts?