### PR TITLE
`branch` method for QueryProxy

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -174,6 +174,25 @@ module Neo4j
           self
         end
 
+        # Executes the relation chain specified in the block, while keeping the current scope
+        #
+        # @example Load all people that have friends
+        #   Person.all.branch { friends }.to_a # => Returns a list of `Person`
+        #
+        # @example Load all people that has old friends
+        #   Person.all.branch { friends.where('age > 70') }.to_a # => Returns a list of `Person`
+        #
+        # @yield the block that will be evaluated starting from the current scope
+        #
+        # @return [QueryProxy] A new QueryProxy
+        def branch(&block)
+          if block
+            instance_eval(&block).query.proxy_as(self.model, identity)
+          else
+            fail LocalJumpError, 'no block given'
+          end
+        end
+
         def [](index)
           # TODO: Maybe for this and other methods, use array if already loaded, otherwise
           # use OFFSET and LIMIT 1?

--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -179,6 +179,25 @@ module Neo4j
           end.first
         end
 
+        # Executes the relation chain specified in the block, while keeping the current scope
+        #
+        # @example Load all people that have friends
+        #   Person.all.branch { friends }.to_a # => Returns a list of `Person`
+        #
+        # @example Load all people that has old friends
+        #   Person.all.branch { friends.where('age > 70') }.to_a # => Returns a list of `Person`
+        #
+        # @yield the block that will be evaluated starting from the current scope
+        #
+        # @return [QueryProxy] A new QueryProxy
+        def branch(&block)
+          if block
+            instance_eval(&block).query.proxy_as(self.model, identity)
+          else
+            fail LocalJumpError, 'no block given'
+          end
+        end
+
         # @return [String] The primary key of a the current QueryProxy's model or target class
         def association_id_key
           self.association.nil? ? model.primary_key : self.association.target_class.primary_key

--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -179,25 +179,6 @@ module Neo4j
           end.first
         end
 
-        # Executes the relation chain specified in the block, while keeping the current scope
-        #
-        # @example Load all people that have friends
-        #   Person.all.branch { friends }.to_a # => Returns a list of `Person`
-        #
-        # @example Load all people that has old friends
-        #   Person.all.branch { friends.where('age > 70') }.to_a # => Returns a list of `Person`
-        #
-        # @yield the block that will be evaluated starting from the current scope
-        #
-        # @return [QueryProxy] A new QueryProxy
-        def branch(&block)
-          if block
-            instance_eval(&block).query.proxy_as(self.model, identity)
-          else
-            fail LocalJumpError, 'no block given'
-          end
-        end
-
         # @return [String] The primary key of a the current QueryProxy's model or target class
         def association_id_key
           self.association.nil? ? model.primary_key : self.association.target_class.primary_key

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -555,6 +555,7 @@ describe 'query_proxy_methods' do
       [Student, Lesson, Teacher].each(&:delete_all)
 
       @john = Student.create(name: 'John')
+      @bill = Student.create(name: 'Bill')
       @history = Lesson.create(name: 'history')
       @jim = Teacher.create(name: 'Jim', age: 40)
       3.times { @john.lessons << @history }
@@ -575,6 +576,12 @@ describe 'query_proxy_methods' do
 
     it 'applies the query in the block' do
       expect(@john.lessons.branch { teachers(:t) }.to_cypher).to include('(t:`Teacher`)')
+    end
+
+    it 'returns only records matching the relation' do
+      students_with_lessons = Student.all.branch { lessons }.to_a
+      expect(students_with_lessons).to include(@john)
+      expect(students_with_lessons).not_to include(@bill)
     end
 
     it 'raises LocalJumpError when no block is passed' do


### PR DESCRIPTION
An implementation for what we discussed here #1143

This method allows to `match` a relation inside the current query proxy, without changing the current scope.

Example:

```ruby
Person.where('age > 3').car # Returns a list of cars
Person.where('age > 3').branch { car } # Returns a list of people that have a car
Person.where('age > 3').branch { car(:c).where("c.kilometers < 5000") } # Returns a list of people that have a new car
```