### PR TITLE
Fix Rails 5 deprecation warning for to_prepare

### DIFF
--- a/lib/neo4j/railtie.rb
+++ b/lib/neo4j/railtie.rb
@@ -7,7 +7,11 @@ module Neo4j
   class Railtie < ::Rails::Railtie
     config.neo4j = ActiveSupport::OrderedOptions.new
 
-    if const_defined?(:ActionDispatch)
+    if defined?(ActiveSupport::Reloader)
+      ActiveSupport::Reloader.to_prepare do
+        Neo4j::ActiveNode::Labels::Reloading.reload_models!
+      end
+    elsif const_defined?(:ActionDispatch)
       ActionDispatch::Reloader.to_prepare do
         Neo4j::ActiveNode::Labels::Reloading.reload_models!
       end


### PR DESCRIPTION
Fixes #1233 

This pull introduces/changes:
 * Switch to use ActiveSupport::Reloader.to_prepare to fix Rails 5 deprecation warning




Pings:
@cheerfulstoic
@subvertallchris

