### PR TITLE
ActiveNode inclusion respects existing id_property_name

### DIFF
--- a/lib/neo4j/active_node.rb
+++ b/lib/neo4j/active_node.rb
@@ -88,7 +88,7 @@ module Neo4j
 
       Neo4j::Session.on_next_session_available do |_|
         next if manual_id_property?
-        id_property :uuid, auto: :uuid unless self.id_property?
+        id_property id_property_name || :uuid, auto: :uuid unless self.id_property?
 
         name = Neo4j::Config[:id_property]
         type = Neo4j::Config[:id_property_type]

--- a/lib/neo4j/active_node/id_property.rb
+++ b/lib/neo4j/active_node/id_property.rb
@@ -162,7 +162,7 @@ module Neo4j::ActiveNode
       end
 
       def id_property_name
-        id_property_info[:name]
+        defined?(super) ? super : id_property_info[:name]
       end
 
       def manual_id_property?

--- a/spec/e2e/id_property_spec.rb
+++ b/spec/e2e/id_property_spec.rb
@@ -408,4 +408,24 @@ describe Neo4j::ActiveNode::IdProperty do
       end
     end
   end
+
+  describe 'after calling .id_property_config class method' do
+    before do
+      stub_const('CrazyModel', Class.new do
+        def self.id_property_name
+          :custom_id_property
+        end
+      end)
+    end
+
+    it 'does not generate constraint for :uuid' do
+      expect(CrazyModel).not_to receive(:id_property).with(:uuid, auto: :uuid)
+      CrazyModel.include Neo4j::ActiveNode
+    end
+
+    it 'sets the constraint to match the ID_PROPERTY constant value' do
+      expect(CrazyModel).to receive(:id_property).with(:custom_id_property, auto: :uuid)
+      CrazyModel.include Neo4j::ActiveNode
+    end
+  end
 end


### PR DESCRIPTION
The problem:

Your id property name is not going to be `uuid`. You do not want to enable `eager_load`. Every time your app starts, it checks for that `uuid` constraint and sets it, even if you don't want it there, then it checks for your custom id property constraint. You find this annoying.

The really simple solution:

``` ruby
class MyModel
  def self.id_property_name
    :cool_id
  end
  include Neo4j::ActiveNode
```

This PR changes the `id_property_name` method to respect an existing value of that method. If you set it before including the module, it will use that value for that class. I'm not sure that this is the absolute best possible solution but it sure is simple, which is rather nice.

Pings:
@cheerfulstoic
@ProGM 
