### PR TITLE
Merge on match

### DIFF
--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -128,9 +128,12 @@ module Neo4j::ActiveNode
         end
       end
 
-      def merge(match_attributes, update_attributes = {})
-        find_or_create_query(match_attributes, update_attributes)
-          .on_match_set(n: on_match_props(update_attributes))
+      def merge(match_attributes, optional_attrs = {})
+        optional_attrs.default = {}
+        on_create_set, set_attrs = optional_attrs.values_at :on_create, :set
+
+        neo4j_session.query.merge(n: {self.mapped_label_names => match_attributes})
+          .on_create_set(n: on_create_props(on_create_set.merge(set_attrs)))
           .pluck(:n).first
       end
 

--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -167,7 +167,7 @@ module Neo4j::ActiveNode
       end
 
       def on_match_props(match_attributes)
-        match_attributes.tap { |props| props[:updated_at] = DateTime.now.to_i if attributes_nil_hash.key?('updated_at'.freeze) }
+        match_attributes.tap { |props| props[:updated_at] = DateTime.now.to_i if attributes_nil_hash.key?('updated_at') }
       end
     end
   end

--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -133,11 +133,11 @@ module Neo4j::ActiveNode
         optional_attrs.assert_valid_keys *options
 
         optional_attrs.default = {}
-        on_create_set, on_match_set, set_attrs = optional_attrs.values_at *options
+        on_create_attrs, on_match_attrs, set_attrs = optional_attrs.values_at *options
 
         neo4j_session.query.merge(n: {self.mapped_label_names => match_attributes})
-          .on_create_set(n: on_create_props(on_create_set.merge(set_attrs)))
-          .on_match_set(n: on_match_props(on_match_set.merge(set_attrs)))
+          .on_create_set(n: on_create_props(on_create_attrs.merge(set_attrs)))
+          .on_match_set(n: on_match_props(on_match_attrs.merge(set_attrs)))
           .pluck(:n).first
       end
 

--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -129,8 +129,11 @@ module Neo4j::ActiveNode
       end
 
       def merge(match_attributes, optional_attrs = {})
+        options = [:on_create, :on_match, :set]
+        optional_attrs.assert_valid_keys *options
+
         optional_attrs.default = {}
-        on_create_set, on_match_set, set_attrs = optional_attrs.values_at :on_create, :on_match, :set
+        on_create_set, on_match_set, set_attrs = optional_attrs.values_at *options
 
         neo4j_session.query.merge(n: {self.mapped_label_names => match_attributes})
           .on_create_set(n: on_create_props(on_create_set.merge(set_attrs)))

--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -130,10 +130,10 @@ module Neo4j::ActiveNode
 
       def merge(match_attributes, optional_attrs = {})
         options = [:on_create, :on_match, :set]
-        optional_attrs.assert_valid_keys *options
+        optional_attrs.assert_valid_keys(*options)
 
         optional_attrs.default = {}
-        on_create_attrs, on_match_attrs, set_attrs = optional_attrs.values_at *options
+        on_create_attrs, on_match_attrs, set_attrs = optional_attrs.values_at(*options)
 
         neo4j_session.query.merge(n: {self.mapped_label_names => match_attributes})
           .on_create_set(n: on_create_props(on_create_attrs))

--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -139,7 +139,10 @@ module Neo4j::ActiveNode
       end
 
       def find_or_create(find_attributes, set_attributes = {})
-        find_or_create_query(find_attributes, set_attributes)
+        on_create_attributes = set_attributes.reverse_merge(on_create_props(find_attributes))
+
+        neo4j_session.query.merge(n: {self.mapped_label_names => find_attributes})
+          .on_create_set(n: on_create_attributes)
           .pluck(:n).first
       end
 
@@ -158,13 +161,6 @@ module Neo4j::ActiveNode
       end
 
       private
-
-      def find_or_create_query(find_attributes, set_attributes = {})
-        on_create_attributes = set_attributes.reverse_merge(on_create_props(find_attributes))
-
-        neo4j_session.query.merge(n: {self.mapped_label_names => find_attributes})
-          .on_create_set(n: on_create_attributes)
-      end
 
       def on_create_props(find_attributes)
         find_attributes.merge(self.new(find_attributes).props_for_create)

--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -130,10 +130,11 @@ module Neo4j::ActiveNode
 
       def merge(match_attributes, optional_attrs = {})
         optional_attrs.default = {}
-        on_create_set, set_attrs = optional_attrs.values_at :on_create, :set
+        on_create_set, on_match_set, set_attrs = optional_attrs.values_at :on_create, :on_match, :set
 
         neo4j_session.query.merge(n: {self.mapped_label_names => match_attributes})
           .on_create_set(n: on_create_props(on_create_set.merge(set_attrs)))
