### PR TITLE
Add migration for mass relabeling relationship nodes

### DIFF
--- a/docs/RakeTasks.rst
+++ b/docs/RakeTasks.rst
@@ -72,3 +72,44 @@ The ``neo4j-core`` gem (automatically included with the ``neo4j`` gem) includes 
     **Example:** ``rake neo4j:restart[development]``
 
     Restart the Neo4j server
+
+Migrations
+----------
+
+RelabelRelationships
+~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+  This strips properties from the relationship nodes! Only run this if you're okay with that.
+
+This relabels relationship nodes from one format to another.
+For example, if you created a relationship ``#foo`` in 3.x,
+and you want to convert it to the 4.x+ ``foo`` syntax, you could
+run this.
+
+Usage:
+
+.. code-block:: bash
+
+    rake neo4j:migrate[relabel_relationships,setup]
+    # Edit the file generated in db/neo4j-migrate/relabel_relationships.yml
+    rake neo4j:migrate[relabel_relationships]
+
+Configuring the YAML:
+
+.. code-block:: yaml
+
+    # Change all these relationships from 3.x `#style` to the new `style`
+    relationships: [enrolled_in,lessons]
+    formats:
+      old: lower_hashtag
+      new: lower
+
+
+.. code-block:: yaml
+
+    # Change a single relationship from `lowercase` to `UPPERCASE`
+    relationships: [some_rels]
+    formats:
+      old: lower
+      new: upper

--- a/docs/api/Neo4j/Migration.rst
+++ b/docs/api/Neo4j/Migration.rst
@@ -23,6 +23,8 @@ Migration
 
    Migration/AddIdProperty
 
+   Migration/RelabelRelationships
+
 
 
 
@@ -110,6 +112,19 @@ Methods
 
      def print_output(string)
        print string unless !!ENV['silenced']
+     end
+
+
+
+.. _`Neo4j/Migration#setup`:
+
+**#setup**
+
+
+  .. code-block:: ruby
+
+     def setup
+       FileUtils.mkdir_p('db/neo4j-migrate')
      end
 
 

--- a/docs/api/Neo4j/Migration/RelabelRelationships.rst
+++ b/docs/api/Neo4j/Migration/RelabelRelationships.rst
@@ -1,0 +1,242 @@
+RelabelRelationships
+====================
+
+
+
+
+
+
+.. toctree::
+   :maxdepth: 3
+   :titlesonly:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Constants
+---------
+
+
+
+  * MESSAGE
+
+
+
+Files
+-----
+
+
+
+  * `lib/neo4j/migration.rb:130 <https://github.com/neo4jrb/neo4j/blob/master/lib/neo4j/migration.rb#L130>`_
+
+
+
+
+
+Methods
+-------
+
+
+
+.. _`Neo4j/Migration/RelabelRelationships#default_path`:
+
+**#default_path**
+
+
+  .. code-block:: ruby
+
+     def default_path
+       Rails.root if defined? Rails
+     end
+
+
+
+.. _`Neo4j/Migration/RelabelRelationships#initialize`:
+
+**#initialize**
+
+
+  .. code-block:: ruby
+
+     def initialize(path = default_path)
+       @relationships_filename = File.join(joined_path(path), 'relabel_relationships.yml')
+     end
+
+
+
+.. _`Neo4j/Migration/RelabelRelationships#joined_path`:
+
+**#joined_path**
+
+
+  .. code-block:: ruby
+
+     def joined_path(path)
+       File.join(path.to_s, 'db', 'neo4j-migrate')
+     end
+
+
+
+.. _`Neo4j/Migration/RelabelRelationships#migrate`:
+
+**#migrate**
+
+
+  .. code-block:: ruby
+
+     def migrate
+       config        = YAML.load_file(relationships_filename).to_hash
+       relationships = config['relationships']
+       @old_format   = config['formats']['old']
+       @new_format   = config['formats']['new']
+
+       output 'This task will relabel every given relationship.'
+       output 'It may take a significant amount of time, please be patient.'
+       relationships.each { |relationship| reindex relationship }
+     end
+
+
+
+.. _`Neo4j/Migration/RelabelRelationships#new_format`:
+
+**#new_format**
+  Returns the value of attribute new_format
+
+  .. code-block:: ruby
+
+     def new_format
+       @new_format
+     end
+
+
+
+.. _`Neo4j/Migration/RelabelRelationships#new_format=`:
+
+**#new_format=**
+  Sets the attribute new_format
+
+  .. code-block:: ruby
+
+     def new_format=(value)
+       @new_format = value
+     end
+
+
+
+.. _`Neo4j/Migration/RelabelRelationships#old_format`:
+
+**#old_format**
+  Returns the value of attribute old_format
+
+  .. code-block:: ruby
+
+     def old_format
+       @old_format
+     end
+
+
+
+.. _`Neo4j/Migration/RelabelRelationships#old_format=`:
+
+**#old_format=**
+  Sets the attribute old_format
+
+  .. code-block:: ruby
+
+     def old_format=(value)
+       @old_format = value
+     end
+
+
+
+.. _`Neo4j/Migration/RelabelRelationships#output`:
+
+**#output**
+
+
+  .. code-block:: ruby
+
+     def output(string = '')
+       puts string unless !!ENV['silenced']
+     end
+
+
+
+.. _`Neo4j/Migration/RelabelRelationships#print_output`:
+
+**#print_output**
+
+
+  .. code-block:: ruby
+
+     def print_output(string)
+       print string unless !!ENV['silenced']
+     end
+
+
+
+.. _`Neo4j/Migration/RelabelRelationships#relationships_filename`:
+
+**#relationships_filename**
+  Returns the value of attribute relationships_filename
+
+  .. code-block:: ruby
+
+     def relationships_filename
+       @relationships_filename
+     end
+
+
+
+.. _`Neo4j/Migration/RelabelRelationships#relationships_filename=`:
+
+**#relationships_filename=**
+  Sets the attribute relationships_filename
+
+  .. code-block:: ruby
+
+     def relationships_filename=(value)
+       @relationships_filename = value
+     end
+
+
+
+.. _`Neo4j/Migration/RelabelRelationships#setup`:
+
+**#setup**
+
+
+  .. code-block:: ruby
+
+     def setup
+       super
+       return if File.file?(relationships_filename)
+       File.open(relationships_filename, 'w') { |f| f.write(MESSAGE) }
+     end

