### PR TITLE
Allow HTTPS scheme in the NEO4J_URL

### DIFF
--- a/lib/neo4j/railtie.rb
+++ b/lib/neo4j/railtie.rb
@@ -88,9 +88,9 @@ module Neo4j
 
     def default_session_type
       if ENV['NEO4J_URL']
-        URI(ENV['NEO4J_URL']).scheme.tap do |scheme|
-          fail "Invalid scheme for NEO4J_URL: #{scheme}" if !%w(http bolt).include?(scheme)
-        end
+        scheme = URI(ENV['NEO4J_URL']).scheme
+        fail "Invalid scheme for NEO4J_URL: #{scheme}" if !%w(http https bolt).include?(scheme)
+        scheme == 'https' ? 'http' : scheme
       else
         ENV['NEO4J_TYPE'] || :http
       end.to_sym

--- a/spec/e2e/railtie_spec.rb
+++ b/spec/e2e/railtie_spec.rb
@@ -48,6 +48,14 @@ module Rails
           expect(Neo4j::SessionManager).to have_received(:open_neo4j_session).with(:bolt, 'bolt://localhost:7472', nil, {})
         end
       end
+
+      context 'NEO4J_URL is https' do
+        let_env_variable(:NEO4J_URL) { 'https://localhost:7472' }
+
+        it 'calls Neo4j::SessionManager' do
+          expect(Neo4j::SessionManager).to have_received(:open_neo4j_session).with(:http, 'https://localhost:7472', nil, {})
+        end
+      end
     end
 
     describe 'open_neo4j_session' do


### PR DESCRIPTION
[This](https://github.com/neo4jrb/neo4j/commit/fdf341d44be5914c2aced54751fb1a7c983e760a) commit introduced a change to enforce the URI scheme on the `NEO4J_URL`, which inadvertently broke the scenario of using an `HTTPS` scheme. This PR restores the ability to use an `HTTPS` scheme (by masquerading as a regular `HTTP` scheme).