+          .on_match_set(n: on_match_props(on_match_set.merge(set_attrs)))
           .pluck(:n).first
       end
 

--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -136,8 +136,9 @@ module Neo4j::ActiveNode
         on_create_attrs, on_match_attrs, set_attrs = optional_attrs.values_at *options
 
         neo4j_session.query.merge(n: {self.mapped_label_names => match_attributes})
-          .on_create_set(n: on_create_props(on_create_attrs.merge(set_attrs)))
-          .on_match_set(n: on_match_props(on_match_attrs.merge(set_attrs)))
+          .on_create_set(n: on_create_props(on_create_attrs))
+          .on_match_set(n: on_match_props(on_match_attrs))
+          .break.set(n: set_attrs)
           .pluck(:n).first
       end
 

--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -128,10 +128,11 @@ module Neo4j::ActiveNode
         end
       end
 
-      def merge(attributes)
-        neo4j_session.query.merge(n: {self.mapped_label_names => attributes})
-          .on_create_set(n: on_create_props(attributes))
-          .on_match_set(n: on_match_props)
+      def merge(match_attributes, update_attributes = {})
+        on_create_attributes = match_attributes.merge(update_attributes)
+        neo4j_session.query.merge(n: {self.mapped_label_names => match_attributes})
+          .on_create_set(n: on_create_props(on_create_attributes))
+          .on_match_set(n: on_match_props(update_attributes))
           .pluck(:n).first
       end
 
@@ -162,8 +163,8 @@ module Neo4j::ActiveNode
         find_attributes.merge(self.new(find_attributes).props_for_create)
       end
 
-      def on_match_props
-        {}.tap { |props| props[:updated_at] = DateTime.now.to_i if attributes_nil_hash.key?('updated_at'.freeze) }
+      def on_match_props(match_attributes)
+        match_attributes.tap { |props| props[:updated_at] = DateTime.now.to_i if attributes_nil_hash.key?('updated_at'.freeze) }
       end
     end
   end

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -219,25 +219,6 @@ describe 'Query API' do
           include Neo4j::ActiveNode
         end
 
-        xit 'sets all expected labels' do
-          node = Substitute.merge({})
-          expect(node.labels).to eq [:TeacherFoo, :Substitute]
-        end
-
-        xit 'allows for merging' do
-          Teacher.merge(name: 'Dr. Harold Samuels')
-          expect(Teacher.count).to eq(1)
-          Teacher.merge(name: 'Dr. Harold Samuels')
-          expect(Teacher.count).to eq(1)
-        end
-
-        xit 'sets created_at and updated_at' do
-          teacher = Teacher.merge(name: 'Dr. Harold Samuels')
-          expect(teacher.created_at).not_to be_nil
-          expect(teacher.updated_at).not_to be_nil
-          expect(teacher.created_at).to eq teacher.updated_at
-        end
-
         context 'merge' do
           let(:timestamps) { [1, 1, 2, 3].lazy }
           let(:merge_attrs) { {name: 'Dr. Dre'} }
@@ -276,40 +257,6 @@ describe 'Query API' do
 
             it 'updated_at' do
               expect(subject.updated_at).to be > subject.created_at
-            end
-          end
-        end
-
-        xcontext 'on match' do
-          it 'updates updated_at but not created_at' do
-            teacher1 = Teacher.merge(name: 'Dr. Harold Samuels')
-            expect(teacher1.created_at).to eq teacher1.updated_at
-            expect(DateTime).to receive(:now).at_least(2).times.and_return 1234
-            teacher2 = Teacher.merge(name: 'Dr. Harold Samuels')
-            expect(teacher1.uuid).to eq teacher2.uuid
-            expect(teacher1.created_at).to eq teacher2.created_at
-            expect(teacher1.created_at).not_to eq teacher2.updated_at
-          end
-
-          describe 'match only attributes' do
-            let(:match_attributes) { {name: 'Dr. Dre'} }
-
-            it 'includes update attributes on creation' do
-              created = Teacher.merge(match_attributes, age: 49)
-
-              expect(created.name).to eq 'Dr. Dre'
-              expect(created.age).to eq 49
-            end
-
-            it 'can update attributes on match' do
-              original = Teacher.merge(match_attributes, age: 49)
-
-              later = DateTime.now + 100
-              expect(DateTime).to receive(:now).at_least(2).times.and_return later
-              updated = Teacher.merge(match_attributes, age: 50)
-
-              expect(Teacher.count).to eq 1
-              expect(original.updated_at).to be < updated.updated_at
             end
           end
         end

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -258,6 +258,14 @@ describe 'Query API' do
             expect(subject.updated_at).to be > subject.created_at
           end
         end