--- a/lib/neo4j/migration.rb
+++ b/lib/neo4j/migration.rb
@@ -126,5 +126,68 @@ MESSAGE
         end
       end
     end
+
+    class RelabelRelationships < Neo4j::Migration
+      attr_accessor :relationships_filename, :old_format, :new_format
+
+      def initialize(path = default_path)
+        @relationships_filename = File.join(joined_path(path), 'relabel_relationships.yml')
+      end
+
+      MESSAGE = <<MESSAGE
+# Provide relationships which should be relabled.
+# relationships: [students,lessons,teachers,exams]\nrelationships: []
+# Provide old and new label formats:
+# Allowed options are lower_hashtag, lower, or upper
+formats:\n  old: lower_hashtag\n  new: lower
+MESSAGE
+
+      def setup
+        super
+        return if File.file?(relationships_filename)
+        File.open(relationships_filename, 'w') { |f| f.write(MESSAGE) }
+      end
+
+      def migrate
+        config        = YAML.load_file(relationships_filename).to_hash
+        relationships = config['relationships']
+        @old_format   = config['formats']['old']
+        @new_format   = config['formats']['new']
+
+        output 'This task will relabel every given relationship.'
+        output 'It may take a significant amount of time, please be patient.'
+        relationships.each { |relationship| reindex relationship }
+      end
+
+      private
+
+      def count(relationship)
+        Neo4j::Session.query(
+          "MATCH (a)-[r:#{style(relationship, :old)}]->(b) RETURN COUNT(r)"
+        ).to_a[0]['COUNT(r)']
+      end
+
+      def reindex(relationship)
+        count = count(relationship)
+        output "Indexing #{count} #{style(relationship, :old)}s into #{style(relationship, :new)}..."
+        while count > 0
+          Neo4j::Session.query(
+            "MATCH (a)-[r:#{style(relationship, :old)}]->(b) CREATE (a)-[r2:#{style(relationship, :new)}]->(b) SET r2 = r WITH r LIMIT 1000 DELETE r"
+          )
+          count = count(relationship)
+          if count > 0
+            output "... #{count} #{style(relationship, :old)}'s left to go.."
+          end
+        end
+      end
+
+      def style(relationship, old_or_new)
+        case (old_or_new == :old ? old_format : new_format)
+        when 'lower_hashtag' then "`##{relationship.downcase}`"
+        when 'lower'         then "`#{relationship.downcase}`"
+        when 'upper'         then "`#{relationship.upcase}`"
+        end
+      end
+    end
   end
 end

--- a/lib/neo4j/migration.rb
+++ b/lib/neo4j/migration.rb
@@ -22,6 +22,10 @@ module Neo4j
       File.join(path.to_s, 'db', 'neo4j-migrate')
     end
 
+    def setup
+      FileUtils.mkdir_p('db/neo4j-migrate')
+    end
+
     class AddIdProperty < Neo4j::Migration
       attr_reader :models_filename
 
@@ -42,8 +46,7 @@ module Neo4j
       end
 
       def setup
-        FileUtils.mkdir_p('db/neo4j-migrate')
-
+        super
         return if File.file?(models_filename)
 
         File.open(models_filename, 'w') do |file|

--- a/spec/e2e/migration_spec.rb
+++ b/spec/e2e/migration_spec.rb
@@ -102,4 +102,42 @@ describe 'migration tasks' do
       expect(user.neo_id).to eq neo_id
     end
   end
