### PR TITLE
Raise an error if two associations with the same name are defined

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,7 +38,7 @@ Metrics/MethodLength:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 162
+  Max: 165
 
 # Offense count: 35
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -221,18 +221,11 @@ module Neo4j::ActiveNode
       end
 
       def associations
-        @associations ||= {}
+        (@associations ||= {}).merge(superclass == Object ? {} : superclass.associations)
       end
 
       def associations_keys
         @associations_keys ||= associations.keys
-      end
-
-      # make sure the inherited classes inherit the <tt>_decl_rels</tt> hash
-      def inherited(klass)
-        klass.instance_variable_set(:@associations, associations.clone)
-        @associations_keys = klass.associations_keys.clone
-        super
       end
 
       # For defining an "has many" association on a model.  This defines a set of methods on
@@ -519,8 +512,9 @@ module Neo4j::ActiveNode
       end
 
       def add_association(name, association_object)
-        fail "Association `#{name}` defined for a second time.  Associations can only be defined once" if associations.key?(name)
-        associations[name] = association_object
+        @associations ||= {}
+        fail "Association `#{name}` defined for a second time.  Associations can only be defined once" if @associations.key?(name)
+        @associations[name] = association_object
       end
     end
   end

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -506,8 +506,7 @@ module Neo4j::ActiveNode
       def build_association(macro, direction, name, options)
         options[:model_class] = options[:model_class].name if options[:model_class] == self
         Neo4j::ActiveNode::HasN::Association.new(macro, direction, name, options).tap do |association|
-          @associations ||= {}
-          @associations[name] = association
+          add_association(name, association)
           create_reflection(macro, name, association, self)
         end
 
@@ -517,6 +516,11 @@ module Neo4j::ActiveNode
       # make sure error message is helpful
       rescue StandardError => e
         raise e.class, "#{e.message} (#{self.class}##{name})"
+      end
+
+      def add_association(name, association_object)
+        fail "Association `#{name}` defined for a second time.  Associations can only be defined once" if associations.key?(name)
+        associations[name] = association_object
       end
     end
   end

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -590,5 +590,17 @@ describe 'has_many' do
         end
       end.to raise_error RuntimeError, /Associations can only be defined once/
     end
+
+    it 'should allow for redefining of an association in a subclass' do
+      expect do
+        stub_active_node_class('DoubledAssociation') do
+          has_many :in, :the_name, type: :the_name
+        end
+
+        stub_named_class('DoubledAssociationSubClass', DoubledAssociation) do
+          has_many :out, :the_name, type: :the_name2
+        end
+      end.to_not raise_error
+    end
   end
 end

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -580,4 +580,15 @@ describe 'has_many' do
       end
     end
   end
+
+  describe 'checking for double definitions of associations' do
+    it 'should raise an error if an assocation is defined twice' do
+      expect do
+        stub_active_node_class('DoubledAssociation') do
+          has_many :in, :the_name, type: :the_name
+          has_many :out, :the_name, type: :the_name2
+        end
+      end.to raise_error RuntimeError, /Associations can only be defined once/
+    end
+  end
 end

--- a/spec/e2e/has_one_spec.rb
+++ b/spec/e2e/has_one_spec.rb
@@ -262,5 +262,17 @@ describe 'has_one' do
         end
       end.to raise_error RuntimeError, /Associations can only be defined once/
     end
+
+    it 'should allow for redefining of an association in a subclass' do
+      expect do
+        stub_active_node_class('DoubledAssociation') do
+          has_one :in, :the_name, type: :the_name
+        end
+
+        stub_named_class('DoubledAssociationSubClass', DoubledAssociation) do
+          has_one :out, :the_name, type: :the_name2
+        end
+      end.to_not raise_error
+    end
   end
 end

--- a/spec/e2e/has_one_spec.rb
+++ b/spec/e2e/has_one_spec.rb
@@ -252,4 +252,15 @@ describe 'has_one' do
       expect(comment.post_neo_id).to eq(post.neo_id)
     end
   end
+
+  describe 'checking for double definitions of associations' do
+    it 'should raise an error if an assocation is defined twice' do
+      expect do
+        stub_active_node_class('DoubledAssociation') do
+          has_one :in, :the_name, type: :the_name
+          has_one :out, :the_name, type: :the_name2
+        end
+      end.to raise_error RuntimeError, /Associations can only be defined once/
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1139

This pull introduces/changes:
 * Exception when two associations with the same name are defined
 * Refactored migration specs to use `stub_active_node_spec` (Could you double-check the changed spec @subvertallchris to make sure the spec is still valid?)

Pings:
@cheerfulstoic
@subvertallchris