### PR TITLE
Show result when #inspect a QueryProxy or AssociationProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Improved `QueryProxy` and `AssociationProxy` `#inspect` method to show a result preview (thanks ProGM / see #1228 #1232)
 - Renamed the old migration task to `neo4j:legacy_migrate`
 - Renamed the ENV variable to silence migrations output from `silenced` to `MIGRATIONS_SILENCED`
 - Changed the behavior with transactions when a validation fails. This is a potentially breaking change, since now calling `save` would not fail the current transaction, as expected. (thanks ProGM / see #1156)

--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -53,6 +53,7 @@ require 'neo4j/active_rel/related_node'
 require 'neo4j/active_rel/types'
 require 'neo4j/active_rel'
 
+require 'neo4j/active_node/node_list_formatter'
 require 'neo4j/active_node/dependent'
 require 'neo4j/active_node/dependent/query_proxy_methods'
 require 'neo4j/active_node/dependent/association_methods'

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -23,11 +23,8 @@ module Neo4j::ActiveNode
       # States:
       # Default
       def inspect
-        if @cached_result
-          result_nodes.inspect
-        else
-          "#<AssociationProxy @query_proxy=#{@query_proxy.inspect}>"
-        end
+        formatted_nodes = ::Neo4j::ActiveNode::NodeListFormatter.new(result_nodes)
+        "#<AssociationProxy #{@query_proxy.context} #{formatted_nodes.inspect}>"
       end
 
       extend Forwardable

--- a/lib/neo4j/active_node/node_list_formatter.rb
+++ b/lib/neo4j/active_node/node_list_formatter.rb
@@ -1,0 +1,13 @@
+module Neo4j::ActiveNode
+  class NodeListFormatter
+    def initialize(list, max_elements = 5)
+      @list = list
+      @max_elements = max_elements
+    end
+
+    def inspect
+      return @list.inspect if !@max_elements || @list.length <= @max_elements
+      "[#{@list.take(5).map!(&:inspect).join(', ')}, ...]"
+    end
+  end
+end

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -54,7 +54,8 @@ module Neo4j
         end
 
         def inspect
-          "#<QueryProxy #{@context} CYPHER: #{self.to_cypher.inspect}>"
+          formatted_nodes = Neo4j::ActiveNode::NodeListFormatter.new(to_a)
+          "#<QueryProxy #{@context} #{formatted_nodes.inspect}>"
         end
 
         attr_reader :start_object, :query_proxy

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -143,4 +143,16 @@ describe 'Association Proxy' do
       end
     end
   end
+
+  describe '#inspect' do
+    context 'when inspecting an association proxy' do
+      let(:association_proxy) { billy.lessons }
+      let(:inspected_elements) { association_proxy.inspect }
+
+      it 'returns the list of resulting elements' do
+        expect(inspected_elements).to include('#<AssociationProxy Student#lessons')
+        expect(inspected_elements).to include(association_proxy.to_a.inspect)
+      end
+    end
+  end
 end

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -777,4 +777,24 @@ describe 'query_proxy_methods' do
                             [@science, nil]]
     end
   end
+
+  describe '#inspect' do
+    before(:each) do
+      delete_db
+
+      Student.create(name: 'Lauren')
+      Student.create(name: 'Bob')
+      Student.create(name: 'Bill')
+    end
+
+    context 'when inspecting a query proxy' do
+      let(:query_proxy) { Student.all }
+      let(:inspected_elements) { query_proxy.inspect }
+
+      it 'returns the list of resulting elements' do
+        expect(inspected_elements).to include('#<QueryProxy Student')
+        expect(inspected_elements).to include(query_proxy.to_a.inspect)
+      end
+    end
+  end
 end

--- a/spec/unit/active_node/node_list_formatter_spec.rb
+++ b/spec/unit/active_node/node_list_formatter_spec.rb
@@ -1,0 +1,19 @@
+module Neo4j::ActiveNode
+  describe NodeListFormatter do
+    let(:max_elements) { 5 }
+
+    subject { described_class.new(list, max_elements) }
+
+    context 'when the list length is greater than `max_elements`' do
+      let(:list) { Array.new(10) { |i| i } }
+
+      its(:inspect) { is_expected.to eq '[0, 1, 2, 3, 4, ...]' }
+    end
+
+    context 'when the list length is less or equal than `max_elements`' do
+      let(:list) { Array.new(5) { |i| i } }
+
+      its(:inspect) { is_expected.to eq '[0, 1, 2, 3, 4]' }
+    end
+  end
+end

--- a/spec/unit/active_node/node_list_formatter_spec.rb
+++ b/spec/unit/active_node/node_list_formatter_spec.rb
@@ -5,13 +5,13 @@ module Neo4j::ActiveNode
     subject { described_class.new(list, max_elements) }
 
     context 'when the list length is greater than `max_elements`' do
-      let(:list) { Array.new(10) { |i| i } }
+      let(:list) { (0...10).to_a }
 
       its(:inspect) { is_expected.to eq '[0, 1, 2, 3, 4, ...]' }
     end
 
     context 'when the list length is less or equal than `max_elements`' do
