### PR TITLE
Implementing `having_rel` and `not_having_rel`

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -191,6 +191,36 @@ module Neo4j
           instance_eval(&block).query.proxy_as(self.model, identity)
         end
 
+        # Matches all nodes having at least a relation
+        #
+        # @example Load all people having a friend
+        #   Person.all.having_rel(:friends).to_a # => Returns a list of `Person`
+        #
+        # @example Load all people having a best friend
+        #   Person.all.having_rel(:friends, best: true).to_a # => Returns a list of `Person`
+        #
+        # @return [QueryProxy] A new QueryProxy
+        def having_rel(association_name, rel_properties = {})
+          association = model.associations[association_name]
+          fail "No such association #{association_name}" unless association
+          where("(#{identity})#{association.arrow_cypher(nil, rel_properties)}()")
+        end
+
+        # Matches all nodes not having a certain relation
+        #
+        # @example Load all people not having friends
+        #   Person.all.not_having_rel(:friends).to_a # => Returns a list of `Person`
+        #
+        # @example Load all people not having best friends
+        #   Person.all.not_having_rel(:friends, best: true).to_a # => Returns a list of `Person`
+        #
+        # @return [QueryProxy] A new QueryProxy
+        def not_having_rel(association_name, rel_properties = {})
+          association = model.associations[association_name]
+          fail "No such association #{association_name}" unless association
+          where_not("(#{identity})#{association.arrow_cypher(nil, rel_properties)}()")
+        end
+
         def [](index)
           # TODO: Maybe for this and other methods, use array if already loaded, otherwise
           # use OFFSET and LIMIT 1?

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -191,36 +191,6 @@ module Neo4j
           instance_eval(&block).query.proxy_as(self.model, identity)
         end
 
-        # Matches all nodes having at least a relation
-        #
-        # @example Load all people having a friend
-        #   Person.all.having_rel(:friends).to_a # => Returns a list of `Person`
-        #
-        # @example Load all people having a best friend
-        #   Person.all.having_rel(:friends, best: true).to_a # => Returns a list of `Person`
-        #
-        # @return [QueryProxy] A new QueryProxy
-        def having_rel(association_name, rel_properties = {})
-          association = model.associations[association_name]
-          fail "No such association #{association_name}" unless association
-          where("(#{identity})#{association.arrow_cypher(nil, rel_properties)}()")
-        end
-
-        # Matches all nodes not having a certain relation
-        #
-        # @example Load all people not having friends
-        #   Person.all.not_having_rel(:friends).to_a # => Returns a list of `Person`
-        #
-        # @example Load all people not having best friends
-        #   Person.all.not_having_rel(:friends, best: true).to_a # => Returns a list of `Person`
-        #
-        # @return [QueryProxy] A new QueryProxy
-        def not_having_rel(association_name, rel_properties = {})
-          association = model.associations[association_name]
-          fail "No such association #{association_name}" unless association
-          where_not("(#{identity})#{association.arrow_cypher(nil, rel_properties)}()")
-        end
-
         def [](index)
           # TODO: Maybe for this and other methods, use array if already loaded, otherwise
           # use OFFSET and LIMIT 1?

--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -173,7 +173,39 @@ module Neo4j
           where("(#{where_clause})")
         end
 
+        # Matches all nodes having at least a relation
+        #
+        # @example Load all people having a friend
+        #   Person.all.having_rel(:friends).to_a # => Returns a list of `Person`
+        #
+        # @example Load all people having a best friend
+        #   Person.all.having_rel(:friends, best: true).to_a # => Returns a list of `Person`
+        #
+        # @return [QueryProxy] A new QueryProxy
+        def having_rel(association_name, rel_properties = {})
+          association = association_or_fail(association_name)
+          where("(#{identity})#{association.arrow_cypher(nil, rel_properties)}()")
+        end
+
+        # Matches all nodes not having a certain relation
+        #
+        # @example Load all people not having friends
+        #   Person.all.not_having_rel(:friends).to_a # => Returns a list of `Person`
+        #
+        # @example Load all people not having best friends
+        #   Person.all.not_having_rel(:friends, best: true).to_a # => Returns a list of `Person`
+        #
+        # @return [QueryProxy] A new QueryProxy
+        def not_having_rel(association_name, rel_properties = {})
+          association = association_or_fail(association_name)
+          where_not("(#{identity})#{association.arrow_cypher(nil, rel_properties)}()")
+        end
+
         private
+
+        def association_or_fail(association_name)
+          model.associations[association_name] || fail(ArgumentError, "No such association #{association_name}")
+        end
 
         def find_inverse_association!(model, source, association)
           model.associations.values.find do |reverse_association|

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -663,6 +663,39 @@ describe 'query_proxy_methods' do
     end
   end
 
+  context 'matching by relations' do
+    before(:each) do
+      [Student, Lesson, Teacher].each(&:delete_all)
+
+      @john = Student.create(name: 'John')
+      @bill = Student.create(name: 'Bill')
+      @frank = Student.create(name: 'Frank')
+      @history = Lesson.create(name: 'history')
+      @john.lessons << @history
+      EnrolledIn.create(from_node: @frank, to_node: @history, absence_count: 10)
+    end
+
+    describe 'having_rel' do
+      it 'returns students having at least a lesson' do
+        expect(Student.all.having_rel(:lessons)).to contain_exactly(@john, @frank)
+      end
+
+      it 'returns students having at least a lesson with no absences' do
+        expect(Student.all.having_rel(:lessons, absence_count: 0)).to contain_exactly(@john)
+      end
+    end
+
+    describe 'not_having_rel' do
+      it 'returns students having at least a lesson' do
+        expect(Student.all.not_having_rel(:lessons)).to contain_exactly(@bill)
+      end
+
+      it 'returns students having at least a lesson with no absences' do
+        expect(Student.all.not_having_rel(:lessons, absence_count: 0)).to contain_exactly(@bill, @frank)
+      end
+    end
+  end
+
   describe 'branch' do
     before(:each) do
       [Student, Lesson, Teacher].each(&:delete_all)

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -683,6 +683,18 @@ describe 'query_proxy_methods' do
       it 'returns students having at least a lesson with no absences' do
         expect(Student.all.having_rel(:lessons, absence_count: 0)).to contain_exactly(@john)
       end
+
+      it 'returns no student when absence is negative' do
+        expect(Student.all.having_rel(:lessons, absence_count: -1)).to eq([])
+      end
+
+      it 'returns no lesson having teacher, since there\'s none' do
+        expect(Lesson.all.having_rel(:teachers)).to eq([])
+      end
+
+      it 'raises ArgumentError when passing a missing relation' do
+        expect { Lesson.all.having_rel(:friends) }.to raise_error(ArgumentError)
+      end
     end
 
     describe 'not_having_rel' do
@@ -692,6 +704,14 @@ describe 'query_proxy_methods' do
 
       it 'returns students having at least a lesson with no absences' do
         expect(Student.all.not_having_rel(:lessons, absence_count: 0)).to contain_exactly(@bill, @frank)
+      end
+
+      it 'returns no lesson having no students, since there\'s none' do
+        expect(Lesson.all.not_having_rel(:students)).to eq([])
+      end
+
+      it 'raises ArgumentError when passing a missing relation' do
+        expect { Lesson.all.not_having_rel(:friends) }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
This pull introduces/changes:
 * `having_rel`, that returns nodes having a certain relation
 * `not_having_rel`, that returns nodes not having a certain relation

Both accept an `association_name` and an optional hash of association properties.


Pings:
@cheerfulstoic
@subvertallchris
