### PR TITLE
fix weird @attributes id property bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+
+### Fixed
+
+- The `@attributes` hash of the first node of each class returned from the database would have have the wrong id property key. This did not appear to cause any problems accessing the value and would be normal for subsequent saves of the affected node as well as all other nodes.
+
 ## [6.1.7] - 2016-02-16
 
 ### Fixed

--- a/lib/neo4j/shared/declared_properties.rb
+++ b/lib/neo4j/shared/declared_properties.rb
@@ -178,7 +178,9 @@ module Neo4j::Shared
     # node load performance.
     def string_map_id_property(key)
       return unless klass.id_property_name == key
-      @_attributes_string_map = attributes_string_map.dup.tap { |h| h[key] = key.to_s }.freeze
+      key.to_s.tap do |string_key|
+        @_attributes_string_map = attributes_string_map.dup.tap { |h| h[key] = string_key }.freeze
+      end
     end
 
     def unregister_magic_typecaster(property)

--- a/spec/unit/active_node/initialize_spec.rb
+++ b/spec/unit/active_node/initialize_spec.rb
@@ -1,0 +1,16 @@
+describe Neo4j::ActiveNode::Initialize do
+  before do
+    stub_active_node_class('MyModel') do
+      property :name, type: String
+    end
+  end
+
+  describe '@attributes' do
+    let(:first_node) { MyModel.create(name: 'foo') }
+    let(:keys) { first_node.instance_variable_get(:@attributes).keys }
+
+    it 'sets @attributes with the expected properties' do
+      expect(keys).to eq(%w(name uuid))
+    end
+  end
+end


### PR DESCRIPTION
Just stumbled upon this. `@attributes` gets used by `ActiveModel`, from what I remember. I think it didn't cause problems for anyone because the id property value isn't _actually_ a property?