### PR TITLE
Accepting `nil` as enum value

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source 'http://rubygems.org'
 
 gemspec
 
-if ENV['CI']
-  gem 'neo4j-core', github: 'neo4jrb/neo4j-core', branch: 'master'
-  gem 'neo4j-rake_tasks', github: 'neo4jrb/neo4j-rake_tasks', branch: 'master'
-end
+# if ENV['CI']
+#   gem 'neo4j-core', github: 'neo4jrb/neo4j-core', branch: 'master'
+#   gem 'neo4j-rake_tasks', github: 'neo4jrb/neo4j-rake_tasks', branch: 'master'
+# end
 
 # gem 'active_attr', github: 'neo4jrb/active_attr', branch: 'performance'
 # gem 'active_attr', path: '../active_attr'

--- a/Gemfile
+++ b/Gemfile
@@ -14,13 +14,18 @@ gem 'listen', '< 3.1'
 
 group 'test' do
   gem 'coveralls', require: false
+  if RUBY_VERSION.to_f < 2.0
+    gem 'tins', '< 1.7'
+    gem 'overcommit', '< 0.35.0'
+  else
+    gem 'overcommit'
+  end
   gem 'codecov', require: false
   gem 'simplecov', require: false
   gem 'simplecov-html', require: false
   gem 'rspec', '~> 3.4'
   gem 'its'
   gem 'test-unit'
-  gem 'overcommit'
   gem 'colored'
   gem 'dotenv'
   gem 'timecop'

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group 'test' do
     gem 'overcommit', '< 0.35.0'
   else
     gem 'overcommit'
+    gem 'activesupport', '>= 4.2'
   end
   gem 'codecov', require: false
   gem 'simplecov', require: false

--- a/lib/neo4j/shared/enum.rb
+++ b/lib/neo4j/shared/enum.rb
@@ -67,7 +67,7 @@ module Neo4j::Shared
         end
       end
 
-      VALID_OPTIONS_FOR_ENUMS = [:_index, :_prefix, :_suffix]
+      VALID_OPTIONS_FOR_ENUMS = [:_index, :_prefix, :_suffix, :_default]
       DEFAULT_OPTIONS_FOR_ENUMS = {
         _index: true
       }
@@ -88,12 +88,12 @@ module Neo4j::Shared
       def define_property(property_name, enum_keys, options)
         property_options = build_property_options(enum_keys, options)
         property property_name, property_options
-        serialize property_name, Neo4j::Shared::TypeConverters::EnumConverter.new(enum_keys)
+        serialize property_name, Neo4j::Shared::TypeConverters::EnumConverter.new(enum_keys, property_options)
       end
 
-      def build_property_options(enum_keys, _options = {})
+      def build_property_options(_enum_keys, options = {})
         {
-          default: enum_keys.keys.first
+          default: options[:_default]
         }
       end
 

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -264,8 +264,9 @@ module Neo4j::Shared
     end
 
     class EnumConverter
-      def initialize(enum_keys)
+      def initialize(enum_keys, options)
         @enum_keys = enum_keys
+        @options = options
       end
 
       def converted?(value)

--- a/neo4j.gemspec
+++ b/neo4j.gemspec
@@ -29,7 +29,7 @@ A Neo4j OGM (Object-Graph-Mapper) for use in Ruby on Rails and Rack frameworks h
   s.add_dependency('orm_adapter', '~> 0.5.0')
   s.add_dependency('activemodel', '~> 4')
   s.add_dependency('activesupport', '~> 4')
-  s.add_dependency('neo4j-core', '>= 6.0.0')
+  s.add_dependency('neo4j-core', '< 7.0.0')
   s.add_dependency('neo4j-community', '~> 2.0') if RUBY_PLATFORM =~ /java/
   s.add_development_dependency('railties', '~> 4')
   s.add_development_dependency('pry')

--- a/neo4j.gemspec
+++ b/neo4j.gemspec
@@ -29,7 +29,7 @@ A Neo4j OGM (Object-Graph-Mapper) for use in Ruby on Rails and Rack frameworks h
   s.add_dependency('orm_adapter', '~> 0.5.0')
   s.add_dependency('activemodel', '~> 4')
   s.add_dependency('activesupport', '~> 4')
-  s.add_dependency('neo4j-core', '< 7.0.0')
+  s.add_dependency('neo4j-core', '>= 6.0.0', '< 7.0.0')
   s.add_dependency('neo4j-community', '~> 2.0') if RUBY_PLATFORM =~ /java/
   s.add_development_dependency('railties', '~> 4')
   s.add_development_dependency('pry')


### PR DESCRIPTION
Fixes #1261 

This pull introduces/changes:
 * Adds a `:_default` option to define the default value for enums.


This is a braking change.
If we want to keep the previous behavior, we can implement an `_allow_nil` option, to enable `nil` as default value.

Pings:
@cheerfulstoic
@subvertallchris

