### PR TITLE
Some improvements on Migrations

### DIFF
--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -88,8 +88,8 @@ require 'neo4j/active_node'
 
 module Neo4j
   extend ActiveSupport::Autoload
-  autoload :Migration
   autoload :Migrations
+  autoload :Migration
 end
 
 require 'neo4j/active_node/orm_adapter'

--- a/lib/neo4j/migration.rb
+++ b/lib/neo4j/migration.rb
@@ -23,6 +23,8 @@ module Neo4j
     end
 
     class AddIdProperty < Neo4j::Migration
+      include Neo4j::Migrations::Helpers::IdProperty
+
       attr_reader :models_filename
 
       def initialize(path = default_path)
@@ -30,6 +32,8 @@ module Neo4j
       end
 
       def migrate
+        ActiveSupport::Deprecation.warn '`AddIdProperty` task is deprecated and may be removed from future releases. '\
+                                        'Create a new migration and use the `populate_id_property` helper.', caller
         models = ActiveSupport::HashWithIndifferentAccess.new(YAML.load_file(models_filename))[:models]
         output 'This task will add an ID Property every node in the given file.'
         output 'It may take a significant amount of time, please be patient.'
@@ -37,9 +41,11 @@ module Neo4j
           output
           output
           output "Adding IDs to #{model}"
-          add_ids_to model.constantize
+          add_id_property model
         end
       end
+
+      delegate :query, to: Neo4j::Session
 
       def setup
         FileUtils.mkdir_p('db/neo4j-migrate')
@@ -53,73 +59,6 @@ module Neo4j
 # # models: [Student,Lesson,Teacher,Exam]\nmodels: []
 MESSAGE
           file.write(message)
