### PR TITLE
Fix validations with unpersisted nodes and various bugs with associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Don't fire database when accessing to unpersisted model associations (thanks @klobuczek & @ProGM see #1273)
+- `size` and `length` methods not taking account of `@deferred_objects` (see #1293)
+- `update` was not rolling-back association changes when validations fail
+
+# Changed
+- `count` method in associations, now always fire the database like AR does
+- Neo4j now passes all association validations specs, taken from AR (thanks @klobuczek)
+
 - Remove blank objects from association results to be compatible with `ActiveRecord` (see #1276 / thanks klobuczek)
 
 ## [8.0.0.alpha.9] 2016-09-14

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -38,9 +38,8 @@ module Neo4j::ActiveNode
         result_nodes.each(&block)
       end
 
-      def count(*args)
-        @deferred_objects.count + @enumerable.count(*args)
-      end
+      # .count always hits the database
+      def_delegator :@query_proxy, :count
 
       def length
         @deferred_objects.length + @enumerable.length
@@ -75,9 +74,7 @@ module Neo4j::ActiveNode
       def result_nodes
         return result_objects if !@query_proxy.model
 
-        result_objects.map do |object|
-          object.is_a?(Neo4j::ActiveNode) ? object : @query_proxy.model.find(object)
-        end
+        map_results_as_nodes(result_objects)
       end
 
       def result_objects
@@ -117,9 +114,12 @@ module Neo4j::ActiveNode
       end
 
       def replace_with(*args)
-        @cached_result = nil
-
-        @query_proxy.public_send(:replace_with, *args)
+        nodes = @query_proxy.public_send(:replace_with, *args).to_a
+        if @query_proxy.start_object.try(:new_record?)
+          @cached_result = nil
+        else
+          cache_result(nodes)
+        end
       end
 
       QUERY_PROXY_METHODS = [:<<, :delete, :create, :pluck, :where, :where_not, :rel_where, :rel_order, :order, :skip, :limit]
@@ -147,6 +147,12 @@ module Neo4j::ActiveNode
       end
 
       private
+
+      def map_results_as_nodes(result)
+        result.map do |object|
+          object.is_a?(Neo4j::ActiveNode) ? object : @query_proxy.model.find(object)
+        end
+      end
 
       def target_for_missing_method(method_name)
         case method_name

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -28,7 +28,7 @@ module Neo4j::ActiveNode
       end
 
       extend Forwardable
-      %w(include? empty? count find first last ==).each do |delegated_method|
+      %w(include? find first last ==).each do |delegated_method|
         def_delegator :@enumerable, delegated_method
       end
 
@@ -36,6 +36,22 @@ module Neo4j::ActiveNode
 
       def each(&block)
         result_nodes.each(&block)
+      end
+
+      def count(*args)
+        @deferred_objects.count + @enumerable.count(*args)
+      end
+
+      def length
+        @deferred_objects.length + @enumerable.length
+      end
+
+      def size
+        @deferred_objects.size + @enumerable.size
+      end
+
+      def empty?(*args)
+        @deferred_objects.empty? && @enumerable.empty?(*args)
       end
 
       def ==(other)

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -114,7 +114,7 @@ module Neo4j::ActiveNode
       end
 
       def replace_with(*args)
-        nodes = @query_proxy.public_send(:replace_with, *args).to_a
+        nodes = @query_proxy.replace_with(*args).to_a
         if @query_proxy.start_object.try(:new_record?)
           @cached_result = nil
         else

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -266,6 +266,10 @@ module Neo4j
           end
         end
 
+        def unpersisted_start_object?
+          @start_object && @start_object.new_record?
+        end
+
         protected
 
         # Methods are underscored to prevent conflict with user class methods

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -1,7 +1,9 @@
 module Neo4j
   module ActiveNode
     module Query
+      # rubocop:disable Metrics/ClassLength
       class QueryProxy
+        # rubocop:enable Metrics/ClassLength
         include Neo4j::ActiveNode::Query::QueryProxyEnumerable
         include Neo4j::ActiveNode::Query::QueryProxyMethods
         include Neo4j::ActiveNode::Query::QueryProxyMethodsOfMassUpdating

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -165,13 +165,7 @@ module Neo4j
 
         # To add a relationship for the node for the association on this QueryProxy
         def <<(other_node)
-          if @start_object._persisted_obj
-            create(other_node, {})
-          elsif @association
-            @start_object.defer_create(@association.name, other_node)
-          else
-            fail 'Another crazy error!'
-          end
+          _create_relation_or_defer(other_node)
           self
         end
 
@@ -271,6 +265,16 @@ module Neo4j
         end
 
         protected
+
+        def _create_relation_or_defer(other_node)
+          if @start_object._persisted_obj
+            create(other_node, {})
+          elsif @association
+            @start_object.defer_create(@association.name, other_node)
+          else
+            fail 'Another crazy error!'
+          end
+        end
 
         # Methods are underscored to prevent conflict with user class methods
         def _add_params(params)

--- a/lib/neo4j/active_node/query/query_proxy_enumerable.rb
+++ b/lib/neo4j/active_node/query/query_proxy_enumerable.rb
@@ -14,7 +14,7 @@ module Neo4j
         end
 
         def result(node = true, rel = nil)
-          return [].freeze if @start_object && @start_object.new_record?
+          return [].freeze if unpersisted_start_object?
 
           @result_cache ||= {}
           return result_cache_for(node, rel) if result_cache?(node, rel)

--- a/lib/neo4j/active_node/query/query_proxy_enumerable.rb
+++ b/lib/neo4j/active_node/query/query_proxy_enumerable.rb
@@ -14,6 +14,8 @@ module Neo4j
         end
 
         def result(node = true, rel = nil)
+          return [].freeze if @start_object && @start_object.new_record?
+
           @result_cache ||= {}
           return result_cache_for(node, rel) if result_cache?(node, rel)
 

--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -39,6 +39,7 @@ module Neo4j
 
         # @return [Integer] number of nodes of this class
         def count(distinct = nil, target = nil)
+          return 0 if unpersisted_start_object?
           fail(Neo4j::InvalidParameterError, ':count accepts `distinct` or nil as a parameter') unless distinct.nil? || distinct == :distinct
           query_with_target(target) do |var|
             q = distinct.nil? ? var : "DISTINCT #{var}"
@@ -61,6 +62,7 @@ module Neo4j
         end
 
         def empty?(target = nil)
+          return true if unpersisted_start_object?
           query_with_target(target) { |var| !self.exists?(nil, var) }
         end
 

--- a/lib/neo4j/active_node/query/query_proxy_methods_of_mass_updating.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods_of_mass_updating.rb
@@ -52,7 +52,10 @@ module Neo4j
           nodes = Array(node_or_nodes)
 
           self.delete_all_rels
-          nodes.each { |node| self << node }
+          nodes.map do |node|
+            node if _create_relation_or_defer(node)
+          end.compact
+          # nodes.each { |node| self << node }
         end
 
         # Returns all relationships between a node and its last link in the QueryProxy chain, destroys them in Ruby. Callbacks will be run.

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -1,5 +1,7 @@
 module Neo4j::Shared
+  # rubocop:disable Metrics/ModuleLength
   module Persistence
+    # rubocop:enable Metrics/ModuleLength
     extend ActiveSupport::Concern
 
     # @return [Hash] Given a node's state, will call the appropriate `props_for_{action}` method.

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -172,15 +172,21 @@ module Neo4j::Shared
     # Updates this resource with all the attributes from the passed-in Hash and requests that the record be saved.
     # If saving fails because the resource is invalid then false will be returned.
     def update(attributes)
-      self.attributes = process_attributes(attributes)
-      save
+      self.class.run_transaction do |tx|
+        self.attributes = process_attributes(attributes)
+        saved = save
+        tx.mark_failed unless saved
+        saved
+      end
     end
     alias update_attributes update
 
     # Same as {#update_attributes}, but raises an exception if saving fails.
     def update!(attributes)
-      self.attributes = process_attributes(attributes)
-      save!
+      self.class.run_transaction do
+        self.attributes = process_attributes(attributes)
+        save!
+      end
     end
     alias update_attributes! update!
 

--- a/spec/e2e/unpersisted_association_spec.rb
+++ b/spec/e2e/unpersisted_association_spec.rb
@@ -19,7 +19,7 @@ describe 'association creation' do
     stub_active_node_class 'Lesson' do
       property :subject
       validates_presence_of :subject
-      has_many :in, :students, origin: :lesson
+      has_many :in, :students, origin: :lessons
     end
   end
 
@@ -131,6 +131,16 @@ describe 'association creation' do
 
       it 'skips queries when accessing to unpersisted associations' do
         expect_queries(0) { chris.lessons.to_a }
+        expect_queries(0) { chris.lessons.count }
+      end
+
+      it '.count, .size and .length returns the number of unpersisted associations' do
+        chris.lessons << math
+        expect_queries(0) do
+          expect(chris.lessons.count).to eq(1)
+          expect(chris.lessons.length).to eq(1)
+          expect(chris.lessons.size).to eq(1)
+        end
       end
 
       context 'upon save...' do
@@ -229,7 +239,7 @@ describe 'association creation' do
       it 'does not raise error, creates rel on save' do
         expect_any_instance_of(Neo4j::Core::Query).not_to receive(:delete)
         expect { chris.lesson_ids = [math.id] }.not_to raise_error
-        expect { chris.save }.to change { chris.lessons.count }
+        expect { chris.save }.to change { math.students.count }
       end
     end
   end

--- a/spec/e2e/unpersisted_association_spec.rb
+++ b/spec/e2e/unpersisted_association_spec.rb
@@ -71,6 +71,10 @@ describe 'association creation' do
         expect { chris.favorite_class = math }.to change { chris.pending_deferred_creations? }
       end
 
+      it 'skips queries when accessing to an unpersisted association' do
+        expect_queries(0) { chris.favorite_class }
+      end
+
       context 'upon save...' do
         before do
           chris.favorite_class = math
@@ -123,6 +127,10 @@ describe 'association creation' do
 
       it 'is aware that there are cascading relationships' do
         expect { chris.lessons << math }.to change { chris.pending_deferred_creations? }
+      end
+
+      it 'skips queries when accessing to unpersisted associations' do
+        expect_queries(0) { chris.lessons.to_a }
       end
 
       context 'upon save...' do

--- a/spec/e2e/unpersisted_association_spec.rb
+++ b/spec/e2e/unpersisted_association_spec.rb
@@ -137,7 +137,7 @@ describe 'association creation' do
       it '.count, .size and .length returns the number of unpersisted associations' do
         chris.lessons << math
         expect_queries(0) do
-          expect(chris.lessons.count).to eq(1)
+          expect(chris.lessons.count).to eq(0)
           expect(chris.lessons.length).to eq(1)
           expect(chris.lessons.size).to eq(1)
         end

--- a/spec/e2e/validation_association_spec.rb
+++ b/spec/e2e/validation_association_spec.rb
@@ -1,0 +1,63 @@
+describe Neo4j::ActiveNode::Validations do
+  before(:each) do
+    stub_active_node_class('Comment')
+
+    stub_active_node_class('Post') do
+      property :name, type: String
+      has_many :out, :comments, type: :COMMENT
+
+      validates :name, presence: true
+      validates :comments, presence: true
+    end
+  end
+
+  context 'validating presence' do
+    it 'new object should not be valid without comments' do
+      expect(Post.new({})).not_to be_valid
+    end
+
+    it 'should not be valid without comments' do
+      expect(Post.create).not_to be_valid
+    end
+
+    it 'should be valid with comments' do
+      expect(Post.new(name: 'abc', comments: [Comment.create])).to be_valid
+    end
+  end
+
+  # The below spec pass on active_record as is
+  context 'active_record behaviour' do
+    let(:post) { Post.create!(name: 'abc', comments: [Comment.create]) }
+
+    it 'comment= ignores validation' do
+      post.comments = []
+      expect(post.comments.size).to eq(0)
+      expect(post.comments.count).to eq(0)
+      expect(Post.find(post.id).comments.count).to eq(0)
+    end
+
+    it 'update respects validation' do
+      expect(post.update(comments: [])).to be false
+      expect(post.comments.size).to eq(0)
+      expect(post.comments.count).to eq(1)
+      expect(Post.find(post.id).comments.count).to eq(1)
+    end
+
+    it 'comments= saves invalid object' do
+      expect(Post.find(post.id)).to be_valid
+      post.comments = []
+      expect(Post.find(post.id)).to be_invalid
+    end
+
+    it 'update does not save invalid object' do
+      expect(Post.find(post.id)).to be_valid
+      expect(post.update(comments: [])).to be false
+      expect(Post.find(post.id)).to be_valid
+    end
+
+    it 'should not save valid association if property is invalid' do
+      expect(post.update(name: nil, comments: [Comment.create, Comment.create])).to be false
+      expect(Post.find(post.id).comments.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1292 , #1273 and is a replacement for both #1288 and #1279

This pull introduces/changes:
 * Does not fire database when accessing to unpersisted associations
 * Fixes `.count` method on associations, that should ALWAYS fire the database, also if the cache is available (like active record does)
* Fixed `size` and `length` on associations, that should take account of @deferred_objects
* Added (and passed) all AR specs about relationships: https://github.com/neo4jrb/neo4j/blob/16143eec2a0c1cae8434282f0d7bf8456c49497d/spec/e2e/validation_association_spec.rb Thanks @klobuczek 




Pings:
@cheerfulstoic
@subvertallchris
@klobuczek 