### PR TITLE
removing unnecessary limitation of scope to maximum 1 parameter

### DIFF
--- a/lib/neo4j/active_node/scope.rb
+++ b/lib/neo4j/active_node/scope.rb
@@ -39,7 +39,7 @@ module Neo4j::ActiveNode
 
         klass = class << self; self; end
         klass.instance_eval do
-          define_method(name) do |query_params = nil, _ = nil|
+          define_method(name) do |*query_params|
             eval_context = ScopeEvalContext.new(self, current_scope || self.query_proxy)
             proc = full_scopes[name.to_sym]
             _call_scope_context(eval_context, query_params, proc)
@@ -68,13 +68,8 @@ module Neo4j::ActiveNode
       end
 
       def _call_scope_context(eval_context, query_params, proc)
-        if proc.arity == 1
-          eval_context.instance_exec(query_params, &proc)
-        else
-          eval_context.instance_exec(&proc)
-        end
+        eval_context.instance_exec(*query_params.fill(nil, query_params.length..proc.arity - 1), &proc)
       end
-
 
       def current_scope #:nodoc:
         ScopeRegistry.value_for(:current_scope, base_class.to_s)

--- a/spec/e2e/scope_spec.rb
+++ b/spec/e2e/scope_spec.rb
@@ -99,7 +99,7 @@ describe 'Neo4j::NodeMixin::Scope' do
 
   describe 'Person.scope :great_students, -> (identifier, score) { where("#{identifier}.score > ?", score)' do
     before(:each) do
-      Person.scope :great_students, -> (identifier, score) { where("#{identifier}.score > ?", score || 41) }
+      Person.scope :great_students, ->(identifier, score) { where("#{identifier}.score > ?", score || 41) }
     end
 
     describe 'Person.great_students.to_a' do

--- a/spec/e2e/scope_spec.rb
+++ b/spec/e2e/scope_spec.rb
@@ -97,6 +97,26 @@ describe 'Neo4j::NodeMixin::Scope' do
     end
   end
 
+  describe 'Person.scope :great_students, -> (identifier, score) { where("#{identifier}.score > ?", score)' do
+    before(:each) do
+      Person.scope :great_students, -> (identifier, score) { where("#{identifier}.score > ?", score || 41) }
+    end
+
+    describe 'Person.great_students.to_a' do
+      subject do
+        Person.as(:foo).great_students(:foo, 41).to_a
+      end
+      it { is_expected.to match_array([@a, @b, @b1, @b2]) }
+    end
+
+    describe 'Person.great_students.to_a with omitted parameter' do
+      subject do
+        Person.as(:foo).great_students(:foo).to_a
+      end
+      it { is_expected.to match_array([@a, @b, @b1, @b2]) }
+    end
+  end
+
   describe 'Person.scope :great_students, -> (identifier) { where("#{identifier}.score > 41")' do
     before(:each) do
       Person.scope :great_students, ->(identifier) { where("#{identifier}.score > 41") }


### PR DESCRIPTION
Fixes #

This pull introduces/changes:
 * scope can now take more than 1 parameter
 * the previous error message was very confusing if defined scope with 2 parameters and called with 2:
` wrong number of arguments (given 0, expected 1)`



Pings:
@cheerfulstoic
@subvertallchris

