### PR TITLE
Fixing `with_associations`

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
+++ b/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
@@ -5,7 +5,7 @@ module Neo4j
         def each(node = true, rel = nil, &block)
           return super if with_associations_spec.size.zero?
 
-          query_from_association_spec.pluck(identity, with_associations_return_clause).map do |record, eager_data|
+          query_from_association_spec.pluck(identity, "[#{with_associations_return_clause}]").map do |record, eager_data|
             eager_data.each_with_index do |eager_records, index|
               record.association_proxy(with_associations_spec[index]).cache_result(eager_records)
             end
@@ -16,10 +16,6 @@ module Neo4j
 
         def with_associations_spec
           @with_associations_spec ||= []
-        end
-
-        def with_associations_return_clause
-          '[' + with_associations_spec.map { |n| "collect(#{n})" }.join(',') + ']'
         end
 
         def with_associations(*spec)
@@ -39,14 +35,25 @@ module Neo4j
 
         private
 
-        def query_from_association_spec
-          with_associations_spec.inject(query_as(identity).return(identity)) do |query, association_name|
-            association = model.associations[association_name]
+        def with_associations_return_clause(variables = with_associations_spec)
+          variables.map { |n| "#{n}_collection" }.join(',')
+        end
 
-            query.optional_match("#{identity}#{association.arrow_cypher}#{association_name}")
-              .where(association.target_where_clause)
-              .break
-          end
+        def query_from_association_spec
+          previous_with_variables = []
+          with_associations_spec.inject(query_as(identity).with(identity)) do |query, association_name|
+            with_association_query_part(query, association_name, previous_with_variables).tap do
+              previous_with_variables << association_name
+            end
+          end.return(identity)
+        end
+
+        def with_association_query_part(base_query, association_name, previous_with_variables)
+          association = model.associations[association_name]
+
+          base_query.optional_match("#{identity}#{association.arrow_cypher}#{association_name}")
+            .where(association.target_where_clause)
+            .with(identity, "collect(#{association_name}) AS #{association_name}_collection", *with_associations_return_clause(previous_with_variables))
         end
       end
     end

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -29,24 +29,26 @@ describe 'Association Proxy' do
   let(:science)   { Lesson.create(subject: 'science', level: 102) }
   let(:math_exam) { Exam.create(name: 'Math Exam') }
   let(:science_exam) { Exam.create(name: 'Science Exam') }
+  let(:science_exam2) { Exam.create(name: 'Science Exam 2') }
 
   before do
     [math, science].each { |lesson| billy.lessons << lesson }
     [math_exam, science_exam].each { |exam| billy.exams << exam }
     math.exams_given << math_exam
     science.exams_given << science_exam
+    science.exams_given << science_exam2
     billy.favorite_lesson = math
   end
 
   it 'Should only make one query per association' do
-    expect(billy.lessons.exams_given.to_a).to match_array([math_exam, science_exam])
+    expect(billy.lessons.exams_given.to_a).to match_array([math_exam, science_exam, science_exam2])
 
     expect_queries(3) do
       grouped_lessons = billy.lessons.group_by(&:subject)
 
       expect(billy.lessons.to_a).to match_array([math, science])
       expect(grouped_lessons['math'][0].exams_given.to_a).to eq([math_exam])
-      expect(grouped_lessons['science'][0].exams_given.to_a).to eq([science_exam])
+      expect(grouped_lessons['science'][0].exams_given.to_a).to match_array([science_exam, science_exam2])
 
       expect(grouped_lessons['math'][0].students.to_a).to eq([billy])
       expect(grouped_lessons['science'][0].students.to_a).to eq([billy])
@@ -73,7 +75,7 @@ describe 'Association Proxy' do
       expect(grouped_lessons['math'][0].exams_given).to eq([math_exam])
 
       expect(grouped_lessons['science'][0].students).to eq([billy])
-      expect(grouped_lessons['science'][0].exams_given).to eq([science_exam])
+      expect(grouped_lessons['science'][0].exams_given).to match_array([science_exam, science_exam2])
     end
   end
 


### PR DESCRIPTION
This should hopefully fix the issues with with_associations and kaminari as well as getting duplicates when using multiple associations with multiple results with at least one association

The big problem is that if you do multiple `OPTIONAL MATCH` clauses in a row you end up getting a cartesian product and your result will have duplicates.

This should also fix issues where previous query proxies are getting mixed up with the clauses from `with_associations` (like with `kaminari-neo4j`).

See #1126 #1048 and #1126 996