### PR TITLE
Fix specs on master with neo4j v3

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
+++ b/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
@@ -51,7 +51,7 @@ module Neo4j
         def with_association_query_part(base_query, association_name, previous_with_variables)
           association = model.associations[association_name]
 
-          base_query.optional_match("(#{identity})#{association.arrow_cypher}#{association_name}")
+          base_query.optional_match("(#{identity})#{association.arrow_cypher}(#{association_name})")
                     .where(association.target_where_clause)
                     .with(identity, "collect(#{association_name}) AS #{association_name}_collection", *with_associations_return_clause(previous_with_variables))
         end


### PR DESCRIPTION
Fixes #1187

This pull introduces/changes:
 * the `with_associations` match query to fit the new neo4j3 () syntax




Pings:
@cheerfulstoic
@subvertallchris
