### PR TITLE
Allow same name for property and scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- `ActiveRel#reload` relied on code written explicitly for loading nodes by ID, not rels.
+
 ## [6.0.3] - 12-18-2015
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [6.0.4] - 12-23-2015
 
 ### Fixed
 
-- `ActiveRel#reload` relied on code written explicitly for loading nodes by ID, not rels.
+- When a `model_class` is specified on an association which is not an ActiveNode model, an error is raised
 
 ## [6.0.3] - 12-18-2015
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - 12-27-2015
+
+### Fixed
+
+- Fixed bug where having the same name for a property and a scope would result in a `Stack Level too Deep` error.
+
 ## [6.0.4] - 12-23-2015
 
 ### Fixed

--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -91,9 +91,17 @@ module Neo4j
         def target_class
           return @target_class if @target_class
 
-          @target_class = target_class_names[0].constantize if target_class_names && target_class_names.size == 1
+          if target_class_names && target_class_names.size == 1
+            class_const = target_class_names[0].constantize
+
+            if !class_const.included_modules.include?(Neo4j::ActiveNode)
+              fail ArgumentError, "Invalid argument to `#{name}` association: `#{class_const.inspect}` is not an ActiveNode model"
+            end
+
+            @target_class = class_const
+          end
         rescue NameError
-          raise ArgumentError, "Could not find `#{@target_class}` class and no :model_class specified"
+          raise ArgumentError, "Invalid argument to `#{name}` association: Could not find class `#{target_class_names[0]}`"
         end
 
         def callback(type)

--- a/lib/neo4j/active_node/scope.rb
+++ b/lib/neo4j/active_node/scope.rb
@@ -37,9 +37,9 @@ module Neo4j::ActiveNode
       def scope(name, proc)
         _scope[name.to_sym] = proc
 
-        define_method(name) do |query_params = nil, some_var = nil|
-          self.class.send(name, query_params, some_var, current_scope)
-        end
+        #define_method(name) do |query_params = nil, some_var = nil|
+        #  self.class.send(name, query_params, some_var, current_scope)
+        #end
 
         klass = class << self; self; end
         klass.instance_eval do

--- a/lib/neo4j/active_node/scope.rb
+++ b/lib/neo4j/active_node/scope.rb
@@ -37,10 +37,6 @@ module Neo4j::ActiveNode
       def scope(name, proc)
         _scope[name.to_sym] = proc
 
-        #define_method(name) do |query_params = nil, some_var = nil|
-        #  self.class.send(name, query_params, some_var, current_scope)
-        #end
-
         klass = class << self; self; end
         klass.instance_eval do
           define_method(name) do |query_params = nil, _ = nil|

--- a/lib/neo4j/version.rb
+++ b/lib/neo4j/version.rb
@@ -1,3 +1,3 @@
 module Neo4j
-  VERSION = '6.0.3'
+  VERSION = '6.0.4'
 end

--- a/spec/unit/active_node/has_n/association_spec.rb
+++ b/spec/unit/active_node/has_n/association_spec.rb
@@ -11,6 +11,9 @@ describe Neo4j::ActiveNode::HasN::Association do
   let(:association) do
     Neo4j::ActiveNode::HasN::Association.new(type, direction, name, options)
   end
+
+  before { stub_active_node_class('Default') }
+
   subject do
     association
   end
@@ -343,12 +346,19 @@ describe Neo4j::ActiveNode::HasN::Association do
     end
 
     describe 'target_class' do
-      # subject { association.target_class }
+      subject { association.target_class }
+
+      let(:options) { {type: nil, model_class: 'BadClass'} }
 
       context 'with invalid target class name' do
-        it 'raises an error' do
-          expect(association).to receive(:target_class_names).at_least(1).times.and_return(['BadObject'])
-          expect { association.target_class }.to raise_error ArgumentError
+        it { expect { subject }.to raise_error ArgumentError, /Could not find class.*BadClass/ }
+      end
+
+      context 'target_class_names defines class which exists, but is not ActiveNode' do
+        let(:options) { {type: nil, model_class: 'Fixnum'} }
+
+        context 'with invalid target class name' do
+          it { expect { subject }.to raise_error ArgumentError, /Fixnum.* is not an ActiveNode model/ }
         end
       end
     end


### PR DESCRIPTION
Ran across this issue in the GraphGist portal app.  My code:

```ruby
class UseCase < GraphStarter::Asset
  property :name, type: String
  property :for_challenge, type: Boolean

  scope :for_challenge, -> { where(for_challenge: true) }

  has_many :in, :graph_gists, origin: :use_cases
end
```

Whenever I would try to use the `UseCase` model (or an association to it), I would get a "stack level to deep" message.  Tracked it down and it seems like we're creating an instance method for scopes, though I don't think we ever need an instance method for scopes, so I killed it.

@subvertallchris seem good?