### PR TITLE
Fix `as` losing the current query chain scope

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ end
 group 'test' do
   gem 'coveralls', require: false
   if RUBY_VERSION.to_f < 2.0
+    gem 'term-ansicolor', '< 1.4'
     gem 'tins', '< 1.7'
     gem 'overcommit', '< 0.35.0'
   else

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -186,11 +186,8 @@ module Neo4j
         #
         # @return [QueryProxy] A new QueryProxy
         def branch(&block)
-          if block
-            instance_eval(&block).query.proxy_as(self.model, identity)
-          else
-            fail LocalJumpError, 'no block given'
-          end
+          fail LocalJumpError, 'no block given' unless block
+          instance_eval(&block).query.proxy_as(self.model, identity)
         end
 
         def [](index)

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -186,7 +186,7 @@ module Neo4j
         #
         # @return [QueryProxy] A new QueryProxy
         def branch(&block)
-          fail LocalJumpError, 'no block given' unless block
+          fail LocalJumpError, 'no block given' if block.nil?
           instance_eval(&block).query.proxy_as(self.model, identity)
         end
 

--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -15,6 +15,10 @@ module Neo4j
           rels.first
         end
 
+        def as(node_var)
+          new_link(node_var)
+        end
+
         # Give ability to call `#find` on associations to get a scoped find
         # Doesn't pass through via `method_missing` because Enumerable has a `#find` method
         def find(*args)

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -511,6 +511,26 @@ describe 'query_proxy_methods' do
       end
     end
 
+    describe 'as' do
+      it 'changes query variable' do
+        query = Student.as(:stud)
+        expect(query.to_cypher).to include('(stud:`Student`)')
+        query.to_a
+      end
+
+      it 'keeps the current context' do
+        query = Student.where(name: 'John').as(:stud)
+        expect(query.to_cypher).to include('(stud:`Student`)', ' WHERE ')
+        query.to_a
+      end
+
+      it 'keeps the current context with associations' do
+        query = Student.all.lessons.as(:less)
+        expect(query.to_cypher).to include('`Student`)', '(less:`Lesson`)')
+        query.to_a
+      end
+    end
+
     describe 'delete, destroy' do
       before { @john.lessons << @history unless @john.lessons.include?(@history) }
 


### PR DESCRIPTION
Fixes #1278 

This pull introduces/changes:
 * `.as` doesn't break query chain anymore




Pings:
@cheerfulstoic
@subvertallchris

