### PR TITLE
Fix usage of NEO4J_TYPE environment variable to match documentation

### DIFF
--- a/lib/neo4j/railtie.rb
+++ b/lib/neo4j/railtie.rb
@@ -70,11 +70,8 @@ module Neo4j
       end
 
       def default_session_type
-        if ENV['NEO4J_TYPE']
-          :embedded_db
-        else
-          config_data[:type] || :server_db
-        end.to_sym
+        type = ENV['NEO4J_TYPE'] || config_data[:type] || :server_db
+        type.to_sym
       end
 
       def default_session_path


### PR DESCRIPTION
Fixes #1234

This pull introduces/changes:
 * Correctly check the value of NEO4J_TYPE environment variable




Pings:
@cheerfulstoic
@subvertallchris

