### PR TITLE
Fix ActiveRel#reload

### DIFF
--- a/lib/neo4j/active_node/initialize.rb
+++ b/lib/neo4j/active_node/initialize.rb
@@ -13,4 +13,9 @@ module Neo4j::ActiveNode::Initialize
     changed_attributes && changed_attributes.clear
     @attributes = convert_and_assign_attributes(properties)
   end
+
+  def init_on_reload(reloaded)
+    @attributes = nil
+    init_on_load(reloaded, reloaded.props)
+  end
 end

--- a/lib/neo4j/active_rel/initialize.rb
+++ b/lib/neo4j/active_rel/initialize.rb
@@ -19,8 +19,8 @@ module Neo4j::ActiveRel
     def init_on_reload(unwrapped_reloaded)
       @attributes = nil
       init_on_load(unwrapped_reloaded,
-                   unwrapped_reloaded.start_node_neo_id,
-                   unwrapped_reloaded.end_node_neo_id,
+                   unwrapped_reloaded._start_node_id,
+                   unwrapped_reloaded._end_node_id,
                    unwrapped_reloaded.rel_type)
       self
     end

--- a/lib/neo4j/active_rel/initialize.rb
+++ b/lib/neo4j/active_rel/initialize.rb
@@ -15,5 +15,14 @@ module Neo4j::ActiveRel
       @attributes = convert_and_assign_attributes(persisted_rel.props)
       load_nodes(from_node_id, to_node_id)
     end
+
+    def init_on_reload(unwrapped_reloaded)
+      @attributes = nil
+      init_on_load(unwrapped_reloaded,
+                   unwrapped_reloaded.start_node_neo_id,
+                   unwrapped_reloaded.end_node_neo_id,
+                   unwrapped_reloaded.rel_type)
+      self
+    end
   end
 end

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -72,6 +72,10 @@ module Neo4j::ActiveRel
       def create_method
         creates_unique? ? :create_unique : :create
       end
+
+      def load_entity(id)
+        Neo4j::Relationship.load(id)
+      end
     end
 
     def create_method

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -137,11 +137,8 @@ module Neo4j::Shared
     end
 
     def reload_from_database
-      # TODO: - Neo4j::IdentityMap.remove_node_by_id(neo_id)
-      if reloaded = self.class.load_entity(neo_id)
-        send(:attributes=, reloaded.attributes)
-      end
-      reloaded
+      reloaded = self.class.load_entity(neo_id)
+      reloaded ? init_on_reload(reloaded._persisted_obj) : nil
     end
 
     # Updates this resource with all the attributes from the passed-in Hash and requests that the record be saved.

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -53,6 +53,11 @@ module Neo4j::Shared
       hash.each { |key, value| send("#{key}=", value) }
     end
 
+    def reload_properties!(properties)
+      @attributes = nil
+      convert_and_assign_attributes(properties)
+    end
+
     protected
 
     # This method is defined in ActiveModel.

--- a/spec/e2e/persistence_spec.rb
+++ b/spec/e2e/persistence_spec.rb
@@ -23,3 +23,24 @@ describe Neo4j::ActiveNode do
     end
   end
 end
+
+describe Neo4j::ActiveRel do
+  before do
+    stub_active_node_class('Person') do
+      property :name
+    end
+    stub_active_rel_class('FriendsWith') do
+      from_class false
+      to_class false
+      property :level
+    end
+  end
+
+  let(:rel) { FriendsWith.create(Person.new(name: 'Chris'), Person.new(name: 'Lauren'), level: 1) }
+
+  it 'reloads' do
+    expect(rel.level).to eq 1
+    rel.level = 0
+    expect { rel.reload }.to change { rel.level }.from(0).to(1)
+  end
+end

--- a/spec/shared_examples/timestamped_model.rb
+++ b/spec/shared_examples/timestamped_model.rb
@@ -49,10 +49,13 @@ shared_examples_for 'timestamped model' do
       end
 
       context 'with missing updated_at' do
+        before do
+          Neo4j::Transaction.run { subject._persisted_obj.remove_property('updated_at') }
+        end
+
         it 'creates the property' do
-          Neo4j::Transaction.run { subject._persisted_obj.remove_property('updated_at'.freeze) }
-          subject.reload
-          expect { subject.save! }.to change { subject.updated_at }
+          expect { subject.reload }.to change { subject.updated_at }.from(instance_of(DateTime)).to(nil)
+          expect { subject.touch }.to change { subject.updated_at }.from(nil).to(instance_of(DateTime))
         end
       end
 


### PR DESCRIPTION
Fixes https://github.com/neo4jrb/neo4j/issues/1073, merging into 6.0.x first. It fixes `#reload` for ActiveRel and sidesteps some of the more troublesome `ActiveAttr` methods.