### PR TITLE
fix ActiveNode mass-assignment association handling

### DIFF
--- a/lib/neo4j/active_node/persistence.rb
+++ b/lib/neo4j/active_node/persistence.rb
@@ -103,27 +103,17 @@ module Neo4j::ActiveNode
       # Creates and saves a new node
       # @param [Hash] props the properties the new node should have
       def create(props = {})
-        association_props = extract_association_attributes!(props) || {}
         new(props).tap do |obj|
           yield obj if block_given?
           obj.save
-          association_props.each do |prop, value|
-            obj.send("#{prop}=", value)
-          end
         end
       end
 
       # Same as #create, but raises an error if there is a problem during save.
-      def create!(*args)
-        props = args[0] || {}
-        association_props = extract_association_attributes!(props) || {}
-
-        new(*args).tap do |o|
+      def create!(props = {})
+        new(props).tap do |o|
           yield o if block_given?
           o.save!
-          association_props.each do |prop, value|
-            o.send("#{prop}=", value)
-          end
         end
       end
 

--- a/spec/e2e/persistence_spec.rb
+++ b/spec/e2e/persistence_spec.rb
@@ -20,6 +20,54 @@ describe Neo4j::ActiveNode do
       expect(o.persisted?).to eq(false)
     end
   end
+
+  describe 'associations and mass-assignment' do
+    before do
+      stub_active_node_class('MyModel') do
+        validates_presence_of :friend
+
+        has_one :out, :friend, type: :FRIENDS_WITH, model_class: :FriendModel
+      end
+
+      stub_active_node_class('FriendModel')
+    end
+
+    describe 'class method #create!' do
+      context 'association validation fails' do
+        it 'raises an error' do
+          expect { MyModel.create! }.to raise_error Neo4j::ActiveNode::Persistence::RecordInvalidError, "Friend can't be blank"
+        end
+
+        it 'does not create the rel' do
+          expect { MyModel.create }.not_to change { MyModel.count }
+        end
+      end
+
+      context 'association validation succeeds' do
+        it 'creates the node and relationship' do
+          expect do
+            MyModel.create!(friend: FriendModel.create!)
+          end.to change { MyModel.as(:m).friend(:f, :r).pluck('count(m), count(r), count(f)').flatten.inject(&:+) }.by(3)
+        end
+      end
+    end
+
+    describe 'instance #save!' do
+      context 'association validation fails' do
+        it 'raises an error' do
+          expect { MyModel.new.save! }.to raise_error Neo4j::ActiveNode::Persistence::RecordInvalidError, "Friend can't be blank"
+        end
+      end
+
+      context 'association validation succeeds' do
+        it 'creates the node and relationship' do
+          expect do
+            MyModel.new(friend: FriendModel.create).save!
+          end.to change { MyModel.as(:m).friend(:f, :r).pluck('count(m), count(r), count(f)').flatten.inject(&:+) }.by(3)
+        end
+      end
+    end
+  end
 end
 
 describe Neo4j::ActiveRel do


### PR DESCRIPTION
Fixes #1182

Fixes the issue described. We're already able to handle associations with save, so create should just let it do its job.

@cheerfulstoic, I couldn't find a better place to put these specs. This seemed like the obvious choice since the methods are defined in persistence.rb, but let me know if there's a better place for them.

Pings:
@cheerfulstoic
@subvertallchris