### PR TITLE
support for using neo_id as id_property

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,7 +38,7 @@ Metrics/MethodLength:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 162
+  Max: 165
 
 # Offense count: 35
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] Unreleased
+
+### Changed
+
+- Invalid options to the `property` method now raise an exception (see #1169)
+
 ## [7.0.1] - 03-22-2016
 
 ### Fixed

--- a/lib/neo4j/active_node.rb
+++ b/lib/neo4j/active_node.rb
@@ -81,19 +81,22 @@ module Neo4j
         Neo4j::Session.on_next_session_available do |_|
           next if other.manual_id_property? || !self.id_property?
           id_prop = self.id_property_info
-          conf = id_prop[:type].empty? ? {auto: :uuid} : id_prop[:type]
+          conf = id_prop[:type].empty? && id_prop[:name] != :neo_id ? {auto: :uuid} : id_prop[:type]
           other.id_property id_prop[:name], conf
         end
       end
 
       Neo4j::Session.on_next_session_available do |_|
         next if manual_id_property?
-        id_property :uuid, auto: :uuid unless self.id_property?
 
         name = Neo4j::Config[:id_property]
         type = Neo4j::Config[:id_property_type]
         value = Neo4j::Config[:id_property_type_value]
-        id_property(name, type => value) if name && type && value
+        if name
+          id_property(name, type && value ? {type => value} : {})
+        else
+          id_property :uuid, auto: :uuid
+        end
       end
     end
 

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -221,18 +221,11 @@ module Neo4j::ActiveNode
       end
 
       def associations
-        @associations ||= {}
+        (@associations ||= {}).merge(superclass == Object ? {} : superclass.associations)
       end
 
       def associations_keys
         @associations_keys ||= associations.keys
-      end
-
-      # make sure the inherited classes inherit the <tt>_decl_rels</tt> hash
-      def inherited(klass)
-        klass.instance_variable_set(:@associations, associations.clone)
-        @associations_keys = klass.associations_keys.clone
-        super
       end
 
       # For defining an "has many" association on a model.  This defines a set of methods on
@@ -506,8 +499,7 @@ module Neo4j::ActiveNode
       def build_association(macro, direction, name, options)
         options[:model_class] = options[:model_class].name if options[:model_class] == self
         Neo4j::ActiveNode::HasN::Association.new(macro, direction, name, options).tap do |association|
-          @associations ||= {}
-          @associations[name] = association
+          add_association(name, association)
           create_reflection(macro, name, association, self)
         end
 
@@ -517,6 +509,12 @@ module Neo4j::ActiveNode
       # make sure error message is helpful
       rescue StandardError => e
         raise e.class, "#{e.message} (#{self.class}##{name})"
+      end
+
+      def add_association(name, association_object)
+        @associations ||= {}
+        fail "Association `#{name}` defined for a second time.  Associations can only be defined once" if @associations.key?(name)
+        @associations[name] = association_object
       end
     end
   end

--- a/lib/neo4j/active_node/id_property.rb
+++ b/lib/neo4j/active_node/id_property.rb
@@ -40,6 +40,8 @@ module Neo4j::ActiveNode
       def define_id_methods(clazz, name, conf)
         validate_conf!(conf)
 
+        return if name == :neo_id
+
         if conf[:on]
           define_custom_method(clazz, name, conf[:on])
         elsif conf[:auto]
@@ -141,7 +143,7 @@ module Neo4j::ActiveNode
         Neo4j::Session.on_next_session_available do |_|
           @id_property_info = {name: name, type: conf}
           TypeMethods.define_id_methods(self, name, conf)
-          constraint(name, type: :unique) unless conf[:constraint] == false
+          constraint(name, type: :unique) unless conf[:constraint] == false || id_property_name == :neo_id
         end
       end
 

--- a/lib/neo4j/active_node/query/query_proxy_link.rb
+++ b/lib/neo4j/active_node/query/query_proxy_link.rb
@@ -48,7 +48,7 @@ module Neo4j
             end
 
             def new_for_key_and_value(model, key, value)
-              key = (key.to_sym == :id ? model.id_property_name : key)
+              key = converted_key(model, key)
 
               val = if !model
                       value
@@ -84,8 +84,8 @@ module Neo4j
               [new(:order, ->(_, v) { arg.is_a?(String) ? arg : {v => arg} })]
             end
 
-            def for_order_clause(arg, _)
-              [new(:order, ->(v, _) { arg.is_a?(String) ? arg : {v => arg} })]
+            def for_order_clause(arg, model)
+              [new(:order, ->(v, _) { arg.is_a?(String) ? arg : {v => converted_keys(model, arg)} })]
             end
 
             def for_args(model, clause, args, association = nil)
@@ -104,6 +104,14 @@ module Neo4j
               Link.for_clause(clause, arg, model, *args) || default
             rescue NoMethodError
               default
+            end
+
+            def converted_keys(model, arg)
+              arg.is_a?(Hash) ? arg.map { |key, value| [converted_key(model, key), value]}.to_h : arg
+            end
+
+            def converted_key(model, key)
+              key.to_sym == :id ? model.id_property_name : key
             end
 
             def converted_value(model, key, value)

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -113,6 +113,7 @@ module Neo4j::Shared
 
       def_delegators :declared_properties, :serialized_properties, :serialized_properties=, :serialize, :declared_property_defaults
 
+      VALID_PROPERTY_OPTIONS = %w(type default index constraint serializer typecaster).map(&:to_sym)
       # Defines a property on the class
       #
       # See active_attr gem for allowed options, e.g which type
@@ -142,6 +143,8 @@ module Neo4j::Shared
       #      property :name, constraint: :unique
       #    end
       def property(name, options = {})
+        invalid_option_keys = options.keys.map(&:to_sym) - VALID_PROPERTY_OPTIONS
+        fail ArgumentError, "Invalid options for property `#{name}` on `#{self.name}`: #{invalid_option_keys.join(', ')}" if invalid_option_keys.any?
         build_property(name, options) do |prop|
           attribute(prop)
         end

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -580,4 +580,27 @@ describe 'has_many' do
       end
     end
   end
+
+  describe 'checking for double definitions of associations' do
+    it 'should raise an error if an assocation is defined twice' do
+      expect do
+        stub_active_node_class('DoubledAssociation') do
+          has_many :in, :the_name, type: :the_name
+          has_many :out, :the_name, type: :the_name2
+        end
+      end.to raise_error RuntimeError, /Associations can only be defined once/
+    end
+
+    it 'should allow for redefining of an association in a subclass' do
+      expect do
+        stub_active_node_class('DoubledAssociation') do
+          has_many :in, :the_name, type: :the_name
+        end
+
+        stub_named_class('DoubledAssociationSubClass', DoubledAssociation) do
+          has_many :out, :the_name, type: :the_name2
+        end
+      end.to_not raise_error
+    end
+  end
 end

--- a/spec/e2e/has_one_spec.rb
+++ b/spec/e2e/has_one_spec.rb
@@ -252,4 +252,27 @@ describe 'has_one' do
       expect(comment.post_neo_id).to eq(post.neo_id)
     end
   end
+
+  describe 'checking for double definitions of associations' do
+    it 'should raise an error if an assocation is defined twice' do
+      expect do
+        stub_active_node_class('DoubledAssociation') do
+          has_one :in, :the_name, type: :the_name
+          has_one :out, :the_name, type: :the_name2
+        end
+      end.to raise_error RuntimeError, /Associations can only be defined once/
+    end
+
+    it 'should allow for redefining of an association in a subclass' do
+      expect do
+        stub_active_node_class('DoubledAssociation') do
+          has_one :in, :the_name, type: :the_name
+        end
+
+        stub_named_class('DoubledAssociationSubClass', DoubledAssociation) do
+          has_one :out, :the_name, type: :the_name2
+        end
+      end.to_not raise_error
+    end
+  end
 end

--- a/spec/e2e/id_property_spec.rb
+++ b/spec/e2e/id_property_spec.rb
@@ -73,7 +73,27 @@ describe Neo4j::ActiveNode::IdProperty do
       it 'will set the id_property after a session has been created' do
         node = Clazz.new
         expect(node).to respond_to(:the_id)
-        expect(Clazz.mapped_label.indexes[:property_keys].sort).to eq([[:the_id], [:uuid]])
+        expect(Clazz.mapped_label.indexes[:property_keys].sort).to eq([[:the_id]])
+      end
+    end
+
+    describe 'when having neo_id configuration' do
+      before do
+        before_session do
+          Neo4j::Config[:id_property] = :neo_id
+          stub_const('Clazz', Class.new do
+            include Neo4j::ActiveNode
+          end)
+        end
+      end
+
+      it 'it will find node by neo_id' do
+        node = Clazz.new
+        expect(node).to respond_to(:id)
+        expect(node).to respond_to(:neo_id)
+        node.save
+        expect(node.id).to eq(node.neo_id)
+        expect(Clazz.where(id: node).first).to eq(node)
       end
     end
   end
@@ -340,38 +360,150 @@ describe Neo4j::ActiveNode::IdProperty do
     end
   end
 
-  describe 'inheritance' do
-    before(:all) do
-      module IdProp
-        Teacher = UniqueClass.create do
-          include Neo4j::ActiveNode
-          id_property :my_id, on: :my_method
+  describe 'id_property :neo_id' do
+    before do
+      Neo4j::Session.current.close if Neo4j::Session.current
+      stub_const('Clazz', UniqueClass.create do
+        include Neo4j::ActiveNode
+        id_property :neo_id
+      end)
+      create_session
+    end
 
-          def my_method
-            'an id'
-          end
-        end
+    it 'has an index' do
+      expect(Clazz.mapped_label.indexes[:property_keys]).to be_empty
+    end
 
-        class Substitute < Teacher; end
+    describe 'property id' do
+      it 'is not defined when before save ' do
+        node = Clazz.new
+        expect(node.id).to be_nil
+      end
 
-        Vehicle = UniqueClass.create do
-          include Neo4j::ActiveNode
-          id_property :my_id, auto: :uuid
-        end
+      it 'is is set when saving ' do
+        node = Clazz.new
+        node.save
+        expect(node.id).to be_present
+      end
 
-        class Car < Vehicle; end
-
-        Fruit = UniqueClass.create do
-          include Neo4j::ActiveNode
-
-          id_property :my_id
-        end
-
-        class Apple < Fruit; end
+      it 'is same as neo_id' do
+        node = Clazz.new
+        expect(node.id).to be_nil
+        node.save
+        expect(node.id).to eq(node.neo_id)
       end
     end
 
-    after(:all) { [IdProp::Teacher, IdProp::Car, IdProp::Apple].each(&:delete_all) }
+    describe 'find_by_id' do
+      it 'finds it if it exists' do
+        Clazz.create
+        node = Clazz.create
+        Clazz.create
+
+        found = Clazz.find_by_id(node.id)
+        expect(found).to eq(node)
+      end
+
+      it 'does not find it if it does not exist' do
+        Clazz.create
+
+        found = Clazz.find_by_id('something else')
+        expect(found).to be_nil
+      end
+    end
+
+    describe 'find_by_ids' do
+      it 'finds them if they exist' do
+        Clazz.create
+        nodes = 3.times.map { Clazz.create }
+        Clazz.create
+
+        expect(Clazz.find_by_ids(nodes.map(&:id))).to eq(nodes)
+      end
+
+      it 'does not find it if it does not exist' do
+        Clazz.create
+
+        found = Clazz.find_by_ids(['something else'])
+        expect(found).to be_empty
+      end
+    end
+
+    describe 'where' do
+      it 'should use neo_id' do
+        Clazz.create
+        node = Clazz.create
+        Clazz.create
+
+        found = Clazz.where(id: node.id).first
+        expect(found).to eq(node)
+      end
+
+      it 'should find if id is a string' do
+        node = Clazz.create
+        expect(Clazz.where(id: node.id.to_s).first).to eq(node)
+      end
+
+      it 'should find with array' do
+        Clazz.create
+        nodes = 3.times.map { Clazz.create }
+        Clazz.create
+
+        expect(Clazz.where(id: nodes)).to eq(nodes)
+      end
+    end
+
+    describe 'where_not' do
+      it 'should find complement' do
+        node = Clazz.create
+        excluded = Clazz.create
+        expect(Clazz.where_not(id: excluded)).to eq([node])
+      end
+    end
+  end
+
+  describe 'inheritance' do
+    before(:all) do
+      before_session do
+        module IdProp
+          Teacher = UniqueClass.create do
+            include Neo4j::ActiveNode
+            id_property :my_id, on: :my_method
+
+            def my_method
+              'an id'
+            end
+          end
+
+          class Substitute < Teacher; end
+
+          Vehicle = UniqueClass.create do
+            include Neo4j::ActiveNode
+            id_property :my_id, auto: :uuid
+          end
+
+          class Car < Vehicle; end
+
+          Fruit = UniqueClass.create do
+            include Neo4j::ActiveNode
+
+            id_property :my_id
+          end
+
+          class Apple < Fruit; end
+
+          Sport = UniqueClass.create do
+            include Neo4j::ActiveNode
+
+            id_property :neo_id
+          end
+
+          class Skiing < Sport; end
+        end
+      end
+    end
+
+    after(:all) { [IdProp::Teacher, IdProp::Car, IdProp::Apple, IdProp::Sport, IdProp::Skiing].each(&:delete_all) }
 
     it 'inherits the base id_property' do
       expect(IdProp::Substitute.create.my_id).to eq 'an id'
@@ -383,6 +515,12 @@ describe Neo4j::ActiveNode::IdProperty do
 
     it 'works without conf specified' do
       expect(IdProp::Apple.create.my_id).not_to be_nil
+    end
+
+    it 'works with neo_id' do
+      node = IdProp::Skiing.create
+      expect(node.id).not_to be_nil
+      expect(node.id).to eq(node.neo_id)
     end
 
     context 'when a session is not started' do

--- a/spec/e2e/id_property_spec.rb
+++ b/spec/e2e/id_property_spec.rb
@@ -81,19 +81,17 @@ describe Neo4j::ActiveNode::IdProperty do
       before do
         before_session do
           Neo4j::Config[:id_property] = :neo_id
-          stub_const('Clazz', Class.new do
-            include Neo4j::ActiveNode
-          end)
+          stub_active_node_class('NeoIdTest')
         end
       end
 
       it 'it will find node by neo_id' do
-        node = Clazz.new
+        node = NeoIdTest.new
         expect(node).to respond_to(:id)
         expect(node).to respond_to(:neo_id)
         node.save
         expect(node.id).to eq(node.neo_id)
-        expect(Clazz.where(id: node).first).to eq(node)
+        expect(NeoIdTest.where(id: node).first).to eq(node)
       end
     end
   end
@@ -176,6 +174,14 @@ describe Neo4j::ActiveNode::IdProperty do
         node1 = Clazz.create
         found = Clazz.find_by_neo_id(node1.neo_id)
         expect(found).to eq node1
+      end
+    end
+
+    describe 'order' do
+      it 'should order by myid' do
+        nodes = 3.times.map { |i| Clazz.create myid: i }
+
+        expect(Clazz.order(id: :desc).to_a).to eq(nodes.reverse)
       end
     end
   end
@@ -362,32 +368,32 @@ describe Neo4j::ActiveNode::IdProperty do
 
   describe 'id_property :neo_id' do
     before do
-      Neo4j::Session.current.close if Neo4j::Session.current
-      stub_const('Clazz', UniqueClass.create do
-        include Neo4j::ActiveNode
-        id_property :neo_id
-      end)
-      create_session
+      before_session do
+        stub_const('NeoIdTest', UniqueClass.create do
+          include Neo4j::ActiveNode
+          id_property :neo_id
+        end)
+      end
     end
 
     it 'has an index' do
-      expect(Clazz.mapped_label.indexes[:property_keys]).to be_empty
+      expect(NeoIdTest.mapped_label.indexes[:property_keys]).to be_empty
     end
 
     describe 'property id' do
       it 'is not defined when before save ' do
-        node = Clazz.new
+        node = NeoIdTest.new
         expect(node.id).to be_nil
       end
 
       it 'is is set when saving ' do
-        node = Clazz.new
+        node = NeoIdTest.new
         node.save
         expect(node.id).to be_present
       end
 
       it 'is same as neo_id' do
-        node = Clazz.new
+        node = NeoIdTest.new
         expect(node.id).to be_nil
         node.save
         expect(node.id).to eq(node.neo_id)
@@ -396,68 +402,75 @@ describe Neo4j::ActiveNode::IdProperty do
 
     describe 'find_by_id' do
       it 'finds it if it exists' do
-        Clazz.create
-        node = Clazz.create
-        Clazz.create
+        NeoIdTest.create
+        node = NeoIdTest.create
+        NeoIdTest.create
 
-        found = Clazz.find_by_id(node.id)
+        found = NeoIdTest.find_by_id(node.id)
         expect(found).to eq(node)
       end
 
       it 'does not find it if it does not exist' do
-        Clazz.create
+        NeoIdTest.create
 
-        found = Clazz.find_by_id('something else')
+        found = NeoIdTest.find_by_id('something else')
         expect(found).to be_nil
       end
     end
 
     describe 'find_by_ids' do
       it 'finds them if they exist' do
-        Clazz.create
-        nodes = 3.times.map { Clazz.create }
-        Clazz.create
+        NeoIdTest.create
+        nodes = 3.times.map { NeoIdTest.create }
+        NeoIdTest.create
 
-        expect(Clazz.find_by_ids(nodes.map(&:id))).to eq(nodes)
+        expect(NeoIdTest.find_by_ids(nodes.map(&:id))).to eq(nodes)
       end
 
       it 'does not find it if it does not exist' do
-        Clazz.create
+        NeoIdTest.create
 
-        found = Clazz.find_by_ids(['something else'])
+        found = NeoIdTest.find_by_ids(['something else'])
         expect(found).to be_empty
       end
     end
 
     describe 'where' do
       it 'should use neo_id' do
-        Clazz.create
-        node = Clazz.create
-        Clazz.create
+        NeoIdTest.create
+        node = NeoIdTest.create
+        NeoIdTest.create
 
-        found = Clazz.where(id: node.id).first
+        found = NeoIdTest.where(id: node.id).first
         expect(found).to eq(node)
       end
 
       it 'should find if id is a string' do
-        node = Clazz.create
-        expect(Clazz.where(id: node.id.to_s).first).to eq(node)
+        node = NeoIdTest.create
+        expect(NeoIdTest.where(id: node.id.to_s).first).to eq(node)
       end
 
       it 'should find with array' do
-        Clazz.create
-        nodes = 3.times.map { Clazz.create }
-        Clazz.create
+        NeoIdTest.create
+        nodes = 3.times.map { NeoIdTest.create }
+        NeoIdTest.create
 
-        expect(Clazz.where(id: nodes)).to eq(nodes)
+        expect(NeoIdTest.where(id: nodes)).to eq(nodes)
       end
     end
 
     describe 'where_not' do
       it 'should find complement' do
-        node = Clazz.create
-        excluded = Clazz.create
-        expect(Clazz.where_not(id: excluded)).to eq([node])
+        node = NeoIdTest.create
+        excluded = NeoIdTest.create
+        expect(NeoIdTest.where_not(id: excluded)).to eq([node])
+      end
+    end
+
+    describe "order" do
+      it 'should order by neo_id' do
+        nodes = 3.times.map { NeoIdTest.create }
+        expect(NeoIdTest.order(id: :desc).to_a).to eq(nodes.reverse)
       end
     end
   end


### PR DESCRIPTION
Fixes #

This pull introduces/changes:
 * support for using neo_id as id_property (`id_property :neo_id`)
 * fixes double index creation under some circumstances




Pings:
@cheerfulstoic
@subvertallchris