### PR TITLE
Some memory optimizations

### DIFF
--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -224,8 +224,12 @@ module Neo4j::ActiveNode
         !!associations[name.to_sym]
       end
 
+      def parent_associations
+        superclass == Object ? {} : superclass.associations
+      end
+
       def associations
-        (@associations ||= superclass == Object ? {} : superclass.associations)
+        (@associations ||= parent_associations)
       end
 
       def associations_keys
@@ -516,9 +520,13 @@ module Neo4j::ActiveNode
       end
 
       def add_association(name, association_object)
-        @associations ||= {}
-        fail "Association `#{name}` defined for a second time.  Associations can only be defined once" if @associations.key?(name)
-        @associations[name] = association_object
+        fail "Association `#{name}` defined for a second time. "\
+             'Associations can only be defined once' if duplicate_association?(name)
+        associations[name] = association_object
+      end
+
+      def duplicate_association?(name)
+        associations.key?(name) && parent_associations[name] != associations[name]
       end
     end
   end

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -225,7 +225,7 @@ module Neo4j::ActiveNode
       end
 
       def associations
-        (@associations ||= {}).merge(superclass == Object ? {} : superclass.associations)
+        (@associations ||= superclass == Object ? {} : superclass.associations)
       end
 
       def associations_keys

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -231,7 +231,7 @@ module Neo4j::ActiveNode
       end
 
       def associations
-        (@associations ||= parent_associations)
+        (@associations ||= parent_associations.dup)
       end
 
       def associations_keys
@@ -513,7 +513,7 @@ module Neo4j::ActiveNode
           create_reflection(macro, name, association, self)
         end
 
-        associations_keys << name
+        @associations_keys = nil
 
       # Re-raise any exception with added class name and association name to
       # make sure error message is helpful

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -207,7 +207,9 @@ module Neo4j::ActiveNode
       end
     end
 
+    # rubocop:disable Metrics/ModuleLength
     module ClassMethods
+      # rubocop:enable Style/PredicateName
       # rubocop:disable Style/PredicateName
 
       # :nocov:

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -581,6 +581,31 @@ describe 'has_many' do
     end
   end
 
+  describe 'checking if associations are propagated to child classes' do
+    before(:each) do
+      stub_active_node_class('Thing') do
+        has_many :out, :parents, origin: :things
+      end
+
+      stub_active_node_class('OtherThing') do
+        has_many :out, :children, origin: :things
+      end
+
+      stub_active_node_class('Parent') do
+        has_one :in, :thing, type: :HAS_THINGS, model_class: :Thing, unique: true
+      end
+
+      stub_named_class('Child', Parent) do
+        has_many :in, :other_things, type: :HAS_OTHER_THINGS, model_class: :OtherThing, unique: true
+        validates :things, presence: true
+      end
+    end
+
+    it 'should return the same associations' do
+      expect(Parent.associations).to eq(Child.associations)
+    end
+  end
+
   describe 'checking for double definitions of associations' do
     it 'should raise an error if an assocation is defined twice' do
       expect do

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -588,7 +588,7 @@ describe 'has_many' do
       end
 
       stub_active_node_class('OtherThing') do
-        has_many :out, :children, origin: :things
+        has_many :out, :children, origin: :other_things
       end
 
       stub_active_node_class('Parent') do
@@ -601,8 +601,9 @@ describe 'has_many' do
       end
     end
 
-    it 'should return the same associations' do
-      expect(Parent.associations).to eq(Child.associations)
+    it 'Child associations should include Parent ones' do
+      expect(Parent.associations_keys).to contain_exactly(:thing)
+      expect(Child.associations_keys).to contain_exactly(:thing, :other_things)
     end
   end
 


### PR DESCRIPTION
I changed a single line, so that calling `associations` will be lazily evaluated.

I don't know if it's a breaking change, however specs are working.

I discovered it while inspecting memory leaks using `derailed` gem.


Pings:
@cheerfulstoic
@subvertallchris