+
+  describe 'RelabelRelationships class' do
+    let(:full_path)    { '/hd/gems/rails/relabel_relationships.yml' }
+    let(:clazz)        { Neo4j::Migration::RelabelRelationships }
+    let(:map_template) { {'relationships' => %w(songs singers), 'formats' => {'old' => 'lower_hashtag', 'new' => 'lower'}} }
+
+    before do
+      allow(Rails).to receive_message_chain(:root, :join).and_return('/hd/gems/rails/add_id_property.yml')
+      allow(YAML).to receive(:load_file).and_return(map_template)
+    end
+
+    it 'loads an initialization file' do
+      expect(Rails).to receive(:root).and_return(path)
+      expect { clazz.new }.not_to raise_error
+    end
+
+    after { [User, Song].each(&:delete_all) }
+
+    it 'converts the old format to the new' do
+      Neo4j::Session.query('CREATE (n:`User`) return n')
+      Neo4j::Session.query('CREATE (s:`Song`) return s')
+      Neo4j::Session.query('MATCH  (n:`User`),(s:`Song`) CREATE (n)-[r:`#songs`]->(s) RETURN r')
+
+      expect(User.first.songs).to be_empty
+      clazz.new.migrate
+      expect(User.first.songs).not_to be_empty
+    end
+
+    it 'does not relabel relationships already in the requested format' do
+      Neo4j::Session.query('CREATE (n:`User`) return n')
+      Neo4j::Session.query('CREATE (s:`Song`) return s')
+      Neo4j::Session.query('MATCH  (n:`User`),(s:`Song`) CREATE (n)-[r:`songs`]->(s) RETURN r')
+
+      expect(User.first.songs.count).to eq 1
+      clazz.new.migrate
+      expect(User.first.songs.count).to eq 1
+    end
+  end
 end

--- a/spec/e2e/migration_spec.rb
+++ b/spec/e2e/migration_spec.rb
@@ -130,6 +130,19 @@ describe 'migration tasks' do
       expect(User.first.songs).not_to be_empty
     end
 
+    it 'cleans up the old relationship' do
+      Neo4j::Session.query('CREATE (n:`User`) return n')
+      Neo4j::Session.query('CREATE (s:`Song`) return s')
+      Neo4j::Session.query('MATCH  (n:`User`),(s:`Song`) CREATE (n)-[r:`#songs`]->(s) RETURN r')
+
+      hashtagged_songs = Neo4j::Session.query('MATCH (n)-[r:`#songs`]->(s) RETURN r').to_a
+      expect(hashtagged_songs).not_to be_empty
+
+      clazz.new.migrate
+      hashtagged_songs_again = Neo4j::Session.query('MATCH (n)-[r:`#songs`]->(s) RETURN r').to_a
+      expect(hashtagged_songs_again).to be_empty
+    end
+
     it 'does not relabel relationships already in the requested format' do
       Neo4j::Session.query('CREATE (n:`User`) return n')
       Neo4j::Session.query('CREATE (s:`Song`) return s')
@@ -138,6 +151,22 @@ describe 'migration tasks' do
       expect(User.first.songs.count).to eq 1
       clazz.new.migrate
       expect(User.first.songs.count).to eq 1
+    end
+
+    it 'does not fail if no old-style relationships are found' do
+      expect { clazz.new.migrate }.not_to raise_error
+    end
+
+    it 'strips properties off the relationship node' do
+      Neo4j::Session.query('CREATE (n:`User`) return n')
+      Neo4j::Session.query('CREATE (s:`Song`) return s')
+      Neo4j::Session.query('MATCH  (n:`User`),(s:`Song`) CREATE (n)-[r:`#songs` { foo: "bar"}]->(s) RETURN r')
+
+      old_rel = Neo4j::Session.query('MATCH (n)-[r]->(s) RETURN r').to_a.first['r']
+      expect(old_rel.props[:foo]).to eq 'bar'
+      clazz.new.migrate
+      new_rel = Neo4j::Session.query('MATCH (n)-[r]->(s) RETURN r').to_a.first['r']
+      expect(new_rel.props[:foo]).to be_nil
     end
   end
 end


### PR DESCRIPTION
> So we're in the midst of updating the neo4j gem from 3.x to 6.x... One of the pain points was the way the relationship labels changed - `#old_way` to `NEW_WAY` (which is a change that makes sense and I'm glad you did!) Anyways, I'd written a helper that went through all the existing relationships and renamed them... [was wondering the best way to contribute it upstream]

- - me

> Hey @JustinAiken! That sounds like it might be a good fit for https://github.com/neo4jrb/neo4j/blob/master/lib/neo4j/migration.rb ?
You just need a class inheriting from `Neo4j::Migration` and the three methods in the public interface

- - @subvertallchris

Here's my first rough whack at fitting into a subclass of that... if this doesn't fit the project well I'll close and maybe create an outside gem, but if you like where it's heading I can clean it up, add more test cases, and do docs/changelog/etc