### PR TITLE
Removed transaction failure when validations fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Changed the behavior with transactions when a validation fails. This is a potentially breaking change, since now calling `save` would not fail the current transaction, as expected. (see #1156)
 - Invalid options to the `property` method now raise an exception (see #1169)
 
 ### Added

--- a/lib/neo4j/shared/validations.rb
+++ b/lib/neo4j/shared/validations.rb
@@ -15,11 +15,7 @@ module Neo4j
       # @option options [true, false] :validate if false no validation will take place
       # @return [Boolean] true if it saved it successfully
       def save(options = {})
-        result = perform_validations(options) ? super : false
-        if !result
-          Neo4j::Transaction.current.failure if Neo4j::Transaction.current
-        end
-        result
+        perform_validations(options) ? super : false
       end
 
       # @return [Boolean] true if valid


### PR DESCRIPTION
Fixes #1156 

This pull introduces/changes:
 * The default behavior with transactions, when a validation fails.




Pings:
@cheerfulstoic
@subvertallchris

