### PR TITLE
Undeclared properties

### DIFF
--- a/docs/Properties.rst
+++ b/docs/Properties.rst
@@ -43,16 +43,26 @@ You will now be able to set the ``title`` property through mass-assignment (``Po
 Undeclared Properties
 ---------------------
 
-Neo4j, being schemaless as far as the database is concerned, does not require that property keys be defined ahead of time. As a result, it's possible (and sometimes desirable) to set properties on the node that are not also defined on the database. For instance:
+Neo4j, being schemaless as far as the database is concerned, does not require that property keys be defined ahead of time. As a result, it's possible (and sometimes desirable) to set properties on the node that are not also defined on the database. By including the module ``Neo4j::UndeclaredProperties`` no exceptions will be thrown if unknown attributes are passed to selected methods.
+
 
 .. code-block:: ruby
 
-  Neo4j::Node.create({ property: 'MyProp', secret_val: 123 }, :Post)
-  post = Post.first
-  post.secret_val
-  => NoMethodError: undefined method `secret_val`...
+  class Post
+    include Neo4j::ActiveNode
+    include Neo4j::UndeclaredProperties
 
-In this case, simply adding the ``secret_val`` property to your model will make it available through the ``secret_val`` method. Alternatively, you can also access the properties of the "unwrapped node" through ``post._persisted_obj.props``. See the Neo4j::Core API for more details about working with CypherNode objects.
+    property :title
+  end
+
+  Post.create(title: 'My Post', secret_val: 123)
+  post = Post.first
+  post.secret_val #=> NoMethodError: undefined method `secret_val`
+  post[:secret_val] #=> 123...
+
+
+In this case, simply adding the ``secret_val`` property to your model will make it available through the ``secret_val`` method.
+The module supports undeclared properties in the following methods: `new`, `create`, `[]`, `[]=`, `update_attribute`, `update_attribute!`, `update_attributes` and their corresponding aliases.
 
 Types and Conversion
 ____________________

--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -26,6 +26,7 @@ require 'neo4j/paginated'
 require 'neo4j/schema/operation'
 
 require 'neo4j/timestamps'
+require 'neo4j/undeclared_properties'
 
 require 'neo4j/shared/callbacks'
 require 'neo4j/shared/filtered_hash'

--- a/lib/neo4j/shared/mass_assignment.rb
+++ b/lib/neo4j/shared/mass_assignment.rb
@@ -29,10 +29,12 @@ module Neo4j::Shared
         if respond_to?(writer)
           send(writer, value)
         else
-          (@undeclared_attributes ||= {})[name] = value
+          add_undeclared_property(name, value)
         end
       end
     end
+
+    def add_undeclared_property(_, _); end
 
     # Mass update a model's attributes
     #

--- a/lib/neo4j/shared/mass_assignment.rb
+++ b/lib/neo4j/shared/mass_assignment.rb
@@ -26,7 +26,11 @@ module Neo4j::Shared
       return unless new_attributes.present?
       new_attributes.each do |name, value|
         writer = :"#{name}="
-        send(writer, value) if respond_to?(writer)
+        if respond_to?(writer)
+          send(writer, value)
+        else
+          (@undeclared_attributes ||= {})[name] = value
+        end
       end
     end
 

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -23,9 +23,10 @@ module Neo4j::Shared
     def initialize(attributes = nil)
       attributes = process_attributes(attributes)
       modded_attributes = inject_defaults!(attributes)
-      validate_attributes!(modded_attributes)
+      # validate_attributes!(modded_attributes)
       writer_method_props = extract_writer_methods!(modded_attributes)
       send_props(writer_method_props)
+      @undeclared_attributes = attributes
       @_persisted_obj = nil
     end
 
@@ -35,7 +36,7 @@ module Neo4j::Shared
     end
 
     def read_attribute(name)
-      respond_to?(name) ? send(name) : nil
+      respond_to?(name) ? send(name) : (_persisted_obj && _persisted_obj.props[name])
     end
     alias [] read_attribute
 

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -23,12 +23,14 @@ module Neo4j::Shared
     def initialize(attributes = nil)
       attributes = process_attributes(attributes)
       modded_attributes = inject_defaults!(attributes)
-      # validate_attributes!(modded_attributes)
+      validate_attributes!(modded_attributes)
       writer_method_props = extract_writer_methods!(modded_attributes)
       send_props(writer_method_props)
-      @undeclared_attributes = attributes
+      self.undeclared_properties = attributes
       @_persisted_obj = nil
     end
+
+    def undeclared_properties=(_); end
 
     def inject_defaults!(starting_props)
       return starting_props if self.class.declared_properties.declared_property_defaults.empty?
@@ -36,7 +38,7 @@ module Neo4j::Shared
     end
 
     def read_attribute(name)
-      respond_to?(name) ? send(name) : (_persisted_obj && _persisted_obj.props[name])
+      respond_to?(name) ? send(name) : nil
     end
     alias [] read_attribute
 

--- a/lib/neo4j/undeclared_properties.rb
+++ b/lib/neo4j/undeclared_properties.rb
@@ -1,0 +1,53 @@
+module Neo4j
+  # This mixin allows storage and update of undeclared properties in the included class
+  module UndeclaredProperties
+    extend ActiveSupport::Concern
+
+    included do
+      attr_accessor :undeclared_properties
+    end
+
+    def validate_attributes!(_)
+    end
+
+    def read_attribute(name)
+      respond_to?(name) ? super(name) : read_undeclared_property(name)
+    end
+    alias [] read_attribute
+
+    def read_undeclared_property(name)
+      _persisted_obj ? _persisted_obj.props[name] : (undeclared_properties && undeclared_properties[name])
+    end
+
+    def write_attribute(name, value)
+      if respond_to? "#{name}="
+        super(name, value)
+      else
+        add_undeclared_property(name, value)
+      end
+    end
+    alias []= write_attribute
+
+    def skip_update?
+      super && undeclared_properties.blank?
+    end
+
+    def props_for_create
+      super.merge(undeclared_properties!)
+    end
+
+    def props_for_update
+      super.merge(undeclared_properties!)
+    end
+
+    def undeclared_properties!
+      undeclared_properties || {}
+    ensure
+      self.undeclared_properties = nil
+    end
+
+    def add_undeclared_property(name, value)
+      (self.undeclared_properties ||= {})[name] = value
+    end
+  end
+end

--- a/lib/neo4j/undeclared_properties.rb
+++ b/lib/neo4j/undeclared_properties.rb
@@ -11,7 +11,7 @@ module Neo4j
     end
 
     def read_attribute(name)
-      respond_to?(name) ? super(name) : read_undeclared_property(name)
+      respond_to?(name) ? super(name) : read_undeclared_property(name.to_sym)
     end
     alias [] read_attribute
 

--- a/spec/e2e/undeclared_properties_spec.rb
+++ b/spec/e2e/undeclared_properties_spec.rb
@@ -1,0 +1,100 @@
+describe Neo4j::ActiveNode do
+  before(:each) do
+    stub_active_node_class('Person') do
+      include Neo4j::UndeclaredProperties
+      property :name, type: String
+    end
+  end
+
+  def get_value_from_db(node, prop)
+    node.class.where(id: node.id).first[prop]
+  end
+
+  describe '.new' do
+    it 'undeclared properties are found' do
+      expect(Person.new(foo: 123)[:foo]).to eq(123)
+      expect(Person.new(foo: 123)['foo']).to eq(123)
+    end
+  end
+
+  describe '.create' do
+    it 'does allow to set undeclared properties using create' do
+      expect { Person.create(foo: 43) }.not_to raise_error Neo4j::Shared::Property::UndefinedPropertyError
+    end
+
+    it 'stores undefined attributes' do
+      person = Person.create(name: 'Jim', foo: 123)
+      expect(person[:foo]).to eq(123)
+      expect(person['foo']).to eq(123)
+      expect(get_value_from_db(person, :foo)).to eq(123)
+    end
+  end
+
+  describe 'save' do
+    it 'does not raise Neo4j::Shared::UnknownAttributeError if trying to set undeclared property' do
+      expect { Person.new[:foo] = 42 }.not_to raise_error(Neo4j::UnknownAttributeError)
+    end
+
+    it 'saves undeclared the properties that has been changed with []= operator' do
+      person = Person.new
+      person[:foo] = 123
+      person.save
+      expect(person[:foo]).to eq(123)
+      expect(get_value_from_db(person, :foo)).to eq(123)
+    end
+  end
+
+  describe '#save!' do
+    it 'returns true on success' do
+      person = Person.new
+      person[:name] = 'Jim'
+      person[:foo] = 123
+      expect(person.save!).to be true
+    end
+  end
+
+  describe 'update_attributes' do
+    let(:person) do
+      Person.create(name: 'Jim', foo: 123)
+    end
+
+    it 'updates given declared and udeclared property' do
+      person.update_attributes(name: 'Joe', foo: 456)
+      expect(get_value_from_db(person, :name)).to eq('Joe')
+      expect(get_value_from_db(person, :foo)).to eq(456)
+    end
+
+    it 'does delete undeclared property' do
+      person.update_attributes(foo: nil)
+      expect(get_value_from_db(person, :foo)).to be_nil
+    end
+  end
+
+  describe 'update_attribute' do
+    let(:person) do
+      Person.create(name: 'Jim')
+    end
+
+    it 'updates given udeclared property' do
+      person.update_attribute(:foo, 123)
+      expect(get_value_from_db(person, :foo)).to eq(123)
+    end
+
+    it 'does delete undeclared property' do
+      person.update_attribute(:foo, 123)
+      person.update_attribute(:foo, nil)
+      expect(get_value_from_db(person, :foo)).to be_nil
+    end
+  end
+
+  describe 'update_attribute!' do
+    let(:person) do
+      Person.create(name: 'Jim')
+    end
+
+    it 'updates given property' do
+      person.update_attribute!(:foo, 123)
+      expect(get_value_from_db(person, :foo)).to eq(123)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #
Introduces handling of undeclared properties via optional Neo4j::UndeclaredProperties module.
This pull introduces/changes:
 * I have tried to keep existing code without any functional change with one exception. I fixed a problem where _persisted_obj was not refreshed after model update
 * All new functionality is in a separate optional module which if included changes the behavior of the basic model manipulation method.




Pings:
@cheerfulstoic
@subvertallchris
