### PR TITLE
Railtie refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Bugs with using `neo_id` as `ActiveNode` `id_property` (thanks klobuczek / see #1274)
 - Issue where `session_url` (now `session.url`) was not working
 - Various issues with not be able to run migrations when migration were pending
+- Broken sessions when threading
 
 ## [8.0.0.alpha.2] 2016-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- A `Neo4j::Migrations.maintain_test_schema!` method, to keep the test database up to date with schema changes. (see #1277)
+- A `Neo4j::Migrations.check_for_pending_migrations!` method, that fails when there are pending migration. In Rails, it's executed automatically on startup. (see #1277)
 - Support for [`ForbiddenAttributesProtection` API](http://edgeapi.rubyonrails.org/classes/ActionController/StrongParameters.html) from ActiveRecord. (thanks ProGM, see #1245)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - `ActiveNode#destroy` and `ActiveRel#destroy` now return the object in question rather than `true` to be compatible with `ActiveRecord` (see #1254)
 
+### Fixed
+
+- Bugs with using `neo_id` as `ActiveNode` `id_property` (thanks klobuczek / see #1274)
+
 ## [8.0.0.alpha.2] 2016-08-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - `ActiveNode#destroy` and `ActiveRel#destroy` now return the object in question rather than `true` to be compatible with `ActiveRecord` (see #1254)
+- Multiple sessions in Rails config no longer supported
+- Instead of using `session_type`, `session_url`, `session_path`, and `session_options` in config `session.type`, `session.url`, `session.path`, and `session.options` should now be used.
 
 ### Fixed
 
 - Bugs with using `neo_id` as `ActiveNode` `id_property` (thanks klobuczek / see #1274)
+- Issue where `session_url` (now `session.url`) was not working
+- Various issues with not be able to run migrations when migration were pending
 
 ## [8.0.0.alpha.2] 2016-08-05
 

--- a/docs/Setup.rst
+++ b/docs/Setup.rst
@@ -107,19 +107,19 @@ You can also use your Rails configuration.  The following example can be put int
 
 .. code-block:: ruby
 
-  config.neo4j.session_type = :http
-  config.neo4j.session_url = 'http://localhost:7474'
+  config.neo4j.session.type = :http
+  config.neo4j.session.url = 'http://localhost:7474'
 
   # Or, for embedded in jRuby
 
-  config.neo4j.session_type = :embedded
-  config.neo4j.session_path = '/path/to/graph.db'
+  config.neo4j.session.type = :embedded
+  config.neo4j.session.path = '/path/to/graph.db'
 
 Neo4j requires authentication by default but if you install using the built-in :doc:`rake tasks </RakeTasks>`) authentication is disabled.  If you are using authentication you can configure it like this:
 
 .. code-block:: ruby
 
-  config.neo4j.session_url = 'http://neo4j:password@localhost:7474'
+  config.neo4j.session.url = 'http://neo4j:password@localhost:7474'
 
 Of course it's often the case that you don't want to expose your username / password / URL in your repository.  In these cases you can use the ``NEO4J_TYPE`` (either ``http`` or ``embedded``) and ``NEO4J_URL``/``NEO4J_PATH`` environment variables.
 
@@ -130,7 +130,7 @@ Configuring Faraday
 
 .. code-block:: ruby
 
-  config.neo4j.session_options = {initialize: { ssl: { verify: true }}}
+  config.neo4j.session.options = {initialize: { ssl: { verify: true }}}
 
 Any Ruby Project
 ~~~~~~~~~~~~~~~~
@@ -212,8 +212,9 @@ Rails configuration
 
 .. code-block:: ruby
 
-  config.neo4j.session_type = :http
+  config.neo4j.session.type = :http
   # GrapheneDB
-  config.neo4j.session_path = ENV["GRAPHENEDB_URL"] || 'http://localhost:7474'
+  config.neo4j.session.path = ENV["GRAPHENEDB_URL"] || 'http://localhost:7474'
   # Graph Story
-  config.neo4j.session_path = ENV["GRAPHSTORY_URL"] || 'http://localhost:7474'
+  config.neo4j.session.path = ENV["GRAPHSTORY_URL"] || 'http://localhost:7474'
+

--- a/docs/UpgradeGuide.rst
+++ b/docs/UpgradeGuide.rst
@@ -197,5 +197,7 @@ Old Exception                                            New Exception
 Neo4j::Server::Resource::ServerException                 Neo4j::Core::CypherSession::ConnectionFailedError
 Neo4j::Server::CypherResponse::ConstraintViolationError  Neo4j::Core::CypherSession::SchemaErrors::ConstraintValidationFailedError
 Neo4j::Session::CypherError                              Neo4j::Core::CypherSession::CypherError
+?                                                        ConstraintAlreadyExistsError
+?                                                        IndexAlreadyExistsError
 =======================================================  =========================================================================
 

--- a/docs/UpgradeGuide.rst
+++ b/docs/UpgradeGuide.rst
@@ -101,7 +101,9 @@ If you are using version ``8.0`` of the ``neo4j`` gem, that will be accessible, 
 server_db
 ^^^^^^^^^
 
-In previous version of the ``neo4j`` gem to connect to Neo4j via HTTP you would define the value ``server_db`` in the ``neo4j.yml`` file, the ``NEO4J_TYPE`` environment variable, or a Rails configuration (``config.neo4j.session_type``).  This should now be replaced and either ``bolt`` or ``http`` should be used depending on which connection type you need.
+In previous version of the ``neo4j`` gem to connect to Neo4j via HTTP you would define the value ``server_db`` in the ``neo4j.yml`` file, the ``NEO4J_TYPE`` environment variable, or a Rails configuration (``config.neo4j.session.type``).  This should now be replaced and either ``bolt`` or ``http`` should be used depending on which connection type you need.
+
+Also, instead of using `session_type`, `session_url`, `session_path`, and `session_options`, you should use `session.type`, `session.url`, `session.path`, and `session.options` respectively.
 
 Some examples:
 
@@ -123,12 +125,12 @@ Some examples:
   # Rails config/application.rb, config/environments/development.rb, etc...
 
   # Before
-  config.neo4j.session_type = :server_db
-  config.neo4j.session_url = 'http://localhost:7474'
+  config.neo4j.session.type = :server_db
+  config.neo4j.session.url = 'http://localhost:7474'
 
   # AFter
-  config.neo4j.session_type = :http # or :bolt
-  config.neo4j.session_url = 'http://localhost:7474'
+  config.neo4j.session.type = :http # or :bolt
+  config.neo4j.session.url = 'http://localhost:7474'
 
 Outside of Rails
 ^^^^^^^^^^^^^^^^

--- a/lib/neo4j/active_base.rb
+++ b/lib/neo4j/active_base.rb
@@ -5,9 +5,17 @@ module Neo4j
     class << self
       # private?
       def current_session
-        SessionRegistry.current_session.tap do |session|
+        (SessionRegistry.current_session || establish_session).tap do |session|
           fail 'No session defined!' if session.nil?
         end
+      end
+
+      def on_establish_session(&block)
+        @establish_session_block = block
+      end
+
+      def establish_session
+        @establish_session_block.call if @establish_session_block
       end
 
       def current_transaction_or_session

--- a/lib/neo4j/active_base.rb
+++ b/lib/neo4j/active_base.rb
@@ -5,7 +5,7 @@ module Neo4j
     class << self
       # private?
       def current_session
-        (SessionRegistry.current_session || establish_session).tap do |session|
+        (SessionRegistry.current_session ||= establish_session).tap do |session|
           fail 'No session defined!' if session.nil?
         end
       end

--- a/lib/neo4j/active_base.rb
+++ b/lib/neo4j/active_base.rb
@@ -34,12 +34,12 @@ module Neo4j
       end
 
       def new_transaction
-        Neo4j::ModelSchema.validate_model_schema!
+        validate_model_schema!
         Neo4j::Transaction.new(current_session)
       end
 
       def new_query(options = {})
-        Neo4j::ModelSchema.validate_model_schema!
+        validate_model_schema!
         Neo4j::Core::Query.new({session: current_session}.merge(options))
       end
 
@@ -52,7 +52,7 @@ module Neo4j
       end
 
       def current_transaction
-        Neo4j::ModelSchema.validate_model_schema!
+        validate_model_schema!
         Neo4j::Transaction.current_for(current_session)
       end
 
@@ -62,6 +62,12 @@ module Neo4j
 
       def logger
         @logger ||= (Neo4j::Config[:logger] || ActiveSupport::Logger.new(STDOUT))
+      end
+
+      private
+
+      def validate_model_schema!
+        Neo4j::ModelSchema.validate_model_schema! unless Neo4j::Migrations.currently_running_migrations
       end
     end
   end

--- a/lib/neo4j/active_node/id_property.rb
+++ b/lib/neo4j/active_node/id_property.rb
@@ -38,9 +38,9 @@ module Neo4j::ActiveNode
 
     module TypeMethods
       def define_id_methods(clazz, name, conf)
-        validate_conf!(conf)
-
         return if name == :neo_id
+
+        validate_conf!(conf)
 
         if conf[:on]
           define_custom_method(clazz, name, conf[:on])
@@ -188,15 +188,15 @@ module Neo4j::ActiveNode
 
       def handle_model_schema!
         id_property_name = @id_property_info[:name]
+
+        return if id_property_name == :neo_id || @id_property_info[:inherited]
+
         if @id_property_info[:type][:constraint] == false &&
-           !@id_property_info[:inherited] &&
            !@id_property_info[:warned_of_constraint]
           @id_property_info[:warned_of_constraint] = true
           warn_constraint_option_false!(id_property_name)
           return
         end
-
-        return if id_property_name == :neo_id || @id_property_info[:inherited]
 
         Neo4j::ModelSchema.add_defined_constraint(self, id_property_name)
       end
@@ -211,7 +211,7 @@ MSG
       def id_property_name_type_value
         name, type, value = Neo4j::Config.to_hash.values_at(*%w(id_property id_property_type id_property_type_value))
 
-        if !(name && type && value)
+        unless name == :neo_id || (name && type && value)
           name = :uuid
           type = :auto
           value = :uuid

--- a/lib/neo4j/config.rb
+++ b/lib/neo4j/config.rb
@@ -95,6 +95,10 @@ module Neo4j
         configuration.to_yaml
       end
 
+      def fail_on_pending_migrations
+        Neo4j::Config[:fail_on_pending_migrations].nil? ? true : Neo4j::Config[:fail_on_pending_migrations]
+      end
+
       def include_root_in_json
         # we use ternary because a simple || will always evaluate true
         Neo4j::Config[:include_root_in_json].nil? ? true : Neo4j::Config[:include_root_in_json]

--- a/lib/neo4j/errors.rb
+++ b/lib/neo4j/errors.rb
@@ -27,7 +27,30 @@ module Neo4j
 
   class DangerousAttributeError < ScriptError; end
   class UnknownAttributeError < NoMethodError; end
+
   class MigrationError < Error; end
   class IrreversibleMigration < MigrationError; end
   class UnknownMigrationVersionError < MigrationError; end
+
+  # Inspired/taken from active_record/migration.rb
+  class PendingMigrationError < MigrationError
+    def initialize
+      if rails? && defined?(Rails.env)
+        super("Migrations are pending. To resolve this issue, run:\n\n        #{command_name} neo4j:migrate RAILS_ENV=#{::Rails.env}")
+      else
+        super("Migrations are pending. To resolve this issue, run:\n\n        #{command_name} neo4j:migrate")
+      end
+    end
+
+    private
+
+    def command_name
+      return 'rake' unless rails?
+      Rails.version.to_f >= 5 ? 'bin/rails' : 'bin/rake'
+    end
+
+    def rails?
+      defined?(Rails)
+    end
+  end
 end

--- a/lib/neo4j/migrations.rb
+++ b/lib/neo4j/migrations.rb
@@ -7,13 +7,17 @@ module Neo4j
     autoload :Runner
     autoload :SchemaMigration
 
-    def self.check_for_pending_migrations!
-      runner = Neo4j::Migrations::Runner.new
-      fail ::Neo4j::PendingMigrationError if runner.pending_migrations?
-    end
+    class << self
+      def check_for_pending_migrations!
+        runner = Neo4j::Migrations::Runner.new
+        fail ::Neo4j::PendingMigrationError if runner.pending_migrations?
+      end
 
-    def self.maintain_test_schema!
-      Neo4j::Migrations::Runner.new(silenced: true).all
+      attr_accessor :currently_running_migrations
+
+      def maintain_test_schema!
+        Neo4j::Migrations::Runner.new(silenced: true).all
+      end
     end
   end
 end

--- a/lib/neo4j/migrations.rb
+++ b/lib/neo4j/migrations.rb
@@ -6,5 +6,14 @@ module Neo4j
     autoload :Base
     autoload :Runner
     autoload :SchemaMigration
+
+    def self.check_for_pending_migrations!
+      runner = Neo4j::Migrations::Runner.new
+      fail ::Neo4j::PendingMigrationError if runner.pending_migrations?
+    end
+
+    def self.maintain_test_schema!
+      Neo4j::Migrations::Runner.new(silenced: true).all
+    end
   end
 end

--- a/lib/neo4j/railtie.rb
+++ b/lib/neo4j/railtie.rb
@@ -54,7 +54,9 @@ module Neo4j
       session_types = cfg.sessions.map { |session_opts| session_opts[:type] }
 
       register_neo4j_cypher_logging(session_types)
-      Neo4j::Migrations.check_for_pending_migrations! if Rails.env.development? && !Neo4j::Migrations.currently_running_migrations && Neo4j::Config.fail_on_pending_migrations
+      if Rails.env.development? && !Neo4j::Migrations.currently_running_migrations && Neo4j::Config.fail_on_pending_migrations
+        Neo4j::Migrations.check_for_pending_migrations!
+      end
     end
 
     TYPE_SUBSCRIBERS = {

--- a/lib/neo4j/railtie.rb
+++ b/lib/neo4j/railtie.rb
@@ -88,14 +88,12 @@ module Neo4j
           fail "Invalid scheme for NEO4J_URL: #{scheme}" if !%w(http bolt).include?(scheme)
         end
       else
-        ENV['NEO4J_TYPE'] || config_data[:type] || :http
+        ENV['NEO4J_TYPE'] || :http
       end.to_sym
     end
 
     def default_session_path_or_url
-      ENV['NEO4J_URL'] || ENV['NEO4J_PATH'] ||
-        config_data[:url] || config_data[:path] ||
-        'http://localhost:7474'
+      ENV['NEO4J_URL'] || ENV['NEO4J_PATH'] || 'http://localhost:7474'
     end
 
 

--- a/lib/neo4j/railtie.rb
+++ b/lib/neo4j/railtie.rb
@@ -54,7 +54,7 @@ module Neo4j
       session_types = cfg.sessions.map { |session_opts| session_opts[:type] }
 
       register_neo4j_cypher_logging(session_types)
-      Neo4j::Migrations.check_for_pending_migrations! if Rails.env.development? && Neo4j::Config.fail_on_pending_migrations
+      Neo4j::Migrations.check_for_pending_migrations! if Rails.env.development? && !Neo4j::Migrations.currently_running_migrations && Neo4j::Config.fail_on_pending_migrations
     end
 
     TYPE_SUBSCRIBERS = {

--- a/lib/neo4j/railtie.rb
+++ b/lib/neo4j/railtie.rb
@@ -36,7 +36,7 @@ module Neo4j
       load 'neo4j/tasks/migration.rake'
     end
 
-    console do |app|
+    console do
       Neo4j::Config[:logger] = ActiveSupport::Logger.new(STDOUT)
     end
 
@@ -44,7 +44,7 @@ module Neo4j
     # register migrations in config/initializers
     initializer 'neo4j.start', after: :load_config_initializers do |app|
       neo4j_config = ActiveSupport::OrderedOptions.new
-      app.config.neo4j.each {|k, v| neo4j_config[k] = v } if app.config.neo4j
+      app.config.neo4j.each { |k, v| neo4j_config[k] = v } if app.config.neo4j
 
       Neo4j::Config.configuration.merge!(neo4j_config.to_h)
 

--- a/lib/neo4j/railtie.rb
+++ b/lib/neo4j/railtie.rb
@@ -22,17 +22,10 @@ module Neo4j
     end
 
     # Rescue responses similar to ActiveRecord.
-    # For rails 3.2 and 4.0
-    if config.action_dispatch.respond_to?(:rescue_responses)
-      config.action_dispatch.rescue_responses.merge!(
-        'Neo4j::RecordNotFound' => :not_found,
-        'Neo4j::ActiveNode::Labels::RecordNotFound' => :not_found
-      )
-    else
-      # For rails 3.0 and 3.1
-      ActionDispatch::ShowExceptions.rescue_responses['Neo4j::RecordNotFound'] = :not_found
-      ActionDispatch::ShowExceptions.rescue_responses['Neo4j::ActiveNode::Labels::RecordNotFound'] = :not_found
-    end
+    config.action_dispatch.rescue_responses.merge!(
+      'Neo4j::RecordNotFound' => :not_found,
+      'Neo4j::ActiveNode::Labels::RecordNotFound' => :not_found
+    )
 
     # Add ActiveModel translations to the I18n load_path
     initializer 'i18n' do
@@ -61,6 +54,7 @@ module Neo4j
       session_types = cfg.sessions.map { |session_opts| session_opts[:type] }
 
       register_neo4j_cypher_logging(session_types)
+      Neo4j::Migrations.check_for_pending_migrations! if Rails.env.development? && Neo4j::Config.fail_on_pending_migrations
     end
 
     TYPE_SUBSCRIBERS = {

--- a/lib/neo4j/session_manager.rb
+++ b/lib/neo4j/session_manager.rb
@@ -7,7 +7,7 @@ require 'neo4j/core/cypher_session/adaptors/embedded'
 module Neo4j
   class SessionManager
     class << self
-      def open_neo4j_session(type, url_or_path, url, wait_for_connection = false, options = {})
+      def open_neo4j_session(type, url_or_path, wait_for_connection = false, options = {})
         enable_unlimited_strength_crypto! if java_platform? && session_type_is_embedded?(session_type)
 
         adaptor = wait_for_value(wait_for_connection) do

--- a/lib/neo4j/session_manager.rb
+++ b/lib/neo4j/session_manager.rb
@@ -8,7 +8,7 @@ module Neo4j
   class SessionManager
     class << self
       def open_neo4j_session(type, url_or_path, wait_for_connection = false, options = {})
-        enable_unlimited_strength_crypto! if java_platform? && session_type_is_embedded?(session_type)
+        enable_unlimited_strength_crypto! if java_platform? && session_type_is_embedded?(type)
 
         adaptor = wait_for_value(wait_for_connection) do
           cypher_session_adaptor(type, url_or_path, options.merge(wrap_level: :proc))

--- a/lib/neo4j/version.rb
+++ b/lib/neo4j/version.rb
@@ -1,3 +1,3 @@
 module Neo4j
-  VERSION = '8.0.0.alpha.3'
+  VERSION = '8.0.0.alpha.4'
 end

--- a/lib/neo4j/version.rb
+++ b/lib/neo4j/version.rb
@@ -1,3 +1,3 @@
 module Neo4j
-  VERSION = '8.0.0.alpha.4'
+  VERSION = '8.0.0.alpha.5'
 end

--- a/lib/neo4j/version.rb
+++ b/lib/neo4j/version.rb
@@ -1,3 +1,3 @@
 module Neo4j
-  VERSION = '8.0.0.alpha.5'
+  VERSION = '8.0.0.alpha.6'
 end

--- a/neo4j.gemspec
+++ b/neo4j.gemspec
@@ -7,7 +7,13 @@ require 'neo4j/version'
 Gem::Specification.new do |s|
   s.name     = 'neo4j'
   s.version  = Neo4j::VERSION
-  s.required_ruby_version = '>= 2.1.9'
+
+  if RUBY_PLATFORM == 'java'
+    s.required_ruby_version = '>= 1.9.3'
+  else
+    s.required_ruby_version = '>= 2.1.9'
+  end
+
 
   s.authors  = 'Andreas Ronge, Brian Underwood, Chris Grigg'
   s.email    = 'andreas.ronge@gmail.com, brian@brian-underwood.codes, chris@subvertallmedia.com'

--- a/neo4j.gemspec
+++ b/neo4j.gemspec
@@ -8,12 +8,7 @@ Gem::Specification.new do |s|
   s.name     = 'neo4j'
   s.version  = Neo4j::VERSION
 
-  if RUBY_PLATFORM == 'java'
-    s.required_ruby_version = '>= 1.9.3'
-  else
-    s.required_ruby_version = '>= 2.1.9'
-  end
-
+  s.required_ruby_version = ((RUBY_PLATFORM == 'java') ? '>= 1.9.3' : '>= 2.1.9')
 
   s.authors  = 'Andreas Ronge, Brian Underwood, Chris Grigg'
   s.email    = 'andreas.ronge@gmail.com, brian@brian-underwood.codes, chris@subvertallmedia.com'

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -596,7 +596,7 @@ describe 'Neo4j::ActiveNode' do
         let(:tz_offset) { Time.now.gmt_offset }
         let(:dst_offset) { tz_offset != 0 && Time.now.dst? ? 1 : 0 }
         let(:base_hour) { 9 }
-        let(:expected_hour) { base_hour - (tz_offset / 60 / 60) + dst_offset }
+        let(:expected_hour) { (base_hour - (tz_offset / 60 / 60) + dst_offset) % 24  }
 
         it 'converts to Time' do
           person = Person.create('time(1i)' => '1', 'time(2i)' => '1', 'time(3i)' => '1', 'time(4i)' => base_hour.to_s, 'time(5i)' => '12', 'time(6i)' => '42')

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -596,7 +596,7 @@ describe 'Neo4j::ActiveNode' do
         let(:tz_offset) { Time.now.gmt_offset }
         let(:dst_offset) { tz_offset != 0 && Time.now.dst? ? 1 : 0 }
         let(:base_hour) { 9 }
-        let(:expected_hour) { (base_hour - (tz_offset / 60 / 60) + dst_offset) % 24  }
+        let(:expected_hour) { (base_hour - (tz_offset / 60 / 60) + dst_offset) % 24 }
 
         it 'converts to Time' do
           person = Person.create('time(1i)' => '1', 'time(2i)' => '1', 'time(3i)' => '1', 'time(4i)' => base_hour.to_s, 'time(5i)' => '12', 'time(6i)' => '42')

--- a/spec/e2e/id_property_spec.rb
+++ b/spec/e2e/id_property_spec.rb
@@ -511,12 +511,13 @@ describe Neo4j::ActiveNode::IdProperty do
       end
     end
 
-    describe 'order' do
-      it 'should order by neo_id' do
-        nodes = Array.new(3) { NeoIdTest.create }
-        expect(NeoIdTest.order(id: :desc).to_a).to eq(nodes.reverse)
-      end
-    end
+    # this cannot be guaranteed anymore in community version'
+    # describe 'order' do
+    #   it 'should order by neo_id' do
+    #     nodes = Array.new(3) { NeoIdTest.create }
+    #     expect(NeoIdTest.order(id: :desc).to_a).to eq(nodes.reverse)
+    #   end
+    # end
   end
 
   describe 'inheritance' do

--- a/spec/e2e/id_property_spec.rb
+++ b/spec/e2e/id_property_spec.rb
@@ -499,7 +499,7 @@ describe Neo4j::ActiveNode::IdProperty do
         nodes = Array.new(3) { NeoIdTest.create }
         NeoIdTest.create
 
-        expect(NeoIdTest.where(id: nodes)).to eq(nodes)
+        expect(NeoIdTest.where(id: nodes)).to match_array(nodes)
       end
     end
 

--- a/spec/e2e/id_property_spec.rb
+++ b/spec/e2e/id_property_spec.rb
@@ -511,13 +511,13 @@ describe Neo4j::ActiveNode::IdProperty do
       end
     end
 
-    # this cannot be guaranteed anymore in community version'
-    # describe 'order' do
-    #   it 'should order by neo_id' do
-    #     nodes = Array.new(3) { NeoIdTest.create }
-    #     expect(NeoIdTest.order(id: :desc).to_a).to eq(nodes.reverse)
-    #   end
-    # end
+    describe 'order' do
+      it 'should order by neo_id' do
+        # ascending neo_ids during insertion cannot be guaranteed anymore in community version'
+        nodes = Array.new(3) { NeoIdTest.create }.sort_by!(&:id)
+        expect(NeoIdTest.order(id: :desc).to_a).to eq(nodes.reverse)
+      end
+    end
   end
 
   describe 'inheritance' do

--- a/spec/e2e/migrations_spec.rb
+++ b/spec/e2e/migrations_spec.rb
@@ -2,7 +2,7 @@ module Neo4j
   # rubocop:disable Metrics/ModuleLength
   module Migrations
     # rubocop:enable Metrics/ModuleLength
-    describe Runner do
+    describe 'Neo4j::Migrations' do
       before { delete_schema }
 
       capture_output!(:output_string)
@@ -16,7 +16,7 @@ module Neo4j
           property :name
         end
 
-        allow_any_instance_of(described_class).to receive(:files_path) do
+        allow_any_instance_of(Runner).to receive(:files_path) do
           Rails.root.join('spec', 'migration_files', 'migrations', '*.rb')
         end
         User.delete_all
@@ -29,211 +29,256 @@ module Neo4j
         SchemaMigration.create! migration_id: '9500000001'
       end
 
-      describe '#all' do
-        it 'runs all migrations sorted by version' do
-          u = User.create! name: 'John'
+      describe '#maintain_test_schema!' do
+        it 'checks and runs pending migrations' do
           expect do
-            described_class.new.all
+            Neo4j::Migrations.maintain_test_schema!
           end.to change { SchemaMigration.count }.by(3)
-            .and(change { u.reload.name }.to('Frank'))
-        end
-
-        it 'skips up migrations' do
-          u = User.create! name: 'Jack'
-          SchemaMigration.create! migration_id: '1234567890'
-          expect do
-            described_class.new.all
-          end.to change { Neo4j::Migrations::SchemaMigration.count }.by(2)
-            .and(change { u.reload.name }.to('Frank'))
         end
       end
 
-      describe '#status' do
-        before do
-          SchemaMigration.create! migration_id: '1234567890', incomplete: true
-          SchemaMigration.create! migration_id: '9500000000'
-          SchemaMigration.create! migration_id: '9400000000'
+      describe '#check_for_pending_migrations!' do
+        it 'fails with a PendingMigrationError for rails >= 5' do
+          allow(Rails).to receive(:version).and_return('5.0.0')
+          expect do
+            Neo4j::Migrations.check_for_pending_migrations!
+          end.to raise_error(PendingMigrationError, %r{bin/rails neo4j:migrate})
         end
 
-        it 'prints the current migration status' do
-          described_class.new.status
-          expect(output_string).to match(/^\s*incomplete\s*1234567890\s*RenameJohnJack$/)
-          expect(output_string).to match(/^\s*down\s*9500000001\s*RenameBobFrank/)
-          expect(output_string).to match(/^\s*up\s*9400000000\s*\*\*\*\* file missing \*\*\*\*/)
+        it 'fails with a PendingMigrationError for rails < 5' do
+          allow(Rails).to receive(:version).and_return('4.0.0')
+          expect do
+            Neo4j::Migrations.check_for_pending_migrations!
+          end.to raise_error(PendingMigrationError, %r{bin/rake neo4j:migrate})
+        end
+
+        it 'fails with a PendingMigrationError for non-rails' do
+          allow_any_instance_of(PendingMigrationError).to receive(:rails?).and_return(false)
+          expect do
+            Neo4j::Migrations.check_for_pending_migrations!
+          end.to raise_error(PendingMigrationError, /rake neo4j:migrate/)
         end
       end
 
-      describe '#up' do
-        it 'runs a certain migration version' do
-          u = User.create! name: 'Jack'
-          expect do
+      describe Runner do
+        describe '#pending_migrations?' do
+          it 'returns true if there are pending migrations' do
+            SchemaMigration.create! migration_id: '1234567890'
+            expect(described_class.new.pending_migrations?).to be_truthy
+          end
+
+          it 'returns false if all migrations are up' do
+            all_migrations_on!
+            expect(described_class.new.pending_migrations?).to be_falsey
+          end
+        end
+
+        describe '#all' do
+          it 'runs all migrations sorted by version' do
+            u = User.create! name: 'John'
+            expect do
+              described_class.new.all
+            end.to change { SchemaMigration.count }.by(3)
+              .and(change { u.reload.name }.to('Frank'))
+          end
+
+          it 'skips up migrations' do
+            u = User.create! name: 'Jack'
+            SchemaMigration.create! migration_id: '1234567890'
+            expect do
+              described_class.new.all
+            end.to change { Neo4j::Migrations::SchemaMigration.count }.by(2)
+              .and(change { u.reload.name }.to('Frank'))
+          end
+        end
+
+        describe '#status' do
+          before do
+            SchemaMigration.create! migration_id: '1234567890', incomplete: true
+            SchemaMigration.create! migration_id: '9500000000'
+            SchemaMigration.create! migration_id: '9400000000'
+          end
+
+          it 'prints the current migration status' do
+            described_class.new.status
+            expect(output_string).to match(/^\s*incomplete\s*1234567890\s*RenameJohnJack$/)
+            expect(output_string).to match(/^\s*down\s*9500000001\s*RenameBobFrank/)
+            expect(output_string).to match(/^\s*up\s*9400000000\s*\*\*\*\* file missing \*\*\*\*/)
+          end
+        end
+
+        describe '#up' do
+          it 'runs a certain migration version' do
+            u = User.create! name: 'Jack'
+            expect do
+              described_class.new.up '9500000000'
+            end.to change { u.reload.name }.to('Bob')
+              .and(change { SchemaMigration.count }.by(1))
+          end
+
+          it 'runs a certain migration version' do
+            u = User.create! name: 'Jack'
+            expect do
+              described_class.new.up '9500000000'
+            end.to change { u.reload.name }.to('Bob')
+              .and(change { SchemaMigration.count }.by(1))
+          end
+
+          it 'prints queries and execution time' do
             described_class.new.up '9500000000'
-          end.to change { u.reload.name }.to('Bob')
-            .and(change { SchemaMigration.count }.by(1))
+            expect(output_string).to include('MATCH (u:`User`)')
+            expect(output_string).to match(/migrated \(\d.\d+s\)/)
+          end
+
+          it 'fails when passing a missing version' do
+            expect { described_class.new.up '123123' }.to raise_error(
+              ::Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
+          end
         end
 
-        it 'runs a certain migration version' do
-          u = User.create! name: 'Jack'
-          expect do
+        describe '#down' do
+          before { all_migrations_on! }
+
+          it 'runs a certain migration version' do
+            u = User.create! name: 'Bob'
+            expect do
+              described_class.new.down '9500000000'
+            end.to change { u.reload.name }.to('Jack')
+          end
+
+          it 'fails when passing a missing version' do
+            expect { described_class.new.down '123123' }.to raise_error(
+              Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
+          end
+
+          it 'fails on irreversible migrations' do
+            expect { described_class.new.down '1234567890' }.to raise_error(::Neo4j::IrreversibleMigration)
+          end
+        end
+
+        describe '#rollback' do
+          it 'rollbacks migrations given a number of steps' do
+            all_migrations_on!
+            u = User.create! name: 'Frank'
+            expect do
+              described_class.new.rollback 2
+            end.to change { SchemaMigration.count }.by(-2)
+              .and(change { u.reload.name }.to('Jack'))
+          end
+        end
+
+        describe 'schema changes in migrations' do
+          before do
+            allow_any_instance_of(described_class).to receive(:files_path) do
+              Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
+            end
+          end
+
+          it 'run `up` without raising errors' do
+            expect do
+              expect do
+                described_class.new.up '8888888888'
+              end.not_to raise_error
+            end.to change { Neo4j::Core::Label.new(:Book, current_session).constraint?(:some) }.to(true)
+          end
+
+          it 'run `down` without raising errors' do
+            create_constraint :Book, :some, type: :unique
+            SchemaMigration.create! migration_id: '8888888888'
+            expect do
+              expect do
+                described_class.new.down '8888888888'
+              end.not_to raise_error
+            end.to change { Neo4j::Core::Label.new(:Book, current_session).constraint?(:some) }.to(false)
+          end
+        end
+
+        describe 'incomplete states' do
+          it 'leaves incomplete states on up' do
+            allow_any_instance_of(SchemaMigration).to receive(:update!)
             described_class.new.up '9500000000'
-          end.to change { u.reload.name }.to('Bob')
-            .and(change { SchemaMigration.count }.by(1))
-        end
+            expect do
+              described_class.new.up '9500000000'
+            end.to raise_error(/incomplete states/)
+          end
 
-        it 'prints queries and execution time' do
-          described_class.new.up '9500000000'
-          expect(output_string).to include('MATCH (u:`User`)')
-          expect(output_string).to match(/migrated \(\d.\d+s\)/)
-        end
-
-        it 'fails when passing a missing version' do
-          expect { described_class.new.up '123123' }.to raise_error(
-            ::Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
-        end
-      end
-
-      describe '#down' do
-        before { all_migrations_on! }
-
-        it 'runs a certain migration version' do
-          u = User.create! name: 'Bob'
-          expect do
+          it 'leaves incomplete states on down' do
+            described_class.new.up '9500000000'
+            allow_any_instance_of(SchemaMigration).to receive(:destroy)
             described_class.new.down '9500000000'
-          end.to change { u.reload.name }.to('Jack')
-        end
-
-        it 'fails when passing a missing version' do
-          expect { described_class.new.down '123123' }.to raise_error(
-            Neo4j::UnknownMigrationVersionError, 'No such migration 123123')
-        end
-
-        it 'fails on irreversible migrations' do
-          expect { described_class.new.down '1234567890' }.to raise_error(::Neo4j::IrreversibleMigration)
-        end
-      end
-
-      describe '#rollback' do
-        it 'rollbacks migrations given a number of steps' do
-          all_migrations_on!
-          u = User.create! name: 'Frank'
-          expect do
-            described_class.new.rollback 2
-          end.to change { SchemaMigration.count }.by(-2)
-            .and(change { u.reload.name }.to('Jack'))
-        end
-      end
-
-      describe 'schema changes in migrations' do
-        before do
-          allow_any_instance_of(described_class).to receive(:files_path) do
-            Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
-          end
-        end
-
-        it 'run `up` without raising errors' do
-          expect do
             expect do
-              described_class.new.up '8888888888'
-            end.not_to raise_error
-          end.to change { Neo4j::Core::Label.new(:Book, current_session).constraint?(:some) }.to(true)
+              described_class.new.down '9500000000'
+            end.to raise_error(/incomplete states/)
+          end
+
+          describe '#resolve' do
+            it 'fixes incomplete states' do
+              migration = SchemaMigration.create! migration_id: 'some', incomplete: true
+              SchemaMigration.find_by!(migration_id: migration.migration_id)
+
+              expect do
+                described_class.new.resolve 'some'
+              end.to change { migration.reload.incomplete }.to(false)
+            end
+          end
+
+          describe '#reset' do
+            it 'rollbacks incomplete states' do
+              SchemaMigration.create! migration_id: 'some', incomplete: true
+              expect do
+                described_class.new.reset 'some'
+              end.to change { SchemaMigration.count }.by(-1)
+            end
+          end
         end
 
-        it 'run `down` without raising errors' do
-          create_constraint :Book, :some, type: :unique
-          SchemaMigration.create! migration_id: '8888888888'
-          expect do
+        describe 'schema and data changes in migrations' do
+          before do
+            allow_any_instance_of(described_class).to receive(:files_path) do
+              Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
+            end
+          end
+
+          it 'run correctly when transactions are disabled' do
+            described_class.new.up '9999999999'
+          end
+
+          it 'fails with a custom error message when transactions are enabled' do
             expect do
-              described_class.new.down '8888888888'
-            end.not_to raise_error
-          end.to change { Neo4j::Core::Label.new(:Book, current_session).constraint?(:some) }.to(false)
-        end
-      end
-
-      describe 'incomplete states' do
-        it 'leaves incomplete states on up' do
-          allow_any_instance_of(SchemaMigration).to receive(:update!)
-          described_class.new.up '9500000000'
-          expect do
-            described_class.new.up '9500000000'
-          end.to raise_error(/incomplete states/)
+              described_class.new.up '0000000000'
+            end.to raise_error(/Please add `disable_transactions!`/)
+          end
         end
 
-        it 'leaves incomplete states on down' do
-          described_class.new.up '9500000000'
-          allow_any_instance_of(SchemaMigration).to receive(:destroy)
-          described_class.new.down '9500000000'
-          expect do
-            described_class.new.down '9500000000'
-          end.to raise_error(/incomplete states/)
-        end
+        describe 'transactional behavior in migrations' do
+          before do
+            stub_active_node_class('Contact') do
+              property :phone
+            end
 
-        describe '#resolve' do
-          it 'fixes incomplete states' do
-            migration = SchemaMigration.create! migration_id: 'some', incomplete: true
-            SchemaMigration.find_by!(migration_id: migration.migration_id)
+            Contact.delete_all
+            create_constraint :Contact, :uuid, type: :unique
+            create_constraint :Contact, :phone, type: :unique
+            Contact.create! phone: '123123'
 
+            allow_any_instance_of(described_class).to receive(:files_path) do
+              Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
+            end
+          end
+
+          let!(:joe) { User.create! name: 'Joe' }
+
+          it 'rollbacks any change when one of the queries fails' do
             expect do
-              described_class.new.resolve 'some'
-            end.to change { migration.reload.incomplete }.to(false)
+              expect { described_class.new.up '1231231231' }.to raise_error(/already exists/)
+            end.not_to change { joe.reload.name }
           end
-        end
 
-        describe '#reset' do
-          it 'rollbacks incomplete states' do
-            SchemaMigration.create! migration_id: 'some', incomplete: true
+          it 'rollbacks nothing when transactions are disabled' do
             expect do
-              described_class.new.reset 'some'
-            end.to change { SchemaMigration.count }.by(-1)
+              expect { described_class.new.up '1234567890' }.to raise_error(/already exists/)
+            end.to change { joe.reload.name }.to('Jack')
           end
-        end
-      end
-
-      describe 'schema and data changes in migrations' do
-        before do
-          allow_any_instance_of(described_class).to receive(:files_path) do
-            Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
-          end
-        end
-
-        it 'run correctly when transactions are disabled' do
-          described_class.new.up '9999999999'
-        end
-
-        it 'fails with a custom error message when transactions are enabled' do
-          expect do
-            described_class.new.up '0000000000'
-          end.to raise_error(/Please add `disable_transactions!`/)
-        end
-      end
-
-      describe 'transactional behavior in migrations' do
-        before do
-          stub_active_node_class('Contact') do
-            property :phone
-          end
-
-          Contact.delete_all
-          create_constraint :Contact, :uuid, type: :unique
-          create_constraint :Contact, :phone, type: :unique
-          Contact.create! phone: '123123'
-
-          allow_any_instance_of(described_class).to receive(:files_path) do
-            Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
-          end
-        end
-
-        let!(:joe) { User.create! name: 'Joe' }
-
-        it 'rollbacks any change when one of the queries fails' do
-          expect do
-            expect { described_class.new.up '1231231231' }.to raise_error(/already exists/)
-          end.not_to change { joe.reload.name }
-        end
-
-        it 'rollbacks nothing when transactions are disabled' do
-          expect do
-            expect { described_class.new.up '1234567890' }.to raise_error(/already exists/)
-          end.to change { joe.reload.name }.to('Jack')
         end
       end
     end

--- a/spec/e2e/railtie_spec.rb
+++ b/spec/e2e/railtie_spec.rb
@@ -27,6 +27,7 @@ module Rails
       end
 
       let_context(session_path: 'http://user:password@localhost:7474') do
+        let_env_variable(:NEO4J_URL) { nil }
         it 'calls Neo4j::SessionManager' do
           expect(Neo4j::SessionManager).to have_received(:open_neo4j_session).with(:http, 'http://user:password@localhost:7474', nil, {})
         end

--- a/spec/e2e/railtie_spec.rb
+++ b/spec/e2e/railtie_spec.rb
@@ -24,7 +24,7 @@ module Rails
       end
 
       subject do
-        Neo4j::SessionManager.setup!(cfg)
+        Neo4j::Railtie.setup!(cfg)
         cfg
       end
 

--- a/spec/e2e/railtie_spec.rb
+++ b/spec/e2e/railtie_spec.rb
@@ -15,61 +15,66 @@ module Rails
       let(:session_path) {}
       let(:cfg) do
         ActiveSupport::OrderedOptions.new.tap do |c|
-          c.session_path = session_path if session_path
+          c.session = ActiveSupport::OrderedOptions.new
+          c.session.path = session_path if session_path
         end
       end
 
       before do
-        expect(Neo4j::SessionManager).to receive(:open_neo4j_session)
-      end
+        stub_const('Neo4j::SessionManager', spy('Neo4j::SessionManager'))
 
-      subject do
         Neo4j::Railtie.setup!(cfg)
-        cfg
       end
 
       let_context(session_path: 'http://user:password@localhost:7474') do
-        its(:session_path) { should eq(session_path) }
+        it 'calls Neo4j::SessionManager' do
+          expect(Neo4j::SessionManager).to have_received(:open_neo4j_session).with(:http, 'http://user:password@localhost:7474', nil, {})
+        end
       end
 
       context 'NEO4J_URL is http' do
         let_env_variable(:NEO4J_URL) { 'http://localhost:7474' }
 
-        its(:session_path) { should eq('http://localhost:7474') }
-        its(:session_type) { should eq(:http) }
+        it 'calls Neo4j::SessionManager' do
+          expect(Neo4j::SessionManager).to have_received(:open_neo4j_session).with(:http, 'http://localhost:7474', nil, {})
+        end
       end
 
       context 'NEO4J_URL is bolt' do
         let_env_variable(:NEO4J_URL) { 'bolt://localhost:7472' }
-        its(:session_path) { should eq('bolt://localhost:7472') }
-        its(:session_type) { should eq(:bolt) }
+
+        it 'calls Neo4j::SessionManager' do
+          expect(Neo4j::SessionManager).to have_received(:open_neo4j_session).with(:bolt, 'bolt://localhost:7472', nil, {})
+        end
       end
     end
 
     describe 'open_neo4j_session' do
-      subject { Neo4j::SessionManager.open_neo4j_session(session_options) }
+      let(:session_type) { nil }
+      let(:session_path_or_url) { nil }
+      let(:session_options) { {} }
+      subject { Neo4j::SessionManager.open_neo4j_session(session_type, session_path_or_url, nil, session_options) }
 
       if TEST_SESSION_MODE != :embedded
-        let_context(session_options: {type: :embedded, path: './db'}) do
+        let_context(session_type: :embedded, session_path_or_url: './db') do
           subject_should_raise(/JRuby is required for embedded mode/)
         end
       end
 
-      let_context(session_options: {type: :invalid_type}) do
+      let_context(session_type: :invalid_type) do
         subject_should_raise(ArgumentError, /Invalid session type: :invalid_type$/)
       end
 
-      let_context(session_options: {type: :server_db}) do
+      let_context(session_type: :server_db) do
         subject_should_raise(ArgumentError, /Invalid session type: :server_db \(`server_db` has been replaced/)
       end
 
       describe 'resulting adaptor' do
         subject do
-          super()
-          Neo4j::ActiveBase.current_session.adaptor
+          super().adaptor
         end
 
-        let_context(session_options: {type: :http, url: 'http://neo4j:specs@the-host:1234'}) do
+        let_context(session_type: :http, session_path_or_url: 'http://neo4j:specs@the-host:1234') do
           it { should be_a(Neo4j::Core::CypherSession::Adaptors::HTTP) }
           its(:url) { should eq('http://neo4j:specs@the-host:1234') }
 
@@ -85,7 +90,7 @@ module Rails
           end
         end
 
-        let_context(session_options: {type: :http, url: 'http://neo4j:specs@the-host:1234', options: {basic_auth: 'neo4j', password: 'specs2'}}) do
+        let_context(session_type: :http, session_path_or_url: 'http://neo4j:specs@the-host:1234', session_options: {basic_auth: 'neo4j', password: 'specs2'}) do
           it { should be_a(Neo4j::Core::CypherSession::Adaptors::HTTP) }
           its(:url) { should eq('http://neo4j:specs@the-host:1234') }
 
@@ -106,9 +111,8 @@ module Rails
 
           context 'embedded session options' do
             let(:tmpdir) { Dir.mktmpdir }
-            let(:session_options) do
-              {type: :embedded, path: tmpdir}
-            end
+            let(:session_type) { :embedded }
+            let(:session_path_or_url) { tmpdir }
 
             # Mocking the embedded connection, to avoid `OutOfMemory` on Travis
             # This checks that the connection would be created


### PR DESCRIPTION
Refactored railtie to start to extract session connection logic out for use outside of Rails

Neo4j sessions are now established when needed, not at Rails startup.  This fixes sessions in multiple threads and avoids the need to have a Neo4j server up when doing things like compiling assets


Pings:
@subvertallchris
@ProGM 
