### PR TITLE
Added a config option for the validations failure behavior within transactions.

### DIFF
--- a/lib/neo4j/config.rb
+++ b/lib/neo4j/config.rb
@@ -119,6 +119,11 @@ module Neo4j
         return nil if namespace.nil?
         "::#{namespace}"
       end
+
+      def fail_transaction_when_validations_fail
+        fail_transaction = Neo4j::Config[:fail_transaction_when_validations_fail]
+        fail_transaction.nil? ? true : fail_transaction
+      end
     end
   end
 end

--- a/lib/neo4j/shared/validations.rb
+++ b/lib/neo4j/shared/validations.rb
@@ -16,7 +16,7 @@ module Neo4j
       # @return [Boolean] true if it saved it successfully
       def save(options = {})
         result = perform_validations(options) ? super : false
-        if !result
+        if !result && Neo4j::Config.fail_transaction_when_validations_fail
           Neo4j::Transaction.current.failure if Neo4j::Transaction.current
         end
         result

--- a/spec/e2e/transaction_spec.rb
+++ b/spec/e2e/transaction_spec.rb
@@ -33,7 +33,7 @@ describe 'Neo4j::Transaction' do
       end
     end
 
-    it 'rollbacks the current transaction' do
+    it 'rollbacks the current transaction by default' do
       expect do
         Neo4j::Transaction.run do |tx|
           clazz.create
@@ -43,7 +43,7 @@ describe 'Neo4j::Transaction' do
       end.not_to change { clazz.count }
     end
 
-    it 'rollbacks the current transaction' do
+    it 'keeps running the current transaction when `fail_transaction_when_validations_fail` is false' do
       Neo4j::Config[:fail_transaction_when_validations_fail] = false
 
       expect do


### PR DESCRIPTION
Fixes #1156 

This pull introduces/changes:
 An option for `Neo4j::Config` to choose what to do when validations fail inside a transaction:

```ruby
Neo4j::Config[:fail_transaction_when_validations_fail] = false
```

It's set to `true` by default, to keep the backward compatibility.


Pings:
@cheerfulstoic
@subvertallchris