+
+        context 'valid options' do
+          before { Teacher.merge(merge_attrs) }
+
+          subject { -> { Teacher.merge(merge_attrs, {extra: 'thing'}) } }
+
+          it { should raise_error ArgumentError, 'Unknown key: :extra. Valid keys are: :on_create, :on_match, :set' }
+        end
       end
 
       describe '.find_or_create' do

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -236,7 +236,7 @@ describe 'Query API' do
             Substitute.merge({})
           end
 
-          its(:labels) { should eq [:TeacherFoo, :Substitute] }
+          its(:labels) { should match_array [:TeacherFoo, :Substitute] }
         end
 
         let_context 'on_create', on_create_attrs: {age: 49} do

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -204,7 +204,7 @@ describe 'Query API' do
       end
 
       describe '.merge' do
-        let(:timestamps) { [1, 1, 2, 3].map &DateTime.method(:new) }
+        let(:timestamps) { [1, 1, 2, 3].map(&DateTime.method(:new)) }
         let(:merge_attrs) { {name: 'Dr. Dre'} }
         let(:on_match_attrs) { {} }
         let(:on_create_attrs) { {} }

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -204,13 +204,13 @@ describe 'Query API' do
       end
 
       describe '.merge' do
-        let(:timestamps) { [1, 1, 2, 3].lazy }
+        let(:timestamps) { [1, 1, 2, 3].map &DateTime.method(:new) }
         let(:merge_attrs) { {name: 'Dr. Dre'} }
         let(:on_match_attrs) { {} }
         let(:on_create_attrs) { {} }
         let(:set_attrs) { {status: 'on create status'} }
 
-        before { allow(DateTime).to receive(:now) { timestamps.next } }
+        before { allow(DateTime).to receive(:now).and_return(*timestamps) }
         after { expect(Teacher.count).to eq 1 }
 
         # The ActiveNode stubbing is doing some odd things with the `name` method on the defined classes,

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -262,7 +262,7 @@ describe 'Query API' do
         context 'valid options' do
           before { Teacher.merge(merge_attrs) }
 
-          subject { -> { Teacher.merge(merge_attrs, {extra: 'thing'}) } }
+          subject { -> { Teacher.merge(merge_attrs, extra: 'thing') } }
 
           it { should raise_error ArgumentError, 'Unknown key: :extra. Valid keys are: :on_create, :on_match, :set' }
         end

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -233,13 +233,15 @@ describe 'Query API' do
         its(:name) { should eq 'Dr. Dre' }
 
         context 'expected labels' do
-          subject { super(); Substitute.merge({}); }
+          subject do
+            super()
+            Substitute.merge({})
+          end
 
           its(:labels) { should eq [:TeacherFoo, :Substitute] }
         end
 
         let_context 'on_create', on_create_attrs: {age: 49} do
-
           its(:age) { should eq 49 }
           its(:status) { should eq 'on create status' }
 

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -199,9 +199,7 @@ describe 'Query API' do
     end
 
     describe 'merge methods' do
-      before(:each) do
-        Teacher.delete_all
-      end
+      before { Teacher.delete_all }
 
       describe '.merge' do
         let(:timestamps) { [1, 1, 2, 3].map(&DateTime.method(:new)) }

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -239,7 +239,7 @@ describe 'Query API' do
         end
 
         context 'merge' do
-          let(:timestamps) { [1, 1, 2, 3, 4, 5, 6].lazy }
+          let(:timestamps) { [1, 1, 2, 3].lazy }
           let(:merge_attrs) { {name: 'Dr. Dre'} }
           let(:on_match_attrs) { {} }
           let(:on_create_attrs) { {} }
@@ -265,6 +265,17 @@ describe 'Query API' do
 
             it 'has the same created and updated' do
               expect(subject.created_at).to eq subject.updated_at
+            end
+          end
+
+          let_context 'on_merge', on_match_attrs: {age: 50}, on_create_attrs: {age: 49}, set_attrs: {status: 'on match status'} do
+            before { Teacher.merge(on_create_attrs.merge(merge_attrs)) }
+
+            its(:age) { should eq 50 }
+            its(:status) { should eq 'on match status' }
+
+            it 'updated_at' do
+              expect(subject.updated_at).to be > subject.created_at
             end
           end
         end

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -249,6 +249,28 @@ describe 'Query API' do
             expect(teacher1.created_at).to eq teacher2.created_at
             expect(teacher1.created_at).not_to eq teacher2.updated_at
           end
