### PR TITLE
Introducing `check_for_pending_migrations!` and `maintain_test_schema!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- A `Neo4j::Migrations.maintain_test_schema!` method, to keep the test database up to date with schema changes. (see #1277)
+- A `Neo4j::Migrations.check_for_pending_migrations!` method, that fails when there are pending migration. In Rails, it's executed automatically on startup. (see #1277)
 - Support for [`ForbiddenAttributesProtection` API](http://edgeapi.rubyonrails.org/classes/ActionController/StrongParameters.html) from ActiveRecord. (thanks ProGM, see #1245)
 
 ### Changed

--- a/lib/neo4j/config.rb
+++ b/lib/neo4j/config.rb
@@ -95,6 +95,10 @@ module Neo4j
         configuration.to_yaml
       end
 
+      def fail_on_pending_migrations
+        Neo4j::Config[:fail_on_pending_migrations].nil? ? true : Neo4j::Config[:fail_on_pending_migrations]
+      end
+
       def include_root_in_json
         # we use ternary because a simple || will always evaluate true
         Neo4j::Config[:include_root_in_json].nil? ? true : Neo4j::Config[:include_root_in_json]

--- a/lib/neo4j/errors.rb
+++ b/lib/neo4j/errors.rb
@@ -27,7 +27,30 @@ module Neo4j
 
   class DangerousAttributeError < ScriptError; end
   class UnknownAttributeError < NoMethodError; end
+
   class MigrationError < Error; end
   class IrreversibleMigration < MigrationError; end
   class UnknownMigrationVersionError < MigrationError; end
+
+  # Inspired/taken from active_record/migration.rb
+  class PendingMigrationError < MigrationError
+    def initialize
+      if rails? && defined?(Rails.env)
+        super("Migrations are pending. To resolve this issue, run:\n\n        #{command_name} neo4j:migrate RAILS_ENV=#{::Rails.env}")
+      else
+        super("Migrations are pending. To resolve this issue, run:\n\n        #{command_name} neo4j:migrate")
+      end
+    end
+
+    private
+
+    def command_name
+      return 'rake' unless rails?
+      Rails.version.to_f >= 5 ? 'bin/rails' : 'bin/rake'
+    end
+
+    def rails?
+      defined?(Rails)
+    end
+  end
 end

--- a/lib/neo4j/migrations.rb
+++ b/lib/neo4j/migrations.rb
@@ -6,5 +6,14 @@ module Neo4j
     autoload :Base
     autoload :Runner
     autoload :SchemaMigration
+
+    def self.check_for_pending_migrations!
+      runner = Neo4j::Migrations::Runner.new
+      fail ::Neo4j::PendingMigrationError if runner.pending_migrations?
+    end
+
+    def self.maintain_test_schema!
+      Neo4j::Migrations::Runner.new(silenced: true).all
+    end
   end
 end

--- a/lib/neo4j/railtie.rb
+++ b/lib/neo4j/railtie.rb
@@ -22,17 +22,10 @@ module Neo4j
     end
 
     # Rescue responses similar to ActiveRecord.
-    # For rails 3.2 and 4.0
-    if config.action_dispatch.respond_to?(:rescue_responses)
-      config.action_dispatch.rescue_responses.merge!(
-        'Neo4j::RecordNotFound' => :not_found,
-        'Neo4j::ActiveNode::Labels::RecordNotFound' => :not_found
-      )
-    else
-      # For rails 3.0 and 3.1
-      ActionDispatch::ShowExceptions.rescue_responses['Neo4j::RecordNotFound'] = :not_found
-      ActionDispatch::ShowExceptions.rescue_responses['Neo4j::ActiveNode::Labels::RecordNotFound'] = :not_found
-    end
+    config.action_dispatch.rescue_responses.merge!(
+      'Neo4j::RecordNotFound' => :not_found,
+      'Neo4j::ActiveNode::Labels::RecordNotFound' => :not_found
+    )
 
     # Add ActiveModel translations to the I18n load_path
     initializer 'i18n' do
@@ -61,6 +54,7 @@ module Neo4j
       session_types = cfg.sessions.map { |session_opts| session_opts[:type] }
 
       register_neo4j_cypher_logging(session_types)
+      Neo4j::Migrations.check_for_pending_migrations! if Rails.env.development? && Neo4j::Config.fail_on_pending_migrations
     end
 
     TYPE_SUBSCRIBERS = {

--- a/spec/e2e/migrations_spec.rb
+++ b/spec/e2e/migrations_spec.rb
@@ -2,7 +2,7 @@ module Neo4j
   # rubocop:disable Metrics/ModuleLength
   module Migrations
     # rubocop:enable Metrics/ModuleLength
-    describe Runner do
+    describe 'Neo4j::Migrations' do
       before { delete_schema }
 
       capture_output!(:output_string)
@@ -16,7 +16,7 @@ module Neo4j
           property :name
         end
 
-        allow_any_instance_of(described_class).to receive(:files_path) do
+        allow_any_instance_of(Runner).to receive(:files_path) do
           Rails.root.join('spec', 'migration_files', 'migrations', '*.rb')
         end
         User.delete_all
@@ -29,211 +29,256 @@ module Neo4j
         SchemaMigration.create! migration_id: '9500000001'
       end
 
-      describe '#all' do
-        it 'runs all migrations sorted by version' do
-          u = User.create! name: 'John'
+      describe '#maintain_test_schema!' do
+        it 'checks and runs pending migrations' do
           expect do
-            described_class.new.all
+            Neo4j::Migrations.maintain_test_schema!
           end.to change { SchemaMigration.count }.by(3)
-            .and(change { u.reload.name }.to('Frank'))
-        end
-
-        it 'skips up migrations' do
-          u = User.create! name: 'Jack'
-          SchemaMigration.create! migration_id: '1234567890'
-          expect do
-            described_class.new.all
-          end.to change { Neo4j::Migrations::SchemaMigration.count }.by(2)
-            .and(change { u.reload.name }.to('Frank'))
         end
       end
 
-      describe '#status' do
-        before do
-          SchemaMigration.create! migration_id: '1234567890', incomplete: true
-          SchemaMigration.create! migration_id: '9500000000'
-          SchemaMigration.create! migration_id: '9400000000'
+      describe '#check_for_pending_migrations!' do
+        it 'fails with a PendingMigrationError for rails >= 5' do
+          allow(Rails).to receive(:version).and_return('5.0.0')
+          expect do
+            Neo4j::Migrations.check_for_pending_migrations!
+          end.to raise_error(PendingMigrationError, %r{bin/rails neo4j:migrate})
         end
 
-        it 'prints the current migration status' do
-          described_class.new.status
-          expect(output_string).to match(/^\s*incomplete\s*1234567890\s*RenameJohnJack$/)
-          expect(output_string).to match(/^\s*down\s*9500000001\s*RenameBobFrank/)
-          expect(output_string).to match(/^\s*up\s*9400000000\s*\*\*\*\* file missing \*\*\*\*/)
+        it 'fails with a PendingMigrationError for rails < 5' do
+          allow(Rails).to receive(:version).and_return('4.0.0')
+          expect do
+            Neo4j::Migrations.check_for_pending_migrations!
+          end.to raise_error(PendingMigrationError, %r{bin/rake neo4j:migrate})
+        end
+
+        it 'fails with a PendingMigrationError for non-rails' do
+          allow_any_instance_of(PendingMigrationError).to receive(:rails?).and_return(false)
+          expect do
+            Neo4j::Migrations.check_for_pending_migrations!
+          end.to raise_error(PendingMigrationError, /rake neo4j:migrate/)
         end
       end
 
-      describe '#up' do
-        it 'runs a certain migration version' do
-          u = User.create! name: 'Jack'
-          expect do
+      describe Runner do
+        describe '#pending_migrations?' do
+          it 'returns true if there are pending migrations' do
+            SchemaMigration.create! migration_id: '1234567890'
+            expect(described_class.new.pending_migrations?).to be_truthy
+          end
+
+          it 'returns false if all migrations are up' do
+            all_migrations_on!
+            expect(described_class.new.pending_migrations?).to be_falsey
+          end
+        end
+
+        describe '#all' do
+          it 'runs all migrations sorted by version' do
+            u = User.create! name: 'John'
+            expect do
+              described_class.new.all
+            end.to change { SchemaMigration.count }.by(3)
+              .and(change { u.reload.name }.to('Frank'))
+          end
+
+          it 'skips up migrations' do
+            u = User.create! name: 'Jack'
+            SchemaMigration.create! migration_id: '1234567890'
+            expect do
+              described_class.new.all
+            end.to change { Neo4j::Migrations::SchemaMigration.count }.by(2)
+              .and(change { u.reload.name }.to('Frank'))
+          end
+        end
+
+        describe '#status' do
+          before do
+            SchemaMigration.create! migration_id: '1234567890', incomplete: true
+            SchemaMigration.create! migration_id: '9500000000'
+            SchemaMigration.create! migration_id: '9400000000'
+          end
+
+          it 'prints the current migration status' do
+            described_class.new.status
+            expect(output_string).to match(/^\s*incomplete\s*1234567890\s*RenameJohnJack$/)
+            expect(output_string).to match(/^\s*down\s*9500000001\s*RenameBobFrank/)
+            expect(output_string).to match(/^\s*up\s*9400000000\s*\*\*\*\* file missing \*\*\*\*/)
+          end
+        end
+
+        describe '#up' do
+          it 'runs a certain migration version' do
+            u = User.create! name: 'Jack'
+            expect do
+              described_class.new.up '9500000000'
+            end.to change { u.reload.name }.to('Bob')
+              .and(change { SchemaMigration.count }.by(1))
+          end
+
+          it 'runs a certain migration version' do
+            u = User.create! name: 'Jack'
+            expect do
+              described_class.new.up '9500000000'
+            end.to change { u.reload.name }.to('Bob')
+              .and(change { SchemaMigration.count }.by(1))
+          end
+
+          it 'prints queries and execution time' do
             described_class.new.up '9500000000'
-          end.to change { u.reload.name }.to('Bob')
-            .and(change { SchemaMigration.count }.by(1))
+            expect(output_string).to include('MATCH (u:`User`)')
+            expect(output_string).to match(/migrated \(\d.\d+s\)/)
+          end
+
+          it 'fails when passing a missing version' do
+            expect { described_class.new.up '123123' }.to raise_error(
+              ::Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
+          end
         end
 
-        it 'runs a certain migration version' do
-          u = User.create! name: 'Jack'
-          expect do
+        describe '#down' do
+          before { all_migrations_on! }
+
+          it 'runs a certain migration version' do
+            u = User.create! name: 'Bob'
+            expect do
+              described_class.new.down '9500000000'
+            end.to change { u.reload.name }.to('Jack')
+          end
+
+          it 'fails when passing a missing version' do
+            expect { described_class.new.down '123123' }.to raise_error(
+              Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
+          end
+
+          it 'fails on irreversible migrations' do
+            expect { described_class.new.down '1234567890' }.to raise_error(::Neo4j::IrreversibleMigration)
+          end
+        end
+
+        describe '#rollback' do
+          it 'rollbacks migrations given a number of steps' do
+            all_migrations_on!
+            u = User.create! name: 'Frank'
+            expect do
+              described_class.new.rollback 2
+            end.to change { SchemaMigration.count }.by(-2)
+              .and(change { u.reload.name }.to('Jack'))
+          end
+        end
+
+        describe 'schema changes in migrations' do
+          before do
+            allow_any_instance_of(described_class).to receive(:files_path) do
+              Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
+            end
+          end
+
+          it 'run `up` without raising errors' do
+            expect do
+              expect do
+                described_class.new.up '8888888888'
+              end.not_to raise_error
+            end.to change { Neo4j::Core::Label.new(:Book, current_session).constraint?(:some) }.to(true)
+          end
+
+          it 'run `down` without raising errors' do
+            create_constraint :Book, :some, type: :unique
+            SchemaMigration.create! migration_id: '8888888888'
+            expect do
+              expect do
+                described_class.new.down '8888888888'
+              end.not_to raise_error
+            end.to change { Neo4j::Core::Label.new(:Book, current_session).constraint?(:some) }.to(false)
+          end
+        end
+
+        describe 'incomplete states' do
+          it 'leaves incomplete states on up' do
+            allow_any_instance_of(SchemaMigration).to receive(:update!)
             described_class.new.up '9500000000'
-          end.to change { u.reload.name }.to('Bob')
-            .and(change { SchemaMigration.count }.by(1))
-        end
+            expect do
+              described_class.new.up '9500000000'
+            end.to raise_error(/incomplete states/)
+          end
 
-        it 'prints queries and execution time' do
-          described_class.new.up '9500000000'
-          expect(output_string).to include('MATCH (u:`User`)')
-          expect(output_string).to match(/migrated \(\d.\d+s\)/)
-        end
-
-        it 'fails when passing a missing version' do
-          expect { described_class.new.up '123123' }.to raise_error(
-            ::Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
-        end
-      end
-
-      describe '#down' do
-        before { all_migrations_on! }
-
-        it 'runs a certain migration version' do
-          u = User.create! name: 'Bob'
-          expect do
+          it 'leaves incomplete states on down' do
+            described_class.new.up '9500000000'
+            allow_any_instance_of(SchemaMigration).to receive(:destroy)
             described_class.new.down '9500000000'
-          end.to change { u.reload.name }.to('Jack')
-        end
-
-        it 'fails when passing a missing version' do
-          expect { described_class.new.down '123123' }.to raise_error(
-            Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
-        end
-
-        it 'fails on irreversible migrations' do
-          expect { described_class.new.down '1234567890' }.to raise_error(::Neo4j::IrreversibleMigration)
-        end
-      end
-
-      describe '#rollback' do
-        it 'rollbacks migrations given a number of steps' do
-          all_migrations_on!
-          u = User.create! name: 'Frank'
-          expect do
-            described_class.new.rollback 2
-          end.to change { SchemaMigration.count }.by(-2)
-            .and(change { u.reload.name }.to('Jack'))
-        end
-      end
-
-      describe 'schema changes in migrations' do
-        before do
-          allow_any_instance_of(described_class).to receive(:files_path) do
-            Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
-          end
-        end
-
-        it 'run `up` without raising errors' do
-          expect do
             expect do
-              described_class.new.up '8888888888'
-            end.not_to raise_error
-          end.to change { Neo4j::Core::Label.new(:Book, current_session).constraint?(:some) }.to(true)
+              described_class.new.down '9500000000'
+            end.to raise_error(/incomplete states/)
+          end
+
+          describe '#resolve' do
+            it 'fixes incomplete states' do
+              migration = SchemaMigration.create! migration_id: 'some', incomplete: true
+              SchemaMigration.find_by!(migration_id: migration.migration_id)
+
+              expect do
+                described_class.new.resolve 'some'
+              end.to change { migration.reload.incomplete }.to(false)
+            end
+          end
+
+          describe '#reset' do
+            it 'rollbacks incomplete states' do
+              SchemaMigration.create! migration_id: 'some', incomplete: true
+              expect do
+                described_class.new.reset 'some'
+              end.to change { SchemaMigration.count }.by(-1)
+            end
+          end
         end
 
-        it 'run `down` without raising errors' do
-          create_constraint :Book, :some, type: :unique
-          SchemaMigration.create! migration_id: '8888888888'
-          expect do
+        describe 'schema and data changes in migrations' do
+          before do
+            allow_any_instance_of(described_class).to receive(:files_path) do
+              Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
+            end
+          end
+
+          it 'run correctly when transactions are disabled' do
+            described_class.new.up '9999999999'
+          end
+
+          it 'fails with a custom error message when transactions are enabled' do
             expect do
-              described_class.new.down '8888888888'
-            end.not_to raise_error
-          end.to change { Neo4j::Core::Label.new(:Book, current_session).constraint?(:some) }.to(false)
-        end
-      end
-
-      describe 'incomplete states' do
-        it 'leaves incomplete states on up' do
-          allow_any_instance_of(SchemaMigration).to receive(:update!)
-          described_class.new.up '9500000000'
-          expect do
-            described_class.new.up '9500000000'
-          end.to raise_error(/incomplete states/)
+              described_class.new.up '0000000000'
+            end.to raise_error(/Please add `disable_transactions!`/)
+          end
         end
 
-        it 'leaves incomplete states on down' do
-          described_class.new.up '9500000000'
-          allow_any_instance_of(SchemaMigration).to receive(:destroy)
-          described_class.new.down '9500000000'
-          expect do
-            described_class.new.down '9500000000'
-          end.to raise_error(/incomplete states/)
-        end
+        describe 'transactional behavior in migrations' do
+          before do
+            stub_active_node_class('Contact') do
+              property :phone
+            end
 
-        describe '#resolve' do
-          it 'fixes incomplete states' do
-            migration = SchemaMigration.create! migration_id: 'some', incomplete: true
-            SchemaMigration.find_by!(migration_id: migration.migration_id)
+            Contact.delete_all
+            create_constraint :Contact, :uuid, type: :unique
+            create_constraint :Contact, :phone, type: :unique
+            Contact.create! phone: '123123'
 
+            allow_any_instance_of(described_class).to receive(:files_path) do
+              Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
+            end
+          end
+
+          let!(:joe) { User.create! name: 'Joe' }
+
+          it 'rollbacks any change when one of the queries fails' do
             expect do
-              described_class.new.resolve 'some'
-            end.to change { migration.reload.incomplete }.to(false)
+              expect { described_class.new.up '1231231231' }.to raise_error(/already exists/)
+            end.not_to change { joe.reload.name }
           end
-        end
 
-        describe '#reset' do
-          it 'rollbacks incomplete states' do
-            SchemaMigration.create! migration_id: 'some', incomplete: true
+          it 'rollbacks nothing when transactions are disabled' do
             expect do
-              described_class.new.reset 'some'
-            end.to change { SchemaMigration.count }.by(-1)
+              expect { described_class.new.up '1234567890' }.to raise_error(/already exists/)
+            end.to change { joe.reload.name }.to('Jack')
           end
-        end
-      end
-
-      describe 'schema and data changes in migrations' do
-        before do
-          allow_any_instance_of(described_class).to receive(:files_path) do
-            Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
-          end
-        end
-
-        it 'run correctly when transactions are disabled' do
-          described_class.new.up '9999999999'
-        end
-
-        it 'fails with a custom error message when transactions are enabled' do
-          expect do
-            described_class.new.up '0000000000'
-          end.to raise_error(/Please add `disable_transactions!`/)
-        end
-      end
-
-      describe 'transactional behavior in migrations' do
-        before do
-          stub_active_node_class('Contact') do
-            property :phone
-          end
-
-          Contact.delete_all
-          create_constraint :Contact, :uuid, type: :unique
-          create_constraint :Contact, :phone, type: :unique
-          Contact.create! phone: '123123'
-
-          allow_any_instance_of(described_class).to receive(:files_path) do
-            Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
-          end
-        end
-
-        let!(:joe) { User.create! name: 'Joe' }
-
-        it 'rollbacks any change when one of the queries fails' do
-          expect do
-            expect { described_class.new.up '1231231231' }.to raise_error(/already exists/)
-          end.not_to change { joe.reload.name }
-        end
-
-        it 'rollbacks nothing when transactions are disabled' do
-          expect do
-            expect { described_class.new.up '1234567890' }.to raise_error(/already exists/)
-          end.to change { joe.reload.name }.to('Jack')
         end
       end
     end


### PR DESCRIPTION
Fixes #1263
Fixes #1260

This pull introduces/changes:
 * `check_for_pending_migrations!`: Fails with a `PendingMigrationError`, showing how to migrate, when there are pending migrations. For now, it's executed on rails startup, but maybe there's a better choice. For example, AR checks for it on every request.
 * `maintain_test_schema!`: It just executes a clean `rake neo4j:migrate`. It's the equivalent of `ActiveRecord::Migration.maintain_test_schema!`

What do you think?

Pings:
@cheerfulstoic
@subvertallchris
