### PR TITLE
Rescuing `Neo4j::ActiveNode::Labels::RecordNotFound` with a 404 error page

### DIFF
--- a/lib/neo4j/railtie.rb
+++ b/lib/neo4j/railtie.rb
@@ -17,11 +17,13 @@ module Neo4j
     # For rails 3.2 and 4.0
     if config.action_dispatch.respond_to?(:rescue_responses)
       config.action_dispatch.rescue_responses.merge!(
-        'Neo4j::RecordNotFound' => :not_found
+        'Neo4j::RecordNotFound' => :not_found,
+        'Neo4j::ActiveNode::Labels::RecordNotFound' => :not_found
       )
     else
       # For rails 3.0 and 3.1
       ActionDispatch::ShowExceptions.rescue_responses['Neo4j::RecordNotFound'] = :not_found
+      ActionDispatch::ShowExceptions.rescue_responses['Neo4j::ActiveNode::Labels::RecordNotFound'] = :not_found
     end
 
     # Add ActiveModel translations to the I18n load_path


### PR DESCRIPTION
I noticed that `ActionDispatch` `rescue_responses` doesn't work with inheritance.

So, even if `Neo4j::ActiveNode::Labels::RecordNotFound` is a child of `Neo4j::RecordNotFound`, and `Neo4j::RecordNotFound` is rescued with a 404 error page, Rails does not rescues it, too.

I had to add it manually to the list.

#1104 

I think you should add this to 7.0 release!
