### PR TITLE
Run tests by Ruby 2.2.4 and 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
+  - 2.3.0
   - 2.2.4
   - 2.0.0
   - jruby-1.7.23

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.2.3
+  - 2.2.4
   - 2.0.0
   - jruby-1.7.23
   - jruby-9.0.4.0


### PR DESCRIPTION
Ruby [2.2.4](https://www.ruby-lang.org/en/news/2015/12/16/ruby-2-2-4-released/) and [2.3.0](https://www.ruby-lang.org/en/news/2015/12/25/ruby-2-3-0-released/) has been released :santa: 