### PR TITLE
ActiveRel factories will build CREATE String

### DIFF
--- a/lib/neo4j/shared/query_factory.rb
+++ b/lib/neo4j/shared/query_factory.rb
@@ -69,7 +69,8 @@ module Neo4j::Shared
 
     def create_query
       return match_query if graph_object.persisted?
-      base_query.create(identifier => {graph_object.labels_for_create => graph_object.props_for_create})
+      labels = graph_object.labels_for_create.map { |l| ":`#{l}`" }.join
+      base_query.create("(#{identifier}#{labels} {#{identifier}_params})").params(identifier_params => graph_object.props_for_create)
     end
   end
 

--- a/spec/e2e/shared/query_factory_spec.rb
+++ b/spec/e2e/shared/query_factory_spec.rb
@@ -1,9 +1,11 @@
 describe Neo4j::Shared::QueryFactory do
-  before do
+  let!(:factory_from_class) do
     stub_active_node_class('FactoryFromClass') do
       property :name
     end
+  end
 
+  before do
     stub_active_node_class('FactoryToClass') do
       property :name
     end
@@ -30,8 +32,32 @@ describe Neo4j::Shared::QueryFactory do
     context 'unpersisted' do
       it 'builds a query to create' do
         expect do
-          expect(from_node_factory.query.pluck(:from_node).first).to be_a(FactoryFromClass)
+          expect(from_node_factory.query.pluck(:from_node).first.labels).to eq FactoryFromClass.mapped_label_names
         end.to change { FactoryFromClass.count }
+      end
+
+      context 'with a value that might be interpreted as a prop' do
+        let(:from_node) { FactoryFromClass.new(name: '{Tricky .Value}') }
+        it 'creates without error' do
+          expect do
+            expect(from_node_factory.query.pluck(:from_node).first.labels).to eq FactoryFromClass.mapped_label_names
+          end.to change { FactoryFromClass.where(name: from_node.name).count }
+        end
+      end
+
+      context 'with multiple labels' do
+        before do
+          stub_named_class('FromSubclass', factory_from_class { include Neo4j::ActiveNode })
+          FromSubclass.property :other_prop
+        end
+
+        let(:from_node) { FromSubclass.new(other_prop: '{Foo .property}') }
+
+        it 'creates the node with all labels' do
+          expect do
+            expect(from_node_factory.query.pluck(:from_node).first.labels).to eq FromSubclass.mapped_label_names
+          end.to change { FromSubclass.where(name: from_node.name).count }
+        end
       end
     end
 
@@ -53,6 +79,16 @@ describe Neo4j::Shared::QueryFactory do
         expect do
           expect(rel_factory.query.pluck(:rel).first).to be_a(FactoryRelClass)
         end.to change { FactoryRelClass.count }
+      end
+
+      context 'with a value that might be interpreted as a prop' do
+        let(:rel) { FactoryRelClass.new(score: '{9000 ....}') }
+
+        it 'creates without error' do
+          expect do
+            expect(rel_factory.query.pluck(:rel).first).to be_a(FactoryRelClass)
+          end.to change { FactoryRelClass.count }
+        end
       end
     end
 


### PR DESCRIPTION
Fixes the bug documented in specs: when using ActiveRel to create nodes in addition to rels, node properties that look like Cypher params were being interpreted literally. This modifies ActiveRel's query factory to build a `CREATE` string. There will be a performance boost, too, since the entire hash of properties will be parameterized instead of just the values.
