### PR TITLE
Check migrations using a Rack Middleware instead of on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Pending migrations check, now using a Rack Middleware instead of failing on startup (thanks @ProGM / see #1300)
+
 ### Added
 
 - Add support for undeclared properties on specific models (see #1294 / thanks @klobuczek)
@@ -26,7 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `update` was not rolling-back association changes when validations fail
 - Broken Rails `neo4j:migrate_v8` generator
 
-# Changed
+### Changed
 - `count` method in associations, now always fire the database like AR does
 - Neo4j now passes all association validations specs, taken from AR (thanks @klobuczek)
 

--- a/lib/neo4j/migrations.rb
+++ b/lib/neo4j/migrations.rb
@@ -6,6 +6,7 @@ module Neo4j
     autoload :Base
     autoload :Runner
     autoload :SchemaMigration
+    autoload :CheckPending
 
     class << self
       def check_for_pending_migrations!

--- a/lib/neo4j/migrations/check_pending.rb
+++ b/lib/neo4j/migrations/check_pending.rb
@@ -1,0 +1,19 @@
+module Neo4j
+  module Migrations
+    class CheckPending
+      def initialize(app)
+        @app = app
+        @last_check = 0
+      end
+
+      def call(env)
+        mtime = Neo4j::Migrations::Runner.latest_migration.version.to_i
+        if @last_check < mtime
+          Neo4j::Migrations.check_for_pending_migrations!
+          @last_check = mtime
+        end
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/neo4j/railtie.rb
+++ b/lib/neo4j/railtie.rb
@@ -56,8 +56,8 @@ module Neo4j
 
       Neo4j::Config[:logger] ||= Rails.logger
 
-      if Rails.env.development? && !Neo4j::Migrations.currently_running_migrations && Neo4j::Config.fail_on_pending_migrations
-        Neo4j::Migrations.check_for_pending_migrations!
+      if Neo4j::Config.fail_on_pending_migrations
+        config.app_middleware.insert_after ::ActionDispatch::Callbacks, Neo4j::Migrations::CheckPending
       end
     end
 

--- a/lib/neo4j/tasks/migration.rake
+++ b/lib/neo4j/tasks/migration.rake
@@ -1,7 +1,7 @@
 require 'active_support/concern'
 require 'neo4j/migration'
 
-unless Rake::Task.task_defined?('environment')
+if !defined?(Rails) && !Rake::Task.task_defined?('environment')
   desc 'Run a script against the database to perform system-wide changes'
   task :environment do
     require 'neo4j/session_manager'
@@ -84,7 +84,7 @@ namespace :neo4j do
   end
 
   desc 'Rollbacks migrations given a STEP number'
-  task :rollback, [:allow_migrations, :environment] do
+  task rollback: [:allow_migrations, :environment] do
     steps = (ENV['STEP'] || 1).to_i
     runner = Neo4j::Migrations::Runner.new
     runner.rollback(steps)

--- a/spec/e2e/migrations_spec.rb
+++ b/spec/e2e/migrations_spec.rb
@@ -16,7 +16,7 @@ module Neo4j
           property :name
         end
 
-        allow_any_instance_of(Runner).to receive(:files_path) do
+        allow(Runner).to receive(:files_path) do
           Rails.root.join('spec', 'migration_files', 'migrations', '*.rb')
         end
         User.delete_all
@@ -169,7 +169,7 @@ module Neo4j
 
         describe 'schema changes in migrations' do
           before do
-            allow_any_instance_of(described_class).to receive(:files_path) do
+            allow(described_class).to receive(:files_path) do
               Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
             end
           end
@@ -234,7 +234,7 @@ module Neo4j
 
         describe 'schema and data changes in migrations' do
           before do
-            allow_any_instance_of(described_class).to receive(:files_path) do
+            allow(described_class).to receive(:files_path) do
               Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
             end
           end
@@ -261,7 +261,7 @@ module Neo4j
             create_constraint :Contact, :phone, type: :unique
             Contact.create! phone: '123123'
 
-            allow_any_instance_of(described_class).to receive(:files_path) do
+            allow(described_class).to receive(:files_path) do
               Rails.root.join('spec', 'migration_files', 'transactional_migrations', '*.rb')
             end
           end


### PR DESCRIPTION
Fixes #1295 

This pull introduces/changes:
 * A `CheckPending` Rack Middleware that checks for pending migrations
 * Removed pending migrations  check on application startup
 * Fixed broken `neo4j:rollback` task



Pings:
@cheerfulstoic
@subvertallchris

