### PR TITLE
Neo4j migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Renamed the old migration task to `neo4j:legacy_migrate`
+- Renamed the ENV variable to silence migrations output from `silenced` to `MIGRATIONS_SILENCED`
 - Changed the behavior with transactions when a validation fails. This is a potentially breaking change, since now calling `save` would not fail the current transaction, as expected. (thanks ProGM / see #1156)
 - Invalid options to the `property` method now raise an exception (see #1169)
 
 ### Added
 
+- Adding a new ActiveRecord-like migration framework (thanks ProGM / see #1197)
+- Adding a set of rake tasks to manage migrations (thanks ProGM / see #1197)
+- Implemented autoloading for new and legacy migration modules (there's no need to `require` them anymore)
 - Adding explicit identity method for use in Query strings (thanks brucek / see #1159)
 - Added support for `find_or_initialize_by` and `first_or_initialize` methods from ActiveRecord (thanks ProGM / see #1164)
 

--- a/docs/Migrations.rst
+++ b/docs/Migrations.rst
@@ -1,0 +1,260 @@
+Migrations
+==================
+
+Neo4j.rb provides an ``ActiveRecord``-like migration framework and a set of helper methods to manipulate both database schema and data.
+
+
+Generators
+------------------
+
+Migrations can be created by using the built-in Rails generator:
+
+.. code-block:: bash
+
+  rails generate neo4j:migration RenameUserNameToFirstName
+
+This will generate a new file located in ``db/neo4j/migrate/xxxxxxxxxx_rename_user_name_to_first_name.rb``
+
+.. code-block:: ruby
+  class RenameUserNameToFirstName < Neo4j::Migrations::Base
+    def up
+    end
+
+    def down
+    end
+  end
+
+In the same way as ``ActiveRecord`` does, you should fill up the ``up`` and ``down`` methods to define the migration and (eventually) the rollback steps.
+
+
+Transactions
+------------------
+Every migrations runs inside a transaction by default. So, if some statement fails inside a migration fails, the database rollbacks to the previous state.
+
+However this behaviour is not always good. For instance, neo4j doesn't allow schema and data changes in the same transaction.
+
+To disable this, you can use the ``disable_transactions!`` helper in your migration definition:
+
+.. code-block:: ruby
+
+  class SomeMigration < Neo4j::Migrations::Base
+    disable_transactions!
+
+    ...
+  end
+
+Neo4j::Migrations::Helpers
+------------------
+
+#execute
+~~~~~~
+
+Executes a pure neo4j cypher query, interpolating parameters.
+
+.. code-block:: ruby
+
+  execute('MATCH (n) WHERE n.name = {node_name} RETURN n', node_name: 'John')
+
+.. code-block:: ruby
+
+  execute('MATCH (n)-[r:`friend`]->() WHERE n.age = 7 DELETE r')
+
+
+#query
+---------------
+
+An alias for ``Neo4j::Session.query``. You can use it as root for the query builder:
+
+.. code-block:: ruby
+
+  query.match(:n).where(name: 'John').delete(:n)
+
+
+#remove_property
+---------------
+
+Removes a property given a label.
+
+:Ruby:
+  .. code-block:: ruby
+
+    remove_property(:User, :money)
+
+:Cypher:
+  .. code-block:: cypher
+
+    MATCH (n:`User`) REMOVE n.money
+
+#rename_property
+------
+
+Renames a property given a label.
+
+:Ruby:
+  .. code-block:: ruby
+
+    rename_property(:User, :name, :first_name)
+
+:Cypher:
+  .. code-block:: cypher
+
+    MATCH (n:`User`) SET n.first_name = n.name REMOVE n.name
+
+#drop_nodes
+------
+
+Removes all nodes with a certain label
+
+:Ruby:
+  .. code-block:: ruby
+
+    drop_nodes(:User)
+
+:Cypher:
+  .. code-block:: cypher
+
+    MATCH (n:`User`) OPTIONAL MATCH (n)-[r]-() DELETE r,n
+
+#add_label
+------
+
+Adds a label to nodes, given their current label
+
+:Ruby:
+  .. code-block:: ruby
+
+    add_label(:User, :Person)
+
+:Cypher:
+  .. code-block:: cypher
+
+    MATCH (n:`User`) SET n:`Person`
+
+#add_labels
+------
+
+Adds labels to nodes, given their current label
+
+:Ruby:
+  .. code-block:: ruby
+
+    add_label(:User, [:Person, :Boy])
+
+:Cypher:
+  .. code-block:: cypher
+
+    MATCH (n:`User`) SET n:`Person`:`Boy`
+
+#remove_label
+------
+
+Removes a label from nodes, given a label
+
+:Ruby:
+  .. code-block:: ruby
+
+    remove_label(:User, :Person)
+
+:Cypher:
+  .. code-block:: cypher
+
+    MATCH (n:`User`) REMOVE n:`Person`
+
+#remove_labels
+------
+
+Removes labels from nodes, given a label
+
+:Ruby:
+  .. code-block:: ruby
+
+    remove_label(:User, [:Person, :Boy])
+
+:Cypher:
+  .. code-block:: cypher
+
+    MATCH (n:`User`) REMOVE n:`Person`:`Boy`
+
+#rename_label
+------
+
+Renames a label
+
+:Ruby:
+  .. code-block:: ruby
+
+    rename_label(:User, :Person)
+
+:Cypher:
+  .. code-block:: cypher
+
+    MATCH (n:`User`) SET n:`Person` REMOVE n:`Person`
+
+#drop_constraint
+------
+
+Drops an unique constraint on a given label attribute.
+
+**Warning** it would fail unless you define ``disable_transactions!`` in your migration file.
+
+.. code-block:: ruby
+
+  drop_constraint(:User, :name)
+
+#drop_index
+------
+
+Drops an exact index on a given label attribute.
+
+**Warning** it would fail unless you define ``disable_transactions!`` in your migration file.
+
+.. code-block:: ruby
+
+  drop_index(:User, :name)
+
+
+#say
+------
+
+Writes some text while running the migration.
+
+:Ruby:
+  .. code-block:: ruby
+
+    say 'Hello'
+
+:Output:
+  .. code-block:: ruby
+
+    -- Hello
+
+When passing ``true`` as second parameter, it writes it more indented.
+
+:Ruby:
+  .. code-block:: ruby
+
+    say 'Hello', true
+
+:Output:
+  .. code-block:: ruby
+
+      -> Hello
+
+#say_with_time
+------
+
+Wraps a set of statements inside a block, printing the given and the execution time. When an ``Integer`` is returned, it assumes it's the number of affected rows.
+
+:Ruby:
+  .. code-block:: ruby
+
+    say_with_time 'Trims all names' do
+      query.match(n: :User).set('n.name = TRIM(n.name)').pluck('count(*)')
+    end
+
+:Output:
+  .. code-block:: bash
+
+    -- Trims all names.
+       -> 0.3451s
+       -> 2233 rows

--- a/docs/Migrations.rst
+++ b/docs/Migrations.rst
@@ -1,7 +1,7 @@
 Migrations
 ==================
 
-Neo4j.rb provides an ``ActiveRecord``-like migration framework and a set of helper methods to manipulate both database schema and data.
+Neo4j does not have a set schema like relational databases, but sometimes changes to the schema and the data are required. To help with this, Neo4j.rb provides an ``ActiveRecord``-like migration framework and a set of helper methods to manipulate both database schema and data.
 
 
 Generators
@@ -18,9 +18,11 @@ This will generate a new file located in ``db/neo4j/migrate/xxxxxxxxxx_rename_us
 .. code-block:: ruby
   class RenameUserNameToFirstName < Neo4j::Migrations::Base
     def up
+      rename_property :User, :name, :first_name
     end
 
     def down
+      rename_property :User, :first_name, :name
     end
   end
 
@@ -43,7 +45,7 @@ To disable this, you can use the ``disable_transactions!`` helper in your migrat
     ...
   end
 
-Neo4j::Migrations::Helpers
+Migration Helpers
 ------------------
 
 #execute
@@ -67,7 +69,7 @@ An alias for ``Neo4j::Session.query``. You can use it as root for the query buil
 
 .. code-block:: ruby
 
-  query.match(:n).where(name: 'John').delete(:n)
+  query.match(:n).where(name: 'John').delete(:n).exec
 
 
 #remove_property
@@ -195,7 +197,7 @@ Renames a label
 
 Drops an unique constraint on a given label attribute.
 
-**Warning** it would fail unless you define ``disable_transactions!`` in your migration file.
+**Warning** it would fail if you make data changes in the same migration. To fix, define ``disable_transactions!`` in your migration file.
 
 .. code-block:: ruby
 
@@ -206,7 +208,7 @@ Drops an unique constraint on a given label attribute.
 
 Drops an exact index on a given label attribute.
 
-**Warning** it would fail unless you define ``disable_transactions!`` in your migration file.
+**Warning** it would fail if you make data changes in the same migration. To fix, define ``disable_transactions!`` in your migration file.
 
 .. code-block:: ruby
 

--- a/docs/Migrations.rst
+++ b/docs/Migrations.rst
@@ -77,120 +77,72 @@ An alias for ``Neo4j::Session.query``. You can use it as root for the query buil
 
 Removes a property given a label.
 
-:Ruby:
-  .. code-block:: ruby
+.. code-block:: ruby
 
-    remove_property(:User, :money)
-
-:Cypher:
-  .. code-block:: cypher
-
-    MATCH (n:`User`) REMOVE n.money
+  remove_property(:User, :money)
 
 #rename_property
 ------
 
 Renames a property given a label.
 
-:Ruby:
-  .. code-block:: ruby
+.. code-block:: ruby
 
-    rename_property(:User, :name, :first_name)
-
-:Cypher:
-  .. code-block:: cypher
-
-    MATCH (n:`User`) SET n.first_name = n.name REMOVE n.name
+  rename_property(:User, :name, :first_name)
 
 #drop_nodes
 ------
 
 Removes all nodes with a certain label
 
-:Ruby:
-  .. code-block:: ruby
+.. code-block:: ruby
 
-    drop_nodes(:User)
-
-:Cypher:
-  .. code-block:: cypher
-
-    MATCH (n:`User`) OPTIONAL MATCH (n)-[r]-() DELETE r,n
+  drop_nodes(:User)
 
 #add_label
 ------
 
 Adds a label to nodes, given their current label
 
-:Ruby:
-  .. code-block:: ruby
+.. code-block:: ruby
 
-    add_label(:User, :Person)
-
-:Cypher:
-  .. code-block:: cypher
-
-    MATCH (n:`User`) SET n:`Person`
+  add_label(:User, :Person)
 
 #add_labels
 ------
 
 Adds labels to nodes, given their current label
 
-:Ruby:
-  .. code-block:: ruby
+.. code-block:: ruby
 
-    add_label(:User, [:Person, :Boy])
-
-:Cypher:
-  .. code-block:: cypher
-
-    MATCH (n:`User`) SET n:`Person`:`Boy`
+  add_label(:User, [:Person, :Boy])
 
 #remove_label
 ------
 
 Removes a label from nodes, given a label
 
-:Ruby:
-  .. code-block:: ruby
+.. code-block:: ruby
 
-    remove_label(:User, :Person)
-
-:Cypher:
-  .. code-block:: cypher
-
-    MATCH (n:`User`) REMOVE n:`Person`
+  remove_label(:User, :Person)
 
 #remove_labels
 ------
 
 Removes labels from nodes, given a label
 
-:Ruby:
-  .. code-block:: ruby
+.. code-block:: ruby
 
-    remove_label(:User, [:Person, :Boy])
-
-:Cypher:
-  .. code-block:: cypher
-
-    MATCH (n:`User`) REMOVE n:`Person`:`Boy`
+  remove_label(:User, [:Person, :Boy])
 
 #rename_label
 ------
 
 Renames a label
 
-:Ruby:
-  .. code-block:: ruby
+.. code-block:: ruby
 
-    rename_label(:User, :Person)
-
-:Cypher:
-  .. code-block:: cypher
-
-    MATCH (n:`User`) SET n:`Person` REMOVE n:`Person`
+  rename_label(:User, :Person)
 
 #drop_constraint
 ------
@@ -251,7 +203,7 @@ Wraps a set of statements inside a block, printing the given and the execution t
   .. code-block:: ruby
 
     say_with_time 'Trims all names' do
-      query.match(n: :User).set('n.name = TRIM(n.name)').pluck('count(*)')
+      query.match(n: :User).set('n.name = TRIM(n.name)').pluck('count(*)').first
     end
 
 :Output:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,8 @@ Contents:
 
    Configuration
 
+   Migrations
+
    Contributing
 
    api/index

--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -86,12 +86,11 @@ require 'neo4j/active_node/query'
 require 'neo4j/active_node/scope'
 require 'neo4j/active_node'
 
-require 'neo4j/migration'
-require 'neo4j/migrations/helpers'
-require 'neo4j/migrations/migration_file'
-require 'neo4j/migrations/base'
-require 'neo4j/migrations/runner'
-require 'neo4j/migrations/schema_migration'
+module Neo4j
+  extend ActiveSupport::Autoload
+  autoload :Migration
+  autoload :Migrations
+end
 
 require 'neo4j/active_node/orm_adapter'
 if defined?(Rails)

--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -88,6 +88,7 @@ require 'neo4j/active_node'
 
 require 'neo4j/migration'
 require 'neo4j/migrations/helpers'
+require 'neo4j/migrations/migration_file'
 require 'neo4j/migrations/base'
 require 'neo4j/migrations/runner'
 require 'neo4j/migrations/schema_migration'

--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -86,6 +86,12 @@ require 'neo4j/active_node/query'
 require 'neo4j/active_node/scope'
 require 'neo4j/active_node'
 
+require 'neo4j/migration'
+require 'neo4j/migrations/helpers'
+require 'neo4j/migrations/base'
+require 'neo4j/migrations/runner'
+require 'neo4j/migrations/schema_migration'
+
 require 'neo4j/active_node/orm_adapter'
 if defined?(Rails)
   require 'rails/generators'

--- a/lib/neo4j/errors.rb
+++ b/lib/neo4j/errors.rb
@@ -25,4 +25,5 @@ module Neo4j
 
   class DangerousAttributeError < ScriptError; end
   class UnknownAttributeError < NoMethodError; end
+  class IrreversibleMigration < Error; end
 end

--- a/lib/neo4j/errors.rb
+++ b/lib/neo4j/errors.rb
@@ -26,4 +26,5 @@ module Neo4j
   class DangerousAttributeError < ScriptError; end
   class UnknownAttributeError < NoMethodError; end
   class IrreversibleMigration < Error; end
+  class UnknownMigrationVersionError < Error; end
 end

--- a/lib/neo4j/errors.rb
+++ b/lib/neo4j/errors.rb
@@ -25,6 +25,7 @@ module Neo4j
 
   class DangerousAttributeError < ScriptError; end
   class UnknownAttributeError < NoMethodError; end
-  class IrreversibleMigration < Error; end
-  class UnknownMigrationVersionError < Error; end
+  class MigrationError < Error; end
+  class IrreversibleMigration < MigrationError; end
+  class UnknownMigrationVersionError < MigrationError; end
 end

--- a/lib/neo4j/migration.rb
+++ b/lib/neo4j/migration.rb
@@ -7,11 +7,11 @@ module Neo4j
     end
 
     def output(string = '')
-      puts string unless !!ENV['silenced']
+      puts string unless !!ENV['MIGRATIONS_SILENCED']
     end
 
     def print_output(string)
-      print string unless !!ENV['silenced']
+      print string unless !!ENV['MIGRATIONS_SILENCED']
     end
 
     def default_path

--- a/lib/neo4j/migrations.rb
+++ b/lib/neo4j/migrations.rb
@@ -1,0 +1,10 @@
+module Neo4j
+  module Migrations
+    extend ActiveSupport::Autoload
+    autoload :Helpers
+    autoload :MigrationFile
+    autoload :Base
+    autoload :Runner
+    autoload :SchemaMigration
+  end
+end

--- a/lib/neo4j/migrations/base.rb
+++ b/lib/neo4j/migrations/base.rb
@@ -1,0 +1,47 @@
+module Neo4j
+  module Migrations
+    class Base < ::Neo4j::Migration
+      def initialize(migration_id)
+        @migration_id = migration_id
+      end
+
+      def migrate(method)
+        Benchmark.realtime do
+          Neo4j::Transaction.run do
+            __send__(method)
+          end
+        end
+      end
+
+      def up
+        fail NotImplementedError
+      end
+
+      def down
+        fail NotImplementedError
+      end
+
+      protected
+
+      def execute(string)
+        Neo4j::Session.query(string).to_a
+      end
+
+      private
+
+      # def migrate_up
+      #   migration = SchemaMigration.new(migration_id: @migration_id)
+      #   if migration.save
+      #     output "Running migration #{@migration_id}..."
+      #     up
+      #   else
+      #     output('Already migrated.')
+      #   end
+      # end
+
+      # def migrate_down
+      #   SchemaMigration.find_by(migration_id: @migration_id) && down
+      # end
+    end
+  end
+end

--- a/lib/neo4j/migrations/base.rb
+++ b/lib/neo4j/migrations/base.rb
@@ -9,15 +9,7 @@ module Neo4j
 
       def migrate(method)
         Benchmark.realtime do
-          Neo4j::Transaction.run do
-            if method == :up
-              up
-              SchemaMigration.create!(migration_id: @migration_id)
-            else
-              down
-              SchemaMigration.find_by!(migration_id: @migration_id).destroy
-            end
-          end
+          transactions? ? migrate_with_transactions(method) : migrate_without_transactions(method)
         end
       end
 
@@ -27,6 +19,24 @@ module Neo4j
 
       def down
         fail NotImplementedError
+      end
+
+      protected
+
+      def migrate_with_transactions(method)
+        Neo4j::Transaction.run do
+          migrate_without_transactions(method)
+        end
+      end
+
+      def migrate_without_transactions(method)
+        if method == :up
+          up
+          SchemaMigration.create!(migration_id: @migration_id)
+        else
+          down
+          SchemaMigration.find_by!(migration_id: @migration_id).destroy
+        end
       end
     end
   end

--- a/lib/neo4j/migrations/base.rb
+++ b/lib/neo4j/migrations/base.rb
@@ -1,6 +1,8 @@
 module Neo4j
   module Migrations
     class Base < ::Neo4j::Migration
+      include Neo4j::Migrations::Helpers
+
       def initialize(migration_id)
         @migration_id = migration_id
       end
@@ -20,28 +22,6 @@ module Neo4j
       def down
         fail NotImplementedError
       end
-
-      protected
-
-      def execute(string)
-        Neo4j::Session.query(string).to_a
-      end
-
-      private
-
-      # def migrate_up
-      #   migration = SchemaMigration.new(migration_id: @migration_id)
-      #   if migration.save
-      #     output "Running migration #{@migration_id}..."
-      #     up
-      #   else
-      #     output('Already migrated.')
-      #   end
-      # end
-
-      # def migrate_down
-      #   SchemaMigration.find_by(migration_id: @migration_id) && down
-      # end
     end
   end
 end

--- a/lib/neo4j/migrations/base.rb
+++ b/lib/neo4j/migrations/base.rb
@@ -10,7 +10,13 @@ module Neo4j
       def migrate(method)
         Benchmark.realtime do
           Neo4j::Transaction.run do
-            __send__(method)
+            if method == :up
+              up
+              SchemaMigration.create!(migration_id: @migration_id)
+            else
+              down
+              SchemaMigration.find_by!(migration_id: @migration_id).destroy
+            end
           end
         end
       end

--- a/lib/neo4j/migrations/helpers.rb
+++ b/lib/neo4j/migrations/helpers.rb
@@ -1,49 +1,68 @@
 module Neo4j
   module Migrations
     module Helpers
-      def rename_property(label, old_property, new_property)
-        by_label(label).where(n: {new_property => nil})
-                       .set("n.#{new_property} = n.#{old_property}")
-                       .remove("n.#{old_property}")
+      def remove_property(label, property)
+        by_label(label).remove(n: property)
                        .exec
       end
 
+      def rename_property(label, old_property, new_property)
+        fail Neo4j::MigrationError, "Property `#{new_property}` is already defined in `#{label}`" if property_exists?(label, new_property)
+        by_label(label).set("n.#{new_property} = n.#{old_property}")
+                       .remove("n.#{old_property}").exec
+      end
+
       def drop_nodes(label)
-        query.match("(n:`#{label}`)")
+        query.match(n: label)
              .optional_match('(n)-[r]-()')
              .delete(:r, :n).exec
       end
 
-      def add_labels(label, *labels)
-        by_label(label).set("n:#{labels.join(':')}").exec
+      def add_labels(label, new_labels)
+        by_label(label).set(n: new_labels).exec
       end
 
-      def remove_labels(label, *labels)
-        by_label(label).remove("n:#{labels.join(':')}").exec
+      def add_label(label, new_label)
+        add_labels(label, [new_label])
       end
 
-      alias add_label add_labels
-      alias remove_label remove_labels
-
-      def remove_constraint(label, property)
-        execute("DROP CONSTRAINT ON (n:`#{label}`) ASSERT n.#{property} IS UNIQUE")
+      def remove_labels(label, labels_to_remove)
+        by_label(label).remove(n: labels_to_remove).exec
       end
 
-      def remove_index(label, property)
-        execute("DROP INDEX ON :#{label}(#{property})")
+      def remove_label(label, label_to_remove)
+        remove_labels(label, [label_to_remove])
+      end
+
+      def drop_constraint(label, property)
+        neo4j_label = Neo4j::Label.create(label)
+        fail Neo4j::MigrationError,
+             "No such constraint for #{label}\##{property}" unless neo4j_label.uniqueness_constraints[:property_keys].flatten.include?(property)
+        neo4j_label.drop_constraint(property, type: :unique)
+      end
+
+      def drop_index(label, property)
+        neo4j_label = Neo4j::Label.create(label)
+        fail Neo4j::MigrationError,
+             "No such index for #{label}\##{property}" unless neo4j_label.indexes[:property_keys].flatten.include?(property)
+        neo4j_label.drop_index(property, type: :exact)
       end
 
       def execute(string, params = {})
         query(string, params).to_a
       end
 
+      delegate :query, to: Neo4j::Session
+
       private
 
-      delegate :query, to: Neo4j::Session
+      def property_exists?(label, property)
+        by_label(label).where("EXISTS(n.#{property})").return(:n).any?
+      end
 
       def by_label(label, options = {})
         symbol = options[:symbol] || :n
-        Neo4j::Session.query.match("(#{symbol}:`#{label}`)")
+        query.match(symbol => label)
       end
     end
   end

--- a/lib/neo4j/migrations/helpers.rb
+++ b/lib/neo4j/migrations/helpers.rb
@@ -58,6 +58,19 @@ module Neo4j
         query(string, params).to_a
       end
 
+      def say_with_time(message)
+        say(message)
+        result = nil
+        time = Benchmark.measure { result = yield }
+        say format('%.4fs', time.real), :subitem
+        say("#{result} rows", :subitem) if result.is_a?(Integer)
+        result
+      end
+
+      def say(message, subitem = false)
+        output "#{subitem ? '   ->' : '--'} #{message}"
+      end
+
       delegate :query, to: Neo4j::Session
 
       protected

--- a/lib/neo4j/migrations/helpers.rb
+++ b/lib/neo4j/migrations/helpers.rb
@@ -40,6 +40,10 @@ module Neo4j
         remove_labels(label, [label_to_remove])
       end
 
+      def rename_label(old_label, new_label)
+        by_label(old_label).set(n: new_label).remove(n: old_label).exec
+      end
+
       def drop_constraint(label, property)
         fail Neo4j::MigrationError, format(SCHEMA_CHANGE_IN_TRANSACTIONS, 'constraints') if transactions? || Neo4j::Transaction.current
         constraint = Neo4j::Schema::UniqueConstraintOperation.new(label, property)
@@ -85,7 +89,6 @@ module Neo4j
         fail Neo4j::MigrationError,
              format(CONSTRAINT_OR_INDEX_MISSING, type: type, label: label, property: property)
       end
-
 
       def property_exists?(label, property)
         by_label(label).where("EXISTS(n.#{property})").return(:n).any?

--- a/lib/neo4j/migrations/helpers.rb
+++ b/lib/neo4j/migrations/helpers.rb
@@ -9,9 +9,9 @@ module Neo4j
       end
 
       def drop_nodes(label)
-        Neo4j::Session.query.match("(n:`#{label}`)")
-                      .optional_match('(n)-[r]-()')
-                      .delete(:r, :n).exec
+        query.match("(n:`#{label}`)")
+             .optional_match('(n)-[r]-()')
+             .delete(:r, :n).exec
       end
 
       def add_labels(label, *labels)
@@ -33,11 +33,13 @@ module Neo4j
         execute("DROP INDEX ON :#{label}(#{property})")
       end
 
-      def execute(string)
-        Neo4j::Session.query(string).to_a
+      def execute(string, params = {})
+        query(string, params).to_a
       end
 
       private
+
+      delegate :query, to: Neo4j::Session
 
       def by_label(label, symbol: :n)
         Neo4j::Session.query.match("(#{symbol}:`#{label}`)")

--- a/lib/neo4j/migrations/helpers.rb
+++ b/lib/neo4j/migrations/helpers.rb
@@ -41,7 +41,8 @@ module Neo4j
 
       delegate :query, to: Neo4j::Session
 
-      def by_label(label, symbol: :n)
+      def by_label(label, options = {})
+        symbol = options[:symbol] || :n
         Neo4j::Session.query.match("(#{symbol}:`#{label}`)")
       end
     end

--- a/lib/neo4j/migrations/helpers.rb
+++ b/lib/neo4j/migrations/helpers.rb
@@ -1,0 +1,47 @@
+module Neo4j
+  module Migrations
+    module Helpers
+      def rename_property(label, old_property, new_property)
+        by_label(label).where(n: {new_property => nil})
+                       .set("n.#{new_property} = n.#{old_property}")
+                       .remove("n.#{old_property}")
+                       .exec
+      end
+
+      def drop_nodes(label)
+        Neo4j::Session.query.match("(n:`#{label}`)")
+                      .optional_match('(n)-[r]-()')
+                      .delete(:r, :n).exec
+      end
+
+      def add_labels(label, *labels)
+        by_label(label).set("n:#{labels.join(':')}").exec
+      end
+
+      def remove_labels(label, *labels)
+        by_label(label).remove("n:#{labels.join(':')}").exec
+      end
+
+      alias add_label add_labels
+      alias remove_label remove_labels
+
+      def remove_constraint(label, property)
+        execute("DROP CONSTRAINT ON (n:`#{label}`) ASSERT n.#{property} IS UNIQUE")
+      end
+
+      def remove_index(label, property)
+        execute("DROP INDEX ON :#{label}(#{property})")
+      end
+
+      def execute(string)
+        Neo4j::Session.query(string).to_a
+      end
+
+      private
+
+      def by_label(label, symbol: :n)
+        Neo4j::Session.query.match("(#{symbol}:`#{label}`)")
+      end
+    end
+  end
+end

--- a/lib/neo4j/migrations/migration_file.rb
+++ b/lib/neo4j/migrations/migration_file.rb
@@ -17,7 +17,7 @@ module Neo4j
 
       def extract_data!
         @version, @symbol_name = File.basename(@file_name, '.rb').split('_', 2)
-        @class_name = @symbol_name.classify
+        @class_name = @symbol_name.camelize
       end
     end
   end

--- a/lib/neo4j/migrations/migration_file.rb
+++ b/lib/neo4j/migrations/migration_file.rb
@@ -1,0 +1,24 @@
+module Neo4j
+  module Migrations
+    class MigrationFile
+      attr_reader :file_name, :symbol_name, :class_name, :version
+
+      def initialize(file_name)
+        @file_name = file_name
+        extract_data!
+      end
+
+      def create
+        require file_name
+        class_name.constantize.new(version)
+      end
+
+      private
+
+      def extract_data!
+        @version, @symbol_name = File.basename(file_name, '.rb').split('_', 2)
+        @class_name = @symbol_name.split('_').map(&:capitalize).join('')
+      end
+    end
+  end
+end

--- a/lib/neo4j/migrations/migration_file.rb
+++ b/lib/neo4j/migrations/migration_file.rb
@@ -9,15 +9,15 @@ module Neo4j
       end
 
       def create
-        require file_name
-        class_name.constantize.new(version)
+        require @file_name
+        class_name.constantize.new(@version)
       end
 
       private
 
       def extract_data!
-        @version, @symbol_name = File.basename(file_name, '.rb').split('_', 2)
-        @class_name = @symbol_name.split('_').map(&:capitalize).join('')
+        @version, @symbol_name = File.basename(@file_name, '.rb').split('_', 2)
+        @class_name = @symbol_name.classify
       end
     end
   end

--- a/lib/neo4j/migrations/runner.rb
+++ b/lib/neo4j/migrations/runner.rb
@@ -1,0 +1,72 @@
+module Neo4j
+  module Migrations
+    class Runner
+      def initialize
+        @up_versions = SchemaMigration.all.pluck(:migration_id)
+      end
+
+      def all
+        all_migrations.each do |file|
+          version, file_name = *version_and_file_name_by_path(file)
+          next if @up_versions.include?(version)
+          klass = classify(file_name)
+          require file
+          migrate_up(version, klass)
+        end
+      end
+
+      def up(version)
+        file = find_by_version!(version)
+        return if @up_versions.include?(version)
+        _, file_name = *version_and_file_name_by_path(file)
+        require file
+        migrate_up(version, classify(file_name))
+      end
+
+      def down(version)
+        file = find_by_version!(version)
+        return if @up_versions.include?(version)
+        _, file_name = *version_and_file_name_by_path(file)
+        require file
+        migrate_down(version, classify(file_name))
+      end
+
+      def rollback
+        fail NotImplementedError
+      end
+
+      private
+
+      def classify(string)
+        string.split('_').map(&:capitalize).join('')
+      end
+
+      def version_and_file_name_by_path(path)
+        File.basename(path, '.rb').split('_', 2)
+      end
+
+      def migrate_up(version, klass)
+        puts "== #{version} #{klass}: running... ========="
+        migration = klass.constantize.new(version)
+        migration.migrate(:up)
+        puts "== #{version} #{klass}: migrated ========="
+      end
+
+      def migrate_down(version, klass)
+        puts "== #{version} #{klass}: reverting... ========="
+        migration = klass.constantize.new(version)
+        migration.migrate(:down)
+        puts "== #{version} #{klass}: reverted ========="
+      end
+
+      def find_by_version!(version)
+        all_migrations.find { |file| File.basename(file).starts_with?(version) } ||
+          fail("No such migration #{version}")
+      end
+
+      def all_migrations
+        Dir[Rails.root.join('db', 'neo4j', 'migrate', '*.rb')].sort
+      end
+    end
+  end
+end

--- a/lib/neo4j/migrations/runner.rb
+++ b/lib/neo4j/migrations/runner.rb
@@ -7,32 +7,34 @@ module Neo4j
       STATUS_TABLE_HEADER = ['Status'.freeze, 'Migration ID'.freeze, 'Migration Name'.freeze].freeze
       UP_MESSAGE = 'up'.freeze
       DOWN_MESSAGE = 'down'.freeze
+      MIGRATION_RUNNING = { up: 'running'.freeze, down: 'reverting'.freeze }.freeze
+      MIGRATION_DONE = { up: 'migrated'.freeze, down: 'reverted'.freeze }.freeze
 
       def initialize
-        @up_versions = SchemaMigration.all.pluck(:migration_id)
+        @up_versions = SortedSet.new(SchemaMigration.all.pluck(:migration_id))
       end
 
       def all
         migration_files.each do |migration_file|
-          next if @up_versions.include?(migration_file.version)
-          migrate_up(migration_file)
+          next if up?(migration_file.version)
+          migrate(:up, migration_file)
         end
       end
 
       def up(version)
         migration_file = find_by_version!(version)
-        return if @up_versions.include?(version)
-        migrate_up(migration_file)
+        return if up?(version)
+        migrate(:up, migration_file)
       end
 
       def down(version)
         migration_file = find_by_version!(version)
-        return unless @up_versions.include?(version)
-        migrate_down(migration_file)
+        return unless up?(version)
+        migrate(:down, migration_file)
       end
 
       def rollback(steps)
-        @up_versions.sort.reverse.first(steps).each do |version|
+        @up_versions.to_a.reverse.first(steps).each do |version|
           down(version)
         end
       end
@@ -41,7 +43,7 @@ module Neo4j
         output STATUS_TABLE_FORMAT, *STATUS_TABLE_HEADER
         output SEPARATOR
         all_migrations.each do |version|
-          status = @up_versions.include?(version) ? UP_MESSAGE : DOWN_MESSAGE
+          status = up?(version) ? UP_MESSAGE : DOWN_MESSAGE
           migration_file = find_by_version(version)
           migration_name = migration_file ? migration_file.class_name : FILE_MISSING
           output STATUS_TABLE_FORMAT, status, version, migration_name
@@ -50,28 +52,25 @@ module Neo4j
 
       private
 
-      def migrate_up(migration_file)
-        migration_message(migration_file, 'running', 'migrated') do
+      def up?(version)
+        @up_versions.include?(version)
+      end
+
+      def migrate(direction, migration_file)
+        migration_message(direction, migration_file) do
           migration = migration_file.create
-          migration.migrate(:up)
+          migration.migrate(direction)
         end
       end
 
-      def migrate_down(migration_file)
-        migration_message(migration_file, 'reverting', 'reverted') do
-          migration = migration_file.create
-          migration.migrate(:down)
-        end
-      end
-
-      def migration_message(migration, running_message, complete_message)
-        output "== #{migration.version} #{migration.class_name}: #{running_message}... ========="
+      def migration_message(direction, migration)
+        output "== #{migration.version} #{migration.class_name}: #{MIGRATION_RUNNING[direction]}... ========="
         yield
-        output "== #{migration.version} #{migration.class_name}: #{complete_message} ========="
+        output "== #{migration.version} #{migration.class_name}: #{MIGRATION_DONE[direction]} ========="
       end
 
       def output(*string_format)
-        puts format(*string_format) unless ENV['silenced']
+        puts format(*string_format) unless !!ENV['MIGRATIONS_SILENCED']
       end
 
       def find_by_version!(version)
@@ -83,7 +82,7 @@ module Neo4j
       end
 
       def all_migrations
-        (@up_versions + files_versions).uniq.sort
+        @up_versions + files_versions
       end
 
       def files_versions

--- a/lib/neo4j/migrations/runner.rb
+++ b/lib/neo4j/migrations/runner.rb
@@ -7,8 +7,8 @@ module Neo4j
       STATUS_TABLE_HEADER = ['Status'.freeze, 'Migration ID'.freeze, 'Migration Name'.freeze].freeze
       UP_MESSAGE = 'up'.freeze
       DOWN_MESSAGE = 'down'.freeze
-      MIGRATION_RUNNING = { up: 'running'.freeze, down: 'reverting'.freeze }.freeze
-      MIGRATION_DONE = { up: 'migrated'.freeze, down: 'reverted'.freeze }.freeze
+      MIGRATION_RUNNING = {up: 'running'.freeze, down: 'reverting'.freeze}.freeze
+      MIGRATION_DONE = {up: 'migrated'.freeze, down: 'reverted'.freeze}.freeze
 
       def initialize
         @up_versions = SortedSet.new(SchemaMigration.all.pluck(:migration_id))

--- a/lib/neo4j/migrations/schema_migration.rb
+++ b/lib/neo4j/migrations/schema_migration.rb
@@ -1,0 +1,11 @@
+module Neo4j
+  module Migrations
+    class SchemaMigration
+      include Neo4j::ActiveNode
+
+      property :migration_id, type: String, constraint: :unique
+
+      validates :migration_id, presence: true, uniqueness: true
+    end
+  end
+end

--- a/lib/neo4j/migrations/schema_migration.rb
+++ b/lib/neo4j/migrations/schema_migration.rb
@@ -2,10 +2,8 @@ module Neo4j
   module Migrations
     class SchemaMigration
       include Neo4j::ActiveNode
-
-      property :migration_id, type: String, constraint: :unique
-
-      validates :migration_id, presence: true, uniqueness: true
+      id_property :migration_id
+      property :migration_id, type: String
     end
   end
 end

--- a/lib/neo4j/tasks/migration.rake
+++ b/lib/neo4j/tasks/migration.rake
@@ -2,7 +2,7 @@ require 'neo4j/migration'
 
 namespace :neo4j do
   desc 'Run a script against the database to perform system-wide changes'
-  task :migrate, [:task_name, :subtask] => :environment do |_, args|
+  task :legacy_migrate, [:task_name, :subtask] => :environment do |_, args|
     path = Rake.original_dir
     migration_task = args[:task_name]
     task_name_constant = migration_task.split('_').map(&:capitalize).join('')
@@ -20,5 +20,38 @@ namespace :neo4j do
     else
       migration.migrate
     end
+  end
+
+  desc 'A shortcut for neo4j::migrate::all'
+  task :migrate do
+    Rake::Task['neo4j::migrate::all'].invoke
+  end
+
+  namespace :migrate do
+    desc 'Run all pending migrations'
+    task :all do
+      runner = Neo4j::Migrations::Runner.new
+      runner.all
+    end
+
+    desc 'Run a migration given its VERSION'
+    task :up do
+      version = ENV['VERSION'] || fail('VERSION is required')
+      runner = Neo4j::Migrations::Runner.new
+      runner.up version
+    end
+
+    desc 'Reverts a migration given its VERSION'
+    task :down do
+      version = ENV['VERSION'] || fail('VERSION is required')
+      runner = Neo4j::Migrations::Runner.new
+      runner.down version
+    end
+  end
+
+  desc 'Rollbacks migrations given a STEP number'
+  task :rollback do
+    runner = Neo4j::Migrations::Runner.new
+    runner.rollback
   end
 end

--- a/lib/neo4j/tasks/migration.rake
+++ b/lib/neo4j/tasks/migration.rake
@@ -24,7 +24,7 @@ namespace :neo4j do
 
   desc 'A shortcut for neo4j::migrate::all'
   task :migrate do
-    Rake::Task['neo4j::migrate::all'].invoke
+    Rake::Task['neo4j:migrate:all'].invoke
   end
 
   namespace :migrate do

--- a/lib/neo4j/tasks/migration.rake
+++ b/lib/neo4j/tasks/migration.rake
@@ -36,22 +36,29 @@ namespace :neo4j do
 
     desc 'Run a migration given its VERSION'
     task :up do
-      version = ENV['VERSION'] || fail('VERSION is required')
+      version = ENV['VERSION'] || fail(ArgumentError, 'VERSION is required')
       runner = Neo4j::Migrations::Runner.new
       runner.up version
     end
 
-    desc 'Reverts a migration given its VERSION'
+    desc 'Revert a migration given its VERSION'
     task :down do
-      version = ENV['VERSION'] || fail('VERSION is required')
+      version = ENV['VERSION'] || fail(ArgumentError, 'VERSION is required')
       runner = Neo4j::Migrations::Runner.new
       runner.down version
+    end
+
+    desc 'Print a report of migrations status'
+    task :status do
+      runner = Neo4j::Migrations::Runner.new
+      runner.status
     end
   end
 
   desc 'Rollbacks migrations given a STEP number'
   task :rollback do
+    steps = (ENV['STEP'] || 1).to_i
     runner = Neo4j::Migrations::Runner.new
-    runner.rollback
+    runner.rollback(steps)
   end
 end

--- a/lib/rails/generators/neo4j_generator.rb
+++ b/lib/rails/generators/neo4j_generator.rb
@@ -48,6 +48,29 @@ class Neo4j::Generators::ActiveModel < Rails::Generators::ActiveModel #:nodoc:
   end
 end
 
+module Neo4j
+  module Generators
+    class Migration < ::Rails::Generators::NamedBase
+      def create_migration_file
+        real_file_name = "#{Time.zone.now.strftime('%Y%m%d%H%M%S')}_#{file_name.parameterize}"
+        class_name = file_name.camelize
+
+        create_file "db/neo4j/migrate/#{real_file_name}.rb", <<-FILE
+class #{class_name} < Neo4j::Migrations::Base
+  def up
+  end
+
+  def down
+    raise Neo4j::IrreversibleMigration
+  end
+end
+        FILE
+      end
+    end
+  end
+end
+
+
 module Rails
   module Generators
     class GeneratedAttribute #:nodoc:

--- a/spec/e2e/migration_spec.rb
+++ b/spec/e2e/migration_spec.rb
@@ -1,9 +1,6 @@
 
 describe 'migration tasks' do
-  require 'neo4j/migration'
-
-  before(:all) { ENV['silenced'] = 'true' }
-  after(:all)  { ENV['silenced'] = nil }
+  let_env_variable('MIGRATIONS_SILENCED') { 'true' }
 
   before do
     stub_active_node_class('User') do

--- a/spec/e2e/migrations_spec.rb
+++ b/spec/e2e/migrations_spec.rb
@@ -1,0 +1,113 @@
+describe Neo4j::Migrations::Runner do
+  before(:all) { ENV['silenced'] = 'true' }
+  after(:all)  { ENV['silenced'] = nil }
+
+  before do
+    stub_active_node_class('User') do
+      property :name
+    end
+
+    allow_any_instance_of(described_class).to receive(:files_path) do
+      Rails.root.join('spec', 'support', 'migrations', '*.rb')
+    end
+    Neo4j::Migrations::SchemaMigration.delete_all
+  end
+
+  let(:all_migrations_on!) do
+    Neo4j::Migrations::SchemaMigration.create! migration_id: '1234567890'
+    Neo4j::Migrations::SchemaMigration.create! migration_id: '9500000000'
+    Neo4j::Migrations::SchemaMigration.create! migration_id: '9500000001'
+  end
+
+  describe '#all' do
+    it 'runs all migrations sorted by version' do
+      u = User.create! name: 'John'
+      expect do
+        described_class.new.all
+      end.to change { Neo4j::Migrations::SchemaMigration.count }.by(3)
+        .and(change { u.reload.name }.to('Frank'))
+    end
+
+    it 'skips up migrations' do
+      u = User.create! name: 'Jack'
+      Neo4j::Migrations::SchemaMigration.create! migration_id: '1234567890'
+      expect do
+        described_class.new.all
+      end.to change { Neo4j::Migrations::SchemaMigration.count }.by(2)
+        .and(change { u.reload.name }.to('Frank'))
+    end
+  end
+
+  describe '#status' do
+    before do
+      Neo4j::Migrations::SchemaMigration.create! migration_id: '1234567890'
+      Neo4j::Migrations::SchemaMigration.create! migration_id: '9500000000'
+      Neo4j::Migrations::SchemaMigration.create! migration_id: '9400000000'
+    end
+
+    it 'prints the current migration status' do
+      output_string = ''
+      allow_any_instance_of(described_class).to receive(:output) do |_, *args|
+        output_string += format(*args) + "\n"
+      end
+      described_class.new.status
+      expect(output_string).to match(/^\s*up\s*1234567890\s*RenameJohnJack$/)
+      expect(output_string).to match(/^\s*down\s*9500000001\s*RenameBobFrank/)
+      expect(output_string).to match(/^\s*up\s*9400000000\s*\*\*\*\* file missing \*\*\*\*/)
+    end
+  end
+
+  describe '#up' do
+    it 'runs a certain migration version' do
+      u = User.create! name: 'Jack'
+      expect do
+        described_class.new.up '9500000000'
+      end.to change { u.reload.name }.to('Bob')
+        .and(change { Neo4j::Migrations::SchemaMigration.count }.by(1))
+    end
+
+    it 'runs a certain migration version' do
+      u = User.create! name: 'Jack'
+      expect do
+        described_class.new.up '9500000000'
+      end.to change { u.reload.name }.to('Bob')
+        .and(change { Neo4j::Migrations::SchemaMigration.count }.by(1))
+    end
+
+    it 'fails when passing a missing version' do
+      expect { described_class.new.up '123123' }.to raise_error(
+        Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
+    end
+  end
+
+  describe '#down' do
+    before { all_migrations_on! }
+
+    it 'runs a certain migration version' do
+      u = User.create! name: 'Bob'
+      expect do
+        described_class.new.down '9500000000'
+      end.to change { u.reload.name }.to('Jack')
+    end
+
+    it 'fails when passing a missing version' do
+      expect { described_class.new.down '123123' }.to raise_error(
+        Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
+    end
+
+    it 'fails on irreversible migrations' do
+      expect { described_class.new.down '1234567890' }.to raise_error(Neo4j::IrreversibleMigration)
+    end
+  end
+
+  describe '#rollback' do
+    it 'rollbacks migrations given a number of steps' do
+      all_migrations_on!
+      u = User.create! name: 'Frank'
+      expect do
+        described_class.new.rollback 2
+      end.to change { Neo4j::Migrations::SchemaMigration.count }.by(-2)
+        .and(change { u.reload.name }.to('Jack'))
+    end
+  end
+end

--- a/spec/e2e/migrations_spec.rb
+++ b/spec/e2e/migrations_spec.rb
@@ -1,113 +1,116 @@
-describe Neo4j::Migrations::Runner do
-  before(:all) { ENV['silenced'] = 'true' }
-  after(:all)  { ENV['silenced'] = nil }
+module Neo4j
+  module Migrations
+    describe Runner do
+      let_env_variable('MIGRATIONS_SILENCED') { 'true' }
 
-  before do
-    stub_active_node_class('User') do
-      property :name
-    end
+      before do
+        stub_active_node_class('User') do
+          property :name
+        end
 
-    allow_any_instance_of(described_class).to receive(:files_path) do
-      Rails.root.join('spec', 'support', 'migrations', '*.rb')
-    end
-    Neo4j::Migrations::SchemaMigration.delete_all
-  end
-
-  let(:all_migrations_on!) do
-    Neo4j::Migrations::SchemaMigration.create! migration_id: '1234567890'
-    Neo4j::Migrations::SchemaMigration.create! migration_id: '9500000000'
-    Neo4j::Migrations::SchemaMigration.create! migration_id: '9500000001'
-  end
-
-  describe '#all' do
-    it 'runs all migrations sorted by version' do
-      u = User.create! name: 'John'
-      expect do
-        described_class.new.all
-      end.to change { Neo4j::Migrations::SchemaMigration.count }.by(3)
-        .and(change { u.reload.name }.to('Frank'))
-    end
-
-    it 'skips up migrations' do
-      u = User.create! name: 'Jack'
-      Neo4j::Migrations::SchemaMigration.create! migration_id: '1234567890'
-      expect do
-        described_class.new.all
-      end.to change { Neo4j::Migrations::SchemaMigration.count }.by(2)
-        .and(change { u.reload.name }.to('Frank'))
-    end
-  end
-
-  describe '#status' do
-    before do
-      Neo4j::Migrations::SchemaMigration.create! migration_id: '1234567890'
-      Neo4j::Migrations::SchemaMigration.create! migration_id: '9500000000'
-      Neo4j::Migrations::SchemaMigration.create! migration_id: '9400000000'
-    end
-
-    it 'prints the current migration status' do
-      output_string = ''
-      allow_any_instance_of(described_class).to receive(:output) do |_, *args|
-        output_string += format(*args) + "\n"
+        allow_any_instance_of(described_class).to receive(:files_path) do
+          Rails.root.join('spec', 'support', 'migrations', '*.rb')
+        end
+        SchemaMigration.delete_all
       end
-      described_class.new.status
-      expect(output_string).to match(/^\s*up\s*1234567890\s*RenameJohnJack$/)
-      expect(output_string).to match(/^\s*down\s*9500000001\s*RenameBobFrank/)
-      expect(output_string).to match(/^\s*up\s*9400000000\s*\*\*\*\* file missing \*\*\*\*/)
-    end
-  end
 
-  describe '#up' do
-    it 'runs a certain migration version' do
-      u = User.create! name: 'Jack'
-      expect do
-        described_class.new.up '9500000000'
-      end.to change { u.reload.name }.to('Bob')
-        .and(change { Neo4j::Migrations::SchemaMigration.count }.by(1))
-    end
+      let(:all_migrations_on!) do
+        SchemaMigration.create! migration_id: '1234567890'
+        SchemaMigration.create! migration_id: '9500000000'
+        SchemaMigration.create! migration_id: '9500000001'
+      end
 
-    it 'runs a certain migration version' do
-      u = User.create! name: 'Jack'
-      expect do
-        described_class.new.up '9500000000'
-      end.to change { u.reload.name }.to('Bob')
-        .and(change { Neo4j::Migrations::SchemaMigration.count }.by(1))
-    end
+      describe '#all' do
+        it 'runs all migrations sorted by version' do
+          u = User.create! name: 'John'
+          expect do
+            described_class.new.all
+          end.to change { SchemaMigration.count }.by(3)
+            .and(change { u.reload.name }.to('Frank'))
+        end
 
-    it 'fails when passing a missing version' do
-      expect { described_class.new.up '123123' }.to raise_error(
-        Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
-    end
-  end
+        it 'skips up migrations' do
+          u = User.create! name: 'Jack'
+          SchemaMigration.create! migration_id: '1234567890'
+          expect do
+            described_class.new.all
+          end.to change { Neo4j::Migrations::SchemaMigration.count }.by(2)
+            .and(change { u.reload.name }.to('Frank'))
+        end
+      end
 
-  describe '#down' do
-    before { all_migrations_on! }
+      describe '#status' do
+        before do
+          SchemaMigration.create! migration_id: '1234567890'
+          SchemaMigration.create! migration_id: '9500000000'
+          SchemaMigration.create! migration_id: '9400000000'
+        end
 
-    it 'runs a certain migration version' do
-      u = User.create! name: 'Bob'
-      expect do
-        described_class.new.down '9500000000'
-      end.to change { u.reload.name }.to('Jack')
-    end
+        it 'prints the current migration status' do
+          output_string = ''
+          allow_any_instance_of(described_class).to receive(:output) do |_, *args|
+            output_string += format(*args) + "\n"
+          end
+          described_class.new.status
+          expect(output_string).to match(/^\s*up\s*1234567890\s*RenameJohnJack$/)
+          expect(output_string).to match(/^\s*down\s*9500000001\s*RenameBobFrank/)
+          expect(output_string).to match(/^\s*up\s*9400000000\s*\*\*\*\* file missing \*\*\*\*/)
+        end
+      end
 
-    it 'fails when passing a missing version' do
-      expect { described_class.new.down '123123' }.to raise_error(
-        Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
-    end
+      describe '#up' do
+        it 'runs a certain migration version' do
+          u = User.create! name: 'Jack'
+          expect do
+            described_class.new.up '9500000000'
+          end.to change { u.reload.name }.to('Bob')
+            .and(change { SchemaMigration.count }.by(1))
+        end
 
-    it 'fails on irreversible migrations' do
-      expect { described_class.new.down '1234567890' }.to raise_error(Neo4j::IrreversibleMigration)
-    end
-  end
+        it 'runs a certain migration version' do
+          u = User.create! name: 'Jack'
+          expect do
+            described_class.new.up '9500000000'
+          end.to change { u.reload.name }.to('Bob')
+            .and(change { SchemaMigration.count }.by(1))
+        end
 
-  describe '#rollback' do
-    it 'rollbacks migrations given a number of steps' do
-      all_migrations_on!
-      u = User.create! name: 'Frank'
-      expect do
-        described_class.new.rollback 2
-      end.to change { Neo4j::Migrations::SchemaMigration.count }.by(-2)
-        .and(change { u.reload.name }.to('Jack'))
+        it 'fails when passing a missing version' do
+          expect { described_class.new.up '123123' }.to raise_error(
+            ::Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
+        end
+      end
+
+      describe '#down' do
+        before { all_migrations_on! }
+
+        it 'runs a certain migration version' do
+          u = User.create! name: 'Bob'
+          expect do
+            described_class.new.down '9500000000'
+          end.to change { u.reload.name }.to('Jack')
+        end
+
+        it 'fails when passing a missing version' do
+          expect { described_class.new.down '123123' }.to raise_error(
+            Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
+        end
+
+        it 'fails on irreversible migrations' do
+          expect { described_class.new.down '1234567890' }.to raise_error(::Neo4j::IrreversibleMigration)
+        end
+      end
+
+      describe '#rollback' do
+        it 'rollbacks migrations given a number of steps' do
+          all_migrations_on!
+          u = User.create! name: 'Frank'
+          expect do
+            described_class.new.rollback 2
+          end.to change { SchemaMigration.count }.by(-2)
+            .and(change { u.reload.name }.to('Jack'))
+        end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -125,6 +125,16 @@ module Neo4jSpecHelpers
         @neo4j_config_vars.delete(var_name)
       end
     end
+
+    def let_env_variable(var_name)
+      before do
+        ENV[var_name] = yield
+      end
+
+      after do
+        ENV[var_name] = nil
+      end
+    end
   end
 
   # rubocop:disable Style/GlobalVars

--- a/spec/support/migrations/1234567890_rename_john_jack.rb
+++ b/spec/support/migrations/1234567890_rename_john_jack.rb
@@ -1,0 +1,10 @@
+class RenameJohnJack < Neo4j::Migrations::Base
+  def up
+    execute 'MATCH (u:`User`) WHERE u.name = {name} SET u.name = {new_name}',
+            name: 'John', new_name: 'Jack'
+  end
+
+  def down
+    fail Neo4j::IrreversibleMigration
+  end
+end

--- a/spec/support/migrations/9500000000_rename_jack_bob.rb
+++ b/spec/support/migrations/9500000000_rename_jack_bob.rb
@@ -1,0 +1,11 @@
+class RenameJackBob < Neo4j::Migrations::Base
+  def up
+    execute 'MATCH (u:`User`) WHERE u.name = {name} SET u.name = {new_name}',
+            name: 'Jack', new_name: 'Bob'
+  end
+
+  def down
+    execute 'MATCH (u:`User`) WHERE u.name = {name} SET u.name = {new_name}',
+            name: 'Bob', new_name: 'Jack'
+  end
+end

--- a/spec/support/migrations/9500000001_rename_bob_frank.rb
+++ b/spec/support/migrations/9500000001_rename_bob_frank.rb
@@ -1,0 +1,11 @@
+class RenameBobFrank < Neo4j::Migrations::Base
+  def up
+    execute 'MATCH (u:`User`) WHERE u.name = {name} SET u.name = {new_name}',
+            name: 'Bob', new_name: 'Frank'
+  end
+
+  def down
+    execute 'MATCH (u:`User`) WHERE u.name = {name} SET u.name = {new_name}',
+            name: 'Frank', new_name: 'Bob'
+  end
+end

--- a/spec/support/transactional_migrations/1231231231_failing_migration.rb
+++ b/spec/support/transactional_migrations/1231231231_failing_migration.rb
@@ -1,0 +1,11 @@
+class FailingMigration < Neo4j::Migrations::Base
+  def up
+    execute 'MATCH (u:`User`) WHERE u.name = {name} SET u.name = {new_name}',
+            name: 'Joe', new_name: 'Jack'
+    execute 'CREATE (n:`Contact` {phone: "123123"})'
+  end
+
+  def down
+    fail Neo4j::IrreversibleMigration
+  end
+end

--- a/spec/support/transactional_migrations/1234567890_migration_without_transaction.rb
+++ b/spec/support/transactional_migrations/1234567890_migration_without_transaction.rb
@@ -1,0 +1,13 @@
+class MigrationWithoutTransaction < Neo4j::Migrations::Base
+  disable_transactions!
+
+  def up
+    execute 'MATCH (u:`User`) WHERE u.name = {name} SET u.name = {new_name}',
+            name: 'Joe', new_name: 'Jack'
+    execute 'CREATE (n:`Contact` {phone: "123123"})'
+  end
+
+  def down
+    fail Neo4j::IrreversibleMigration
+  end
+end

--- a/spec/support/transactional_migrations/1234567890_migration_without_transactions.rb
+++ b/spec/support/transactional_migrations/1234567890_migration_without_transactions.rb
@@ -1,4 +1,4 @@
-class MigrationWithoutTransaction < Neo4j::Migrations::Base
+class MigrationWithoutTransactions < Neo4j::Migrations::Base
   disable_transactions!
 
   def up

--- a/spec/unit/migrations/helpers_spec.rb
+++ b/spec/unit/migrations/helpers_spec.rb
@@ -1,0 +1,60 @@
+describe Neo4j::Migrations::Helpers do
+  include described_class
+
+  before do
+    clear_model_memory_caches
+    delete_db
+
+    stub_active_node_class('Book') do
+      property :name, constraint: :unique
+      property :author_name, index: :exact
+    end
+
+    Book.create!(name: 'Book1')
+    Book.create!(name: 'Book2')
+    Book.create!(name: 'Book3')
+  end
+
+  describe '#rename_property' do
+    it 'renames a property' do
+      rename_property :Book, :name, :title
+      expect(Book.all.pluck(n: :title)).to include('Book1', 'Book2', 'Book3')
+    end
+  end
+
+  describe '#drop_nodes' do
+    it 'drops all nodes given a label' do
+      drop_nodes :Book
+      expect(Book.all.count).to eq(0)
+    end
+  end
+
+  describe '#add_labels' do
+    it 'adds labels to a node' do
+      add_labels :Book, :Item, :Readable
+      expect(Book.first.labels).to eq([:Book, :Item, :Readable])
+    end
+  end
+
+  describe '#remove_labels' do
+    it 'removes labels from a node' do
+      add_labels :Book, :Item
+      expect(Book.first.labels).to eq([:Book, :Item])
+      remove_labels :Book, :Item
+      expect(Book.first.labels).to eq([:Book])
+    end
+  end
+
+  describe '#remove_constraint' do
+    it 'removes a constraint from a property' do
+      remove_constraint :Book, :name
+      expect { Book.create! name: Book.first.name }.not_to raise_error
+    end
+  end
+
+  describe '#remove_index' do
+    it 'removes an index from a property' do
+      remove_index :Book, :author_name
+    end
+  end
+end

--- a/spec/unit/migrations/helpers_spec.rb
+++ b/spec/unit/migrations/helpers_spec.rb
@@ -69,6 +69,32 @@ describe Neo4j::Migrations::Helpers do
     end
   end
 
+  describe '#say' do
+    it 'prints some text' do
+      expect(self).to receive(:output).with('-- Hello')
+      say 'Hello'
+    end
+
+    it 'prints some text as sub item' do
+      expect(self).to receive(:output).with('   -> Hello')
+      say 'Hello', :subitem
+    end
+  end
+
+  describe '#say_with_time' do
+    it 'wraps a block within some text' do
+      text = ''
+      allow(self).to receive(:output) do |new_text|
+        text += "#{new_text}\n"
+      end
+      say_with_time 'Hello' do
+        sleep 0.1
+        12
+      end
+      expect(text).to match(/-- Hello\n   -> [0-9]\.[0-9]+s\n   -> 12 rows\n/)
+    end
+  end
+
   describe '#drop_constraint' do
     it 'removes a constraint from a property' do
       expect do

--- a/spec/unit/migrations/helpers_spec.rb
+++ b/spec/unit/migrations/helpers_spec.rb
@@ -18,7 +18,7 @@ describe Neo4j::Migrations::Helpers do
   describe '#rename_property' do
     it 'renames a property' do
       rename_property :Book, :name, :title
-      expect(Book.all.pluck(n: :title)).to include('Book1', 'Book2', 'Book3')
+      expect(Book.all(:n).pluck('n.title')).to include('Book1', 'Book2', 'Book3')
     end
   end
 

--- a/spec/unit/migrations/helpers_spec.rb
+++ b/spec/unit/migrations/helpers_spec.rb
@@ -61,6 +61,14 @@ describe Neo4j::Migrations::Helpers do
     end
   end
 
+  describe '#rename_label' do
+    it 'renames a label' do
+      execute 'CREATE (n:`Item` { name: "Lorem Ipsum" })'
+      rename_label :Item, :Book
+      expect(Book.find_by(name: 'Lorem Ipsum')).not_to be_nil
+    end
+  end
+
   describe '#execute' do
     it 'executes plan cypher query with parameters' do
       expect do

--- a/spec/unit/migrations/helpers_spec.rb
+++ b/spec/unit/migrations/helpers_spec.rb
@@ -52,6 +52,14 @@ describe Neo4j::Migrations::Helpers do
     end
   end
 
+  describe '#execute' do
+    it 'executes plan cypher query with parameters' do
+      expect do
+        execute 'MATCH (b:`Book`) WHERE b.name = {book_name} DELETE b', book_name: Book.first.name
+      end.to change { Book.count }.by(-1)
+    end
+  end
+
   describe '#remove_index' do
     it 'removes an index from a property' do
       remove_index :Book, :author_name

--- a/spec/unit/migrations/helpers_spec.rb
+++ b/spec/unit/migrations/helpers_spec.rb
@@ -13,8 +13,6 @@ describe Neo4j::Migrations::Helpers do
       property :author_name, index: :exact
     end
 
-    self.class.disable_transactions!
-
     Book.create!(name: 'Book1')
     Book.create!(name: 'Book2')
     Book.create!(name: 'Book3')
@@ -34,7 +32,8 @@ describe Neo4j::Migrations::Helpers do
     end
 
     it 'fails to remove when destination property is already defined' do
-      expect { rename_property :Book, :author_name, :name }.to raise_error('Property `name` is already defined in `Book`')
+      expect { rename_property :Book, :author_name, :name }.to raise_error(
+        'Property `name` is already defined in `Book`. To overwrite, call `remove_property(:Book, :name)` before this method.')
     end
   end
 

--- a/spec/unit/migrations/migration_file_spec.rb
+++ b/spec/unit/migrations/migration_file_spec.rb
@@ -1,0 +1,11 @@
+describe Neo4j::Migrations::MigrationFile do
+  let(:file_name) do
+    "#{Rails.root}/spec/support/transactional_migrations/1234567890_migration_without_transactions.rb"
+  end
+  subject { described_class.new(file_name) }
+
+  its(:version) { is_expected.to eq('1234567890') }
+  its(:symbol_name) { is_expected.to eq('migration_without_transactions') }
+  its(:class_name) { is_expected.to eq('MigrationWithoutTransactions') }
+  its(:create) { is_expected.to be_a(MigrationWithoutTransactions) }
+end


### PR DESCRIPTION
This pull introduces an `ActiveRecord` like migration method.

It's W.I.P., but I have a small thing I want to discuss before proceeding:

I'm using this conventions: migration files are searched in `db/neo4j/migrate` folder using the same strategy as ActiveRecord.
Migrations state is saved in a `SchemaMigration` node.

Since i wanted to copy the ActiveRecord implementation, I created this set of tasks:

```bash
rake neo4j::migrate # Alias of ::all
rake neo4j::migrate::all
rake neo4j::migrate::up VERSION=some_version
rake neo4j::migrate::down VERSION=some_version
rake neo4j::rollback
```

However, the first one is conflicting the current neo4j migration task. For now, I renamed it `rake neo4j::legacy_migrate`. What do you think about it?

Pings:
@cheerfulstoic
@subvertallchris
