### PR TITLE
Use class_path when generating a model

### DIFF
--- a/lib/rails/generators/neo4j/model/model_generator.rb
+++ b/lib/rails/generators/neo4j/model/model_generator.rb
@@ -12,7 +12,7 @@ class Neo4j::Generators::ModelGenerator < Neo4j::Generators::Base #:nodoc:
   class_option :has_many,   type: :array,  desc: 'A list of has_many relationships'
 
   def create_model_file
-    template 'model.erb', File.join('app/models', "#{singular_name}.rb")
+    template 'model.erb', File.join('app/models', class_path, "#{singular_name}.rb")
   end
 
   protected

--- a/test/lib/generators/model_generator_test.rb
+++ b/test/lib/generators/model_generator_test.rb
@@ -19,6 +19,16 @@ class Neo4j::Generators::ModelGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test 'invoke with model name using namespace' do
+    run_generator %w(Namespaces Account)
+
+    assert_file 'app/models/namespaces/account.rb' do |account|
+      assert_class 'Namespaces::Account', account do |klass|
+        assert_equal 'include Neo4j::ActiveNode', klass
+      end
+    end
+  end
+
   test 'invoke with model name and attributes' do
     run_generator %w(Account name:string age:integer)
 


### PR DESCRIPTION
**Problem:** 
When creating a new model using the generator with Rails, namespaces are ignored. For example, you would expect `rails g model namespaces/my_model` to create a model file at the following location,  `app/models/namespaces/my_model.rb`. But _instead_, it is created at `app/models/my_model.rb`.

**Fix:**
Include the `class_path` variable when generating the file's path. Taken from [ActiveRecord's model generator](https://github.com/rails/rails/blob/571b090a85b09422b4ed2744383b90ada433a2f0/activerecord/lib/rails/generators/active_record/model/model_generator.rb#L23-L25).

Michael De Lorenzo
delorenzo.michael [at] gmail.com
