### PR TITLE
Run `ensure_model_data_state!` in v8 generator

### DIFF
--- a/lib/neo4j/model_schema.rb
+++ b/lib/neo4j/model_schema.rb
@@ -80,6 +80,7 @@ module Neo4j
       end
 
       def legacy_model_schema_informations
+        ensure_model_data_state!
         data = {index: [], constraint: []}
         each_schema_element do |type, model, label, property_name|
           data[type] << {label: label, property_name: property_name, model: model}


### PR DESCRIPTION
A hot-fix to make `rails g neo4j:upgrade_v8` work again :)


Pings:
@cheerfulstoic
@subvertallchris
