### PR TITLE
Allow to pass a Proc for a default property value

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ end
 
 group 'test' do
   gem 'coveralls', require: false
+  gem 'tins', '< 1.7' if RUBY_VERSION.to_f < 2.0
   gem 'codecov', require: false
   gem 'simplecov', require: false
   gem 'simplecov-html', require: false

--- a/lib/neo4j/shared/declared_properties.rb
+++ b/lib/neo4j/shared/declared_properties.rb
@@ -156,7 +156,7 @@ module Neo4j::Shared
 
     def inject_defaults!(object, props)
       declared_property_defaults.each_pair do |k, v|
-        props[k.to_sym] = v if object.send(k).nil? && props[k.to_sym].nil?
+        props[k.to_sym] = v.respond_to?(:call) ? v.call : v if object.send(k).nil? && props[k.to_sym].nil?
       end
       props
     end

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -97,7 +97,7 @@ module Neo4j::Shared
     def apply_default_values
       return if self.class.declared_property_defaults.empty?
       self.class.declared_property_defaults.each_pair do |key, value|
-        self.send("#{key}=", value) if self.send(key).nil?
+        self.send("#{key}=", value.respond_to?(:call) ? value.call : value) if self.send(key).nil?
       end
     end
 


### PR DESCRIPTION
This pull introduces/changes:
 * Allow to pass a Proc for a default property value. Similar to mongoid, which allows to have dynamic default values.





Pings:
@cheerfulstoic
@subvertallchris

