### PR TITLE
update_node_property/update_node_properties, AKA update_column(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Add support for undeclared properties on specific models (see #1294 / thanks @klobuczek)
+- Add `update_node_property` and `update_node_properties` methods, aliased as `update_column` and `update_columns`, to persist changes without triggering validations, callbacks, timestamps, etc,...
 
 ## [8.0.0.alpha.12] 2016-09-29
 

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -189,6 +189,25 @@ module Neo4j::Shared
     end
     alias update_attributes update
 
+    def update_db_property(field, value)
+      update_db_properties(field => value)
+      true
+    end
+    alias update_column update_db_property
+
+    def update_db_properties(hash)
+      fail ::Neo4j::Error, 'can not update on a new record object' unless persisted?
+      self.class.run_transaction do
+        db_values = props_for_db(hash)
+        neo4j_query(query_as(:n).set(n: db_values))
+        db_values.each_pair { |k, v| self.public_send(:"#{k}=", v) }
+        _persisted_obj.props.merge!(db_values)
+        db_values.each_key { |k| changed_attributes.delete(k) }
+        true
+      end
+    end
+    alias update_columns update_db_properties
+
     # Same as {#update_attributes}, but raises an exception if saving fails.
     def update!(attributes)
       self.class.run_transaction do


### PR DESCRIPTION
This'll close #1285. I agree with @cheerfulstoic's statement that `update_column` is a little weird in our context, but I think that plain ole `update_property` is also potentially misleading because we have a very well-defined concept of "properties" within the gem. I made the distinction of _node_ properties because it strikes me as just a tiny bit clearer, but I'm open to something else if someone has a good suggestion.

Pings:
@cheerfulstoic
@ProGM 
