### PR TITLE
ActiveSupport to_datetime for DateTime conversion

### DIFF
--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -2,6 +2,7 @@ require 'date'
 require 'bigdecimal'
 require 'bigdecimal/util'
 require 'active_support/core_ext/big_decimal/conversions'
+require 'active_support/core_ext/string/conversions'
 
 module Neo4j::Shared
   class Boolean; end
@@ -176,7 +177,6 @@ module Neo4j::Shared
           Time.utc(*args).to_i
         end
 
-        DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S %z'
         def to_ruby(value)
           return value if value.is_a?(DateTime)
           t = case value
@@ -185,7 +185,7 @@ module Neo4j::Shared
               when Integer
                 Time.at(value).utc
               when String
-                DateTime.strptime(value, DATETIME_FORMAT)
+                return value.to_datetime
               else
                 fail ArgumentError, "Invalid value type for DateType property: #{value.inspect}"
               end

--- a/spec/integration/type_converters/type_converters_spec.rb
+++ b/spec/integration/type_converters/type_converters_spec.rb
@@ -351,6 +351,10 @@ describe Neo4j::Shared::TypeConverters do
       it 'translate a Integer back to DateTime' do
         expect(subject.to_ruby(@dt + 6 * @hr)).to eq(DateTime.parse('2012-11-10T09:08:07-06:00'))
       end
+
+      it 'translate a String back to DateTime' do
+        expect(subject.to_ruby(Time.at(@dt - 6 * @hr).to_datetime.to_s)).to eq(DateTime.parse('2012-11-10T09:08:07+06:00'))
+      end
     end
 
     it 'translate from and to database' do


### PR DESCRIPTION
Fixes #1162.

This pull introduces/changes:
 * ActiveAttr used `to_datetime` for DateTime conversion; changing to `strptime` broke conversion of string values from form inputs. Going back to `to_datetime` fixes this.

Pings:
@cheerfulstoic
@subvertallchris