### PR TITLE
remove blank ids in _ids= methods (active_record compatibility)

### DIFF
--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -386,7 +386,7 @@ module Neo4j::ActiveNode
 
         define_method_unless_defined("#{name.to_s.singularize}_ids=") do |ids|
           clear_deferred_nodes_for_association(name)
-          association_proxy(name).replace_with(ids)
+          association_proxy(name).replace_with(Array(ids).reject(&:blank?))
         end
 
         define_method_unless_defined("#{name.to_s.singularize}_neo_ids") do

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -557,7 +557,7 @@ describe 'has_many' do
     end
 
     it 'ignores blank IDs for has_many' do
-      post = Post.create(comment: Comment.create)
+      post = Post.create(comments: Comment.create)
 
       post.comment_ids = ['', nil]
 

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -556,6 +556,26 @@ describe 'has_many' do
       expect(post.comments.to_a).to match_array([comment])
     end
 
+    it 'ignores blank IDs for has_many' do
+      post = Post.create
+      comment = Comment.create
+
+      post.comment_ids = ['', nil]
+
+      post = Post.find(post.id)
+      expect(post.comments.to_a).to be_empty
+    end
+
+    it 'allows single ID for has_many' do
+      post = Post.create
+      comment = Comment.create
+
+      post.comment_ids = comment.id
+
+      post = Post.find(post.id)
+      expect(post.comments.to_a).to match_array([comment])
+    end
+
     it 'sets IDs for has_one' do
       post = Post.create
       comment = Comment.create

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -557,8 +557,7 @@ describe 'has_many' do
     end
 
     it 'ignores blank IDs for has_many' do
-      post = Post.create
-      comment = Comment.create
+      post = Post.create(comment: Comment.create)
 
       post.comment_ids = ['', nil]
 


### PR DESCRIPTION
Fixes #

This pull introduces/changes:
 * as much as I dislike the change as it should not be a concern of an ORM, this is required for compatibility with active record. My colleagues use this feature quite extensively. Apparently in rails when implementing a collection as series of checkboxes if all are unchecked this is the value you get in the controller `['']`. Why this cleanup has been implemented in activerecord instead of actionpack? Go figure.
 * at the same time added a convenience to assign single id in _ids= methods, which is as well present in activerecord




Pings:
@cheerfulstoic
@subvertallchris

…methods and cleaning blank values out of the argument list