+
+          describe 'match only attributes' do
+            let(:match_attributes) { {name: 'Dr. Dre'} }
+
+            it 'includes update attributes on creation' do
+              created = Teacher.merge(match_attributes, age: 49)
+
+              expect(created.name).to eq 'Dr. Dre'
+              expect(created.age).to eq 49
+            end
+
+            it 'can update attributes on match' do
+              original = Teacher.merge(match_attributes, age: 49)
+
+              later = DateTime.now + 100
+              expect(DateTime).to receive(:now).at_least(2).times.and_return later
+              updated = Teacher.merge(match_attributes, age: 50)
+
+              expect(Teacher.count).to eq 1
+              expect(original.updated_at).to be < updated.updated_at
+            end
+          end
         end
       end
 

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -219,27 +219,57 @@ describe 'Query API' do
           include Neo4j::ActiveNode
         end
 
-        it 'sets all expected labels' do
+        xit 'sets all expected labels' do
           node = Substitute.merge({})
-          expect(node.labels.count).to eq 2
-          expect(node.labels).to include(:TeacherFoo, :Substitute)
+          expect(node.labels).to eq [:TeacherFoo, :Substitute]
         end
 
-        it 'allows for merging' do
+        xit 'allows for merging' do
           Teacher.merge(name: 'Dr. Harold Samuels')
           expect(Teacher.count).to eq(1)
           Teacher.merge(name: 'Dr. Harold Samuels')
           expect(Teacher.count).to eq(1)
         end
 
-        it 'sets created_at and updated_at' do
+        xit 'sets created_at and updated_at' do
           teacher = Teacher.merge(name: 'Dr. Harold Samuels')
           expect(teacher.created_at).not_to be_nil
           expect(teacher.updated_at).not_to be_nil
           expect(teacher.created_at).to eq teacher.updated_at
         end
 
-        context 'on match' do
+        context 'merge' do
+          let(:timestamps) { [1, 1, 2, 3, 4, 5, 6].lazy }
+          let(:merge_attrs) { {name: 'Dr. Dre'} }
+          let(:on_match_attrs) { {} }
+          let(:on_create_attrs) { {} }
+          let(:set_attrs) { {status: 'on create status'} }
+
+          before { allow(DateTime).to receive(:now) { timestamps.next } }
+          after { expect(Teacher.count).to eq 1 }
+
+          subject { Teacher.merge(merge_attrs, on_match: on_match_attrs, on_create: on_create_attrs, set: set_attrs) }
+
+          its(:name) { should eq 'Dr. Dre' }
+
+          context 'expected labels' do
+            subject { super(); Substitute.merge({}); }
+
+            its(:labels) { should eq [:TeacherFoo, :Substitute] }
+          end
+
+          let_context 'on_create', on_create_attrs: {age: 49} do
+
+            its(:age) { should eq 49 }
+            its(:status) { should eq 'on create status' }
+
+            it 'has the same created and updated' do
+              expect(subject.created_at).to eq subject.updated_at
+            end
+          end
+        end
+
+        xcontext 'on match' do
           it 'updates updated_at but not created_at' do
             teacher1 = Teacher.merge(name: 'Dr. Harold Samuels')
             expect(teacher1.created_at).to eq teacher1.updated_at

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -201,6 +201,29 @@ module ActiveNodeRelStubHelpers
   end
 end
 
+# Introduces `let_context` helper method
+# This allows us to simplify the case where we want to
+# have a context which contains one or more `let` statements
+module RSpecHelpers
+  # Supports giving either a Hash or a String and a Hash as arguments
+  # In both cases the Hash will be used to define `let` statements
+  # When a String is specified that becomes the context description
+  # If String isn't specified, Hash#inspect becomes the context description
+  def let_context(*args, &block)
+    context_string, hash =
+      case args.map(&:class)
+      when [String, Hash] then ["#{args[0]} #{args[1]}", args[1]]
+      when [Hash] then [args[0].inspect, args[0]]
+      end
+
+    context(context_string) do
+      hash.each { |var, value| let(var) { value } }
+
+      instance_eval(&block)
+    end
+  end
+end
+
 def before_session
   Neo4j::Session.current.close if Neo4j::Session.current
   yield

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -231,6 +231,7 @@ def before_session
 end
 
 RSpec.configure do |c|
+  c.extend RSpecHelpers
   c.include Neo4jSpecHelpers
 
   c.before(:all) do


### PR DESCRIPTION
## Description
`find_or_create` is nice, and #1017 modifies it so it only does what it says; but sometimes I find myself needing [update-only attributes](https://github.com/neo4jrb/neo4j/issues/1017#issuecomment-154123488).

This pull modifies `merge` so that you can (optionally) separate your match-only / update-only attributes.

Feedback welcome!