-        end
-      end
-
-      private
-
-      def add_ids_to(model)
-        max_per_batch = (ENV['MAX_PER_BATCH'] || default_max_per_batch).to_i
-
-        label = model.mapped_label_name
-        last_time_taken = nil
-
-        until (nodes_left = idless_count(label, model.primary_key)) == 0
-          print_status(last_time_taken, max_per_batch, nodes_left)
-
-          count = [nodes_left, max_per_batch].min
-          last_time_taken = Benchmark.realtime do
-            max_per_batch = id_batch_set(label, model.primary_key, Array.new(count) { new_id_for(model) }, count)
-          end
-        end
-      end
-
-      def idless_count(label, id_property)
-        Neo4j::Session.query.match(n: label).where("NOT EXISTS(n.#{id_property})").pluck('COUNT(n) AS ids').first
-      end
-
-      def print_status(last_time_taken, max_per_batch, nodes_left)
-        time_per_node = last_time_taken / max_per_batch if last_time_taken
-        message = if time_per_node
-                    eta_seconds = (nodes_left * time_per_node).round
-                    "#{nodes_left} nodes left.  Last batch: #{(time_per_node * 1000.0).round(1)}ms / node (ETA: #{eta_seconds / 60} minutes)\r"
-                  else
-                    "Running first batch...\r"
-                  end
-
-        print_output message
-      end
-
-
-      def id_batch_set(label, id_property, new_ids, count)
-        tx = Neo4j::Transaction.new
-
-        Neo4j::Session.query("MATCH (n:`#{label}`) WHERE NOT EXISTS(n.#{id_property})
-          with COLLECT(n) as nodes, #{new_ids} as ids
-          FOREACH(i in range(0,#{count - 1})|
-            FOREACH(node in [nodes[i]]|
-              SET node.#{id_property} = ids[i]))
-          RETURN distinct(true)
-          LIMIT #{count}")
-
-        count
-      rescue Neo4j::Server::CypherResponse::ResponseError, Faraday::TimeoutError
-        new_max_per_batch = (max_per_batch * 0.8).round
-        output "Error querying #{max_per_batch} nodes.  Trying #{new_max_per_batch}"
-        new_max_per_batch
-      ensure
-        tx.close
-      end
-
-      def default_max_per_batch
-        900
-      end
-
-      def new_id_for(model)
-        if model.id_property_info[:type][:auto]
-          SecureRandom.uuid
-        else
-          model.new.send(model.id_property_info[:type][:on])
         end
       end
     end

--- a/lib/neo4j/migration.rb
+++ b/lib/neo4j/migration.rb
@@ -41,7 +41,7 @@ module Neo4j
           output
           output
           output "Adding IDs to #{model}"
-          add_id_property model
+          populate_id_property model
         end
       end
 

--- a/lib/neo4j/migrations/base.rb
+++ b/lib/neo4j/migrations/base.rb
@@ -2,6 +2,8 @@ module Neo4j
   module Migrations
     class Base < ::Neo4j::Migration
       include Neo4j::Migrations::Helpers
+      include Neo4j::Migrations::Helpers::Schema
+      include Neo4j::Migrations::Helpers::IdProperty
 
       def initialize(migration_id)
         @migration_id = migration_id

--- a/lib/neo4j/migrations/helpers/id_property.rb
+++ b/lib/neo4j/migrations/helpers/id_property.rb
@@ -5,7 +5,7 @@ module Neo4j
         extend ActiveSupport::Concern
 
         def populate_id_property(label)
-          model = label.constantize
+          model = label.to_s.constantize
           max_per_batch = (ENV['MAX_PER_BATCH'] || default_max_per_batch).to_i
 
           last_time_taken = nil

--- a/lib/neo4j/migrations/helpers/id_property.rb
+++ b/lib/neo4j/migrations/helpers/id_property.rb
@@ -1,0 +1,75 @@
+module Neo4j
+  module Migrations
+    module Helpers
+      module IdProperty
+        extend ActiveSupport::Concern
+
+        def populate_id_property(label)
+          model = label.constantize
+          max_per_batch = (ENV['MAX_PER_BATCH'] || default_max_per_batch).to_i
+
+          last_time_taken = nil
+
+          until (nodes_left = idless_count(label, model.primary_key)) == 0
+            print_status(last_time_taken, max_per_batch, nodes_left)
+
+            count = [nodes_left, max_per_batch].min
+            last_time_taken = Benchmark.realtime do
+              max_per_batch = id_batch_set(label, model.primary_key, Array.new(count) { new_id_for(model) }, count)
+            end
+          end
+        end
+
+        protected
+
+        def idless_count(label, id_property)
+          query.match(n: label).where("NOT EXISTS(n.#{id_property})").pluck('COUNT(n) AS ids').first
+        end
+
+        def id_batch_set(label, id_property, new_ids, count)
+          tx = Neo4j::Transaction.new
+
+          query("MATCH (n:`#{label}`) WHERE NOT EXISTS(n.#{id_property})
+            with COLLECT(n) as nodes, #{new_ids} as ids
+            FOREACH(i in range(0,#{count - 1})|
+              FOREACH(node in [nodes[i]]|
+                SET node.#{id_property} = ids[i]))
+            RETURN distinct(true)
+            LIMIT #{count}")
+
+          count
+        rescue Neo4j::Server::CypherResponse::ResponseError, Faraday::TimeoutError
+          new_max_per_batch = (max_per_batch * 0.8).round
+          output "Error querying #{max_per_batch} nodes. Trying #{new_max_per_batch}"
+          new_max_per_batch
+        ensure
+          tx.close
+        end
+
+        def print_status(last_time_taken, max_per_batch, nodes_left)
+          time_per_node = last_time_taken / max_per_batch if last_time_taken
+          message = if time_per_node
+                      eta_seconds = (nodes_left * time_per_node).round
+                      "#{nodes_left} nodes left.  Last batch: #{(time_per_node * 1000.0).round(1)}ms / node (ETA: #{eta_seconds / 60} minutes)"
+                    else
+                      'Running first batch...'
+                    end
+
+          output message
+        end
+
+        def default_max_per_batch
+          900
+        end
+
+        def new_id_for(model)
+          if model.id_property_info[:type][:auto]
+            SecureRandom.uuid
+          else
+            model.new.send(model.id_property_info[:type][:on])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/neo4j/migrations/helpers/schema.rb
+++ b/lib/neo4j/migrations/helpers/schema.rb
@@ -1,0 +1,47 @@
+module Neo4j
+  module Migrations
+    module Helpers
+      module Schema
+        extend ActiveSupport::Concern
+        MISSING_CONSTRAINT_OR_INDEX = 'No such %{type} for %{label}#%{property}'.freeze
+        DUPLICATE_CONSTRAINT_OR_INDEX = 'Duplicate %{type} for %{label}#%{property}'.freeze
+
+        def add_constraint(label, property)
+          constraint = Neo4j::Schema::UniqueConstraintOperation.new(label, property)
+          fail_duplicate_constraint_or_index!(:constraint, label, property) if constraint.exist?
+          constraint.create!
+        end
+
+        def add_index(label, property)
+          index = Neo4j::Schema::ExactIndexOperation.new(label, property)
+          fail_duplicate_constraint_or_index!(:index, label, property) if index.exist?
+          index.create!
+        end
+
+        def drop_constraint(label, property)
+          constraint = Neo4j::Schema::UniqueConstraintOperation.new(label, property)
+          fail_missing_constraint_or_index!(:constraint, label, property) unless constraint.exist?
+          constraint.drop!
+        end
+
+        def drop_index(label, property)
+          index = Neo4j::Schema::ExactIndexOperation.new(label, property)
+          fail_missing_constraint_or_index!(:index, label, property) unless index.exist?
+          index.drop!
+        end
+
+        protected
+
+        def fail_missing_constraint_or_index!(type, label, property)
+          fail Neo4j::MigrationError,
+               format(MISSING_CONSTRAINT_OR_INDEX, type: type, label: label, property: property)
+        end
+
+        def fail_duplicate_constraint_or_index!(type, label, property)
+          fail Neo4j::MigrationError,
+               format(DUPLICATE_CONSTRAINT_OR_INDEX, type: type, label: label, property: property)
+        end
+      end
+    end
+  end
+end

--- a/lib/neo4j/tasks/migration.rake
+++ b/lib/neo4j/tasks/migration.rake
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+require 'neo4j/migrations/helpers/id_property'
 require 'neo4j/migration'
 
 namespace :neo4j do

--- a/spec/unit/migrations/helpers_spec.rb
+++ b/spec/unit/migrations/helpers_spec.rb
@@ -104,6 +104,66 @@ describe Neo4j::Migrations::Helpers do
     end
   end
 
+  describe '#add_constraint' do
+    after { drop_constraint :Book, :code if Neo4j::Label.constraint?(:Book, :code) }
+
+    it 'adds a constraint to a property' do
+      expect do
+        add_constraint :Book, :code
+      end.to change { Neo4j::Label.constraint?(:Book, :code) }.from(false).to(true)
+    end
+
+    it 'fails when constraint is already defined' do
+      expect { add_constraint :Book, :name }.to raise_error('Duplicate constraint for Book#name')
+    end
+  end
+
+  describe '#add_index' do
+    after { drop_index :Book, :pages if Neo4j::Label.index?(:Book, :pages) }
+    it 'adds an index to a property' do
+      expect do
+        add_index :Book, :pages
+      end.to change { Neo4j::Label.index?(:Book, :pages) }.from(false).to(true)
+    end
+
+    it 'fails when index is already defined' do
+      expect do
+        expect { add_index :Book, :author_name }.to raise_error('Duplicate index for Book#author_name')
+      end.not_to change { Neo4j::Label.create(:Book).indexes[:property_keys].flatten.count }
+    end
+  end
+
+  describe '#populate_id_property' do
+    before do
+      3.times do
+        execute 'CREATE (c:`Cat`)'
+        execute 'CREATE (d:`Dog`)'
+      end
+
+      stub_active_node_class('Cat') {}
+      stub_active_node_class('Dog') do
+        id_property :my_id, on: :generate_id
+
+        def generate_id
+          "id-#{rand}"
+        end
+      end
+    end
+
+    it 'populates uuid' do
+      populate_id_property :Cat
+      uuids = Cat.all.pluck(:uuid)
+      expect(uuids.count).to eq(3)
+      expect(uuids.all? { |u| u =~ /\A([a-z0-9]+\-?)+\Z/ }).to be_truthy
+    end
+
+    it 'populates custom ids' do
+      populate_id_property :Dog
+      uuids = Dog.all(:n).pluck('n.my_id')
+      expect(uuids.all? { |u| u.start_with?('id-') }).to be_truthy
+    end
+  end
+
   describe '#drop_constraint' do
     it 'removes a constraint from a property' do
       expect do

--- a/spec/unit/migrations/helpers_spec.rb
+++ b/spec/unit/migrations/helpers_spec.rb
@@ -1,5 +1,7 @@
 describe Neo4j::Migrations::Helpers do
   include described_class
+  include Neo4j::Migrations::Helpers::Schema
+  include Neo4j::Migrations::Helpers::IdProperty
 
   before do
     Neo4j::Session.current.close if Neo4j::Session.current


### PR DESCRIPTION
This pull introduces/changes:
 * `add_index` and `add_constraint` helpers
 * A `populate_id_property` helper, as a replacement for the legacy `AddIdProperty` task
 * Splits migration helpers in submodules



Pings:
@cheerfulstoic
@subvertallchris

