### PR TITLE
Implemented `distinct` in QueryProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+# Added
+- `distinct` method for QueryProxy (thanks @ProGM / see #1305)
+
 ## [8.0.0.rc.1] 2016-10-04
 
 ### Changed

--- a/lib/neo4j/active_node/query/query_proxy_enumerable.rb
+++ b/lib/neo4j/active_node/query/query_proxy_enumerable.rb
@@ -20,7 +20,7 @@ module Neo4j
           return result_cache_for(node, rel) if result_cache?(node, rel)
 
           pluck_vars = []
-          pluck_vars << identity if node
+          pluck_vars << ensure_distinct(identity) if node
           pluck_vars << @rel_var if rel
 
           result = pluck(*pluck_vars)
@@ -86,6 +86,12 @@ module Neo4j
           end
 
           self.query.pluck(*arg_list)
+        end
+
+        protected
+
+        def ensure_distinct(node, force = false)
+          @distinct || force ? "DISTINCT(#{node})" : node
         end
       end
     end


### PR DESCRIPTION
Fixes #1217

This pull introduces/changes:
 * Implements `distinct` in query proxy




Pings:
@cheerfulstoic
@subvertallchris
