### PR TITLE
Validates presence on has_many associations

### DIFF
--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -29,10 +29,14 @@ module Neo4j::ActiveNode
 
       extend Forwardable
       %w(include? empty? count find first last ==).each do |delegated_method|
-        def_delegator :@enumerable, delegated_method
+        def_delegator :deferred_objects_or_enumerable, delegated_method
       end
 
       include Enumerable
+
+      def deferred_objects_or_enumerable
+        @query_proxy.start_object.try(:new_record?) ? @deferred_objects : @enumerable
+      end
 
       def each(&block)
         result_nodes.each(&block)

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -35,7 +35,7 @@ module Neo4j::ActiveNode
       include Enumerable
 
       def deferred_objects_or_enumerable
-        #This is not good enough. Updates have to be taken care of as well
+        # This is not good enough. Updates have to be taken care of as well
         @query_proxy.start_object.try(:new_record?) ? @deferred_objects : @enumerable
       end
 

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -35,6 +35,7 @@ module Neo4j::ActiveNode
       include Enumerable
 
       def deferred_objects_or_enumerable
+        #This is not good enough. Updates have to be taken care of as well
         @query_proxy.start_object.try(:new_record?) ? @deferred_objects : @enumerable
       end
 

--- a/spec/e2e/unpersisted_association_spec.rb
+++ b/spec/e2e/unpersisted_association_spec.rb
@@ -221,7 +221,11 @@ describe 'association creation' do
       it 'does not raise error, creates rel on save' do
         expect_any_instance_of(Neo4j::Core::Query).not_to receive(:delete)
         expect { chris.lesson_ids = [math.id] }.not_to raise_error
-        expect { chris.save }.to change { chris.lessons.count }
+        expect { chris.save }.not_to change { chris.lessons.count }
+      end
+
+      it 'changes count' do
+        expect { chris.lesson_ids = [math.id] }.to change { chris.lessons.count }
       end
     end
   end

--- a/spec/e2e/unpersisted_association_spec.rb
+++ b/spec/e2e/unpersisted_association_spec.rb
@@ -19,7 +19,7 @@ describe 'association creation' do
     stub_active_node_class 'Lesson' do
       property :subject
       validates_presence_of :subject
-      has_many :in, :students, origin: :lesson
+      has_many :in, :students, origin: :lessons
     end
   end
 
@@ -221,10 +221,10 @@ describe 'association creation' do
       it 'does not raise error, creates rel on save' do
         expect_any_instance_of(Neo4j::Core::Query).not_to receive(:delete)
         expect { chris.lesson_ids = [math.id] }.not_to raise_error
-        expect { chris.save }.not_to change { chris.lessons.count }
+        expect { chris.save }.to change { Lesson.where(id: math.id).students.count }.by(1)
       end
 
-      it 'changes count' do
+      it 'changes count, even before persisting the node' do
         expect { chris.lesson_ids = [math.id] }.to change { chris.lessons.count }
       end
     end

--- a/spec/e2e/validation_association_spec.rb
+++ b/spec/e2e/validation_association_spec.rb
@@ -25,40 +25,39 @@ describe Neo4j::ActiveNode::Validations do
     end
   end
 
-  #The below spec pass on active_record as is
+  # The below spec pass on active_record as is
   context 'active_record behaviour' do
-    before :each do
-      @post = Post.create(name: 'abc', comments: [Comment.create])
-    end
-    it "comment= ignores validation" do
-      @post.comments = []
-      expect(@post.comments.size).to eq(0)
-      expect(@post.comments.count).to eq(0)
-      expect(Post.find(@post.id).comments.count).to eq(0)
+    let(:post) { Post.create(name: 'abc', comments: [Comment.create]) }
+
+    it 'comment= ignores validation' do
+      post.comments = []
+      expect(post.comments.size).to eq(0)
+      expect(post.comments.count).to eq(0)
+      expect(Post.find(post.id).comments.count).to eq(0)
     end
 
