### PR TITLE
ActiveRel factories will build CREATE String

### DIFF
--- a/lib/neo4j/shared/query_factory.rb
+++ b/lib/neo4j/shared/query_factory.rb
@@ -69,7 +69,8 @@ module Neo4j::Shared
 
     def create_query
       return match_query if graph_object.persisted?
-      base_query.create(identifier => {graph_object.labels_for_create => graph_object.props_for_create})
+      labels = graph_object.labels_for_create.map { |l| ":`#{l}`" }.join
+      base_query.create("(#{identifier}#{labels} {#{identifier}_params})").params(identifier_params => graph_object.props_for_create)
     end
   end
 


### PR DESCRIPTION
Fixes the bug documented in specs: when using ActiveRel to create nodes in addition to rels, node properties that look like Cypher params were being interpreted literally. This modifies ActiveRel's query factory to build a CREATE string. There will be a performance boost, too, since the entire hash of properties will be parameterized instead of just the values.