-      let(:list) { Array.new(5) { |i| i } }
+      let(:list) { (0...5).to_a }
 
       its(:inspect) { is_expected.to eq '[0, 1, 2, 3, 4]' }
     end


### PR DESCRIPTION
Fixes #1228

A replacement `inspect` method for QueryProxy and AssociationProxy, that shows (some of) the resulting nodes.

(To be precise, it shows the first 5 records found)

`QueryProxy`'s example:

```ruby
irb(main):001:0> Person.all
 Person 27ms MATCH (n:`Person`) RETURN n
=> #<QueryProxy Person [#<Person uuid: "d95b0a82-95af-4492-a344-8443a6f8783e", cover_image: nil, created_at: Thu, 23 Jun 2016 09:48:16 +0000, description: nil, facebook_data: nil, first_name: "John", google_plus_data: nil, last_name: "Doe 0", linkedin_data: nil, location: nil, pg_id: 1, profile_picture: "http://placehold.it/350x350", title: nil, twitter_data: nil, updated_at: Thu, 23 Jun 2016 09:48:16 +0000, username: "john-doe-0", visits: 0>, #<Person uuid: "89d97589-1af2-421e-a6ea-bd98a70dea4a", cover_image: nil, created_at: Thu, 23 Jun 2016 09:48:16 +0000, description: nil, facebook_data: nil, first_name: "John", google_plus_data: nil, last_name: "Doe 1", linkedin_data: nil, location: nil, pg_id: 2, profile_picture: "http://placehold.it/350x350", title: nil, twitter_data: nil, updated_at: Thu, 23 Jun 2016 09:48:16 +0000, username: "john-doe-1", visits: 1>, #<Person uuid: "64c31c0d-6520-4ef7-8c88-f16b54487540", cover_image: nil, created_at: Thu, 23 Jun 2016 09:48:16 +0000, description: nil, facebook_data: nil, first_name: "John", google_plus_data: nil, last_name: "Doe 2", linkedin_data: nil, location: nil, pg_id: 3, profile_picture: "http://placehold.it/350x350", title: nil, twitter_data: nil, updated_at: Thu, 23 Jun 2016 09:48:16 +0000, username: "john-doe-2", visits: 0>, #<Person uuid: "f5764264-533b-4657-a276-6b7ae2a78670", cover_image: nil, created_at: Thu, 23 Jun 2016 09:48:17 +0000, description: nil, facebook_data: nil, first_name: "John", google_plus_data: nil, last_name: "Doe 3", linkedin_data: nil, location: nil, pg_id: 4, profile_picture: "http://placehold.it/350x350", title: nil, twitter_data: nil, updated_at: Thu, 23 Jun 2016 09:48:17 +0000, username: "john-doe-3", visits: 0>, #<Person uuid: "b2ba19f2-9aca-4ea0-ab80-916491c2eb1e", cover_image: nil, created_at: Thu, 23 Jun 2016 09:48:17 +0000, description: nil, facebook_data: nil, first_name: "John", google_plus_data: nil, last_name: "Doe 4", linkedin_data: nil, location: nil, pg_id: 5, profile_picture: "http://placehold.it/350x350", title: nil, twitter_data: nil, updated_at: Thu, 23 Jun 2016 09:48:17 +0000, username: "john-doe-4", visits: 0>, ...]>
```

`AssociationProxy`'s example:
```ruby
irb(main):002:0> Person.articles
 Person#articles 30ms MATCH (node2:`Person`) MATCH (node2)<-[rel1:`creator`]-(result_articles:`Article`) RETURN result_articles
=> #<AssociationProxy Person#articles [#<Article uuid: "kouOezJoqso", abstract: "lorem ipsum dolor sit amet consectetuer adipiscing elit proin risus praesent lectus vestibulum quam s", authentic: false, created_at: Thu, 23 Jun 2016 09:48:28 +0000, title: "Article Title 19", updated_at: Thu, 23 Jun 2016 09:48:28 +0000, visits: 0>, #<Article uuid: "9imOp739IWY", abstract: nil, authentic: false, created_at: Tue, 05 Jul 2016 14:33:30 +0000, title: nil, updated_at: Tue, 05 Jul 2016 14:33:30 +0000, visits: 0>, #<Article uuid: "8DoRXaaCp-I", abstract: nil, authentic: false, created_at: Mon, 04 Jul 2016 14:49:11 +0000, title: nil, updated_at: Mon, 04 Jul 2016 14:49:11 +0000, visits: 0>, #<Article uuid: "6XJXRG02P6M", abstract: nil, authentic: false, created_at: Mon, 04 Jul 2016 14:25:27 +0000, title: nil, updated_at: Mon, 04 Jul 2016 14:25:27 +0000, visits: 0>, #<Article uuid: "IZPoJ4GQRp8", abstract: nil, authentic: false, created_at: Fri, 01 Jul 2016 16:15:28 +0000, title: nil, updated_at: Fri, 01 Jul 2016 16:15:28 +0000, visits: 0>, ...]>
```

Pings:
@cheerfulstoic
@subvertallchris
