### PR TITLE
Refactor code in the Reloading module

### DIFF
--- a/lib/neo4j/active_node/labels/reloading.rb
+++ b/lib/neo4j/active_node/labels/reloading.rb
@@ -2,20 +2,9 @@ module Neo4j::ActiveNode::Labels
   module Reloading
     extend ActiveSupport::Concern
 
-    MODELS_TO_RELOAD = []
-
     def self.reload_models!
-      MODELS_TO_RELOAD.each(&:constantize)
-      MODELS_TO_RELOAD.clear
-    end
-
-    module ClassMethods
-      def before_remove_const
-        associations.each_value(&:queue_model_refresh!)
-        MODELS_FOR_LABELS_CACHE.clear
-        WRAPPED_CLASSES.each { |c| MODELS_TO_RELOAD << c.name }
-        WRAPPED_CLASSES.clear
-      end
+      Neo4j::ActiveNode::Labels::WRAPPED_CLASSES.clear
+      Neo4j::ActiveNode::Labels.clear_wrapped_models
     end
   end
 end


### PR DESCRIPTION
This is an attempt to fix the issue where `CypherNode` objects cease to be wrapped anymore until the Ruby process (server, background workers, whatever) process is restarted.

@subvertallchris I ripped out some of this and so I'm somewhat worried that I've broken something, but it seems to work locally on my app.  Curious for your feedback