-    it "update respects validation" do
-      expect(@post.update(comments: [])).to be false
-      expect(@post.comments.size).to eq(0)
-      expect(@post.comments.count).to eq(1)
-      expect(Post.find(@post.id).comments.count).to eq(1)
+    it 'update respects validation' do
+      expect(post.update(comments: [])).to be false
+      expect(post.comments.size).to eq(0)
+      expect(post.comments.count).to eq(1)
+      expect(Post.find(post.id).comments.count).to eq(1)
     end
 
     it 'comments= saves invalid object' do
-      expect(Post.find(@post.id)).to be_valid
-      @post.comments = []
-      expect(Post.find(@post.id)).not_to be_valid
+      expect(Post.find(post.id)).to be_valid
+      post.comments = []
+      expect(Post.find(post.id)).to be_invalid
     end
 
     it 'update does not save invalid object' do
-      expect(Post.find(@post.id)).to be_valid
-      expect(@post.update(comments: [])).to be false
-      expect(Post.find(@post.id)).to be_valid
+      expect(Post.find(post.id)).to be_valid
+      expect(post.update(comments: [])).to be false
+      expect(Post.find(post.id)).to be_valid
     end
 
-    it 'does not save valid association if property is invalid' do
-      expect(@post.update(name: nil, comments: [Comment.create, Comment.create])).to be false
-      expect(Post.find(@post.id).comments.count).to eq(1)
+    it 'should not save valid association if property is invalid' do
+      expect(post.update(name: nil, comments: [Comment.create, Comment.create])).to be false
+      expect(Post.find(post.id).comments.count).to eq(1)
     end
   end
 end

--- a/spec/e2e/validation_association_spec.rb
+++ b/spec/e2e/validation_association_spec.rb
@@ -15,6 +15,8 @@ describe Neo4j::ActiveNode::Validations do
     end
 
     it 'should be valid with comments' do
+      post = Post.new(comments: [Comment.create])
+      post.valid?
       expect(Post.new(comments: [Comment.create])).to be_valid
     end
   end

--- a/spec/e2e/validation_association_spec.rb
+++ b/spec/e2e/validation_association_spec.rb
@@ -16,8 +16,22 @@ describe Neo4j::ActiveNode::Validations do
 
     it 'should be valid with comments' do
       post = Post.new(comments: [Comment.create])
-      post.valid?
       expect(Post.new(comments: [Comment.create])).to be_valid
+    end
+
+    it 'direct comments assignment should ignore validation' do
+      post = Post.new(comments: [Comment.create])
+      post.comments = []
+      expect(post.reload.comments).to be_empty
+    end
+
+    it 'should not save on update_attributes if invalid' do
+      post = Post.create(comments: [Comment.create])
+      expect(post.update(comment_ids: [])).to be false
+      post.comments
+      # expect(Post.find(post.id).comments).not_to be_empty
+      # expect(post.reload.comments).not_to be_empty
+      expect(post.reload.comments).to be_present
     end
   end
 end

--- a/spec/e2e/validation_association_spec.rb
+++ b/spec/e2e/validation_association_spec.rb
@@ -1,0 +1,21 @@
+describe Neo4j::ActiveNode::Validations do
+  before(:each) do
+    stub_active_node_class('Comment')
+
+    stub_active_node_class('Post') do
+      has_many :out, :comments, type: :COMMENT
+
+      validates :comments, presence: true
+    end
+  end
+
+  context 'validating presence' do
+    it 'should not be valid without comments' do
+      expect(Post.create.valid?).to be false
+    end
+
+    it 'should be valid with comments' do
+      expect(Post.new(comments: [Comment.create])).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
Fixes #
This is an attempt to start fixing numerous bugs around validation and saving of associations which is either wrong or inconsistent with active_record. It is by no means complete.
This pull introduces/changes:
 * Fixes validation for new object
 * Does not fix validation for update




Pings:
@cheerfulstoic
@subvertallchris
