### PR TITLE
Many migrations improvements and bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Inconsistent `drop_constraint` and `drop_index` behavior: they were accepting `force` option (like `add_*` methods)
+- `PendingMigrationError` not showing pending migrations versions
+- Fixed `silenced: true` for `Neo4j::Migration::Runner` option, not working properly
+- Removed "strange" inheritance between Neo4j::Migrations::Base and the legacy Neo4j::Migration class
+- Avoid creating the `SchemaMigration` model constraint when it already exists
+
 ## [8.0.0.rc.2] 2016-10-07
 
 ### Fixed

--- a/lib/neo4j/errors.rb
+++ b/lib/neo4j/errors.rb
@@ -34,11 +34,12 @@ module Neo4j
 
   # Inspired/taken from active_record/migration.rb
   class PendingMigrationError < MigrationError
-    def initialize
+    def initialize(migrations)
+      pending_migrations = migrations.join("\n")
       if rails? && defined?(Rails.env)
-        super("Migrations are pending. To resolve this issue, run:\n\n        #{command_name} neo4j:migrate RAILS_ENV=#{::Rails.env}")
+        super("Migrations are pending:\n#{pending_migrations}\n To resolve this issue, run:\n\n        #{command_name} neo4j:migrate RAILS_ENV=#{::Rails.env}")
       else
-        super("Migrations are pending. To resolve this issue, run:\n\n        #{command_name} neo4j:migrate")
+        super("Migrations are pending:\n#{pending_migrations}\n To resolve this issue, run:\n\n        #{command_name} neo4j:migrate")
       end
     end
 

--- a/lib/neo4j/migrations.rb
+++ b/lib/neo4j/migrations.rb
@@ -11,7 +11,8 @@ module Neo4j
     class << self
       def check_for_pending_migrations!
         runner = Neo4j::Migrations::Runner.new
-        fail ::Neo4j::PendingMigrationError if runner.pending_migrations?
+        pending = runner.pending_migrations
+        fail ::Neo4j::PendingMigrationError, pending if pending.any?
       end
 
       attr_accessor :currently_running_migrations

--- a/lib/neo4j/migrations/base.rb
+++ b/lib/neo4j/migrations/base.rb
@@ -1,13 +1,14 @@
 module Neo4j
   module Migrations
-    class Base < ::Neo4j::Migration
+    class Base
       include Neo4j::Migrations::Helpers
       include Neo4j::Migrations::Helpers::Schema
       include Neo4j::Migrations::Helpers::IdProperty
       include Neo4j::Migrations::Helpers::Relationships
 
-      def initialize(migration_id)
+      def initialize(migration_id, options = {})
         @migration_id = migration_id
+        @silenced = options[:silenced]
       end
 
       def migrate(method)

--- a/lib/neo4j/migrations/helpers.rb
+++ b/lib/neo4j/migrations/helpers.rb
@@ -72,6 +72,10 @@ module Neo4j
 
       protected
 
+      def output(*string_format)
+        puts format(*string_format) unless @silenced
+      end
+
       def transactions?
         self.class.transaction?
       end

--- a/lib/neo4j/migrations/helpers/schema.rb
+++ b/lib/neo4j/migrations/helpers/schema.rb
@@ -24,13 +24,13 @@ module Neo4j
         def drop_constraint(label, property, options = {})
           type = options[:type] || :uniqueness
           label_object = ActiveBase.label_object(label)
-          fail_missing_constraint_or_index!(:constraint, label, property) if !label_object.constraint?(property)
+          fail_missing_constraint_or_index!(:constraint, label, property) if !options[:force] && !label_object.constraint?(property)
           label_object.drop_constraint(property, type: type)
         end
 
-        def drop_index(label, property)
+        def drop_index(label, property, options = {})
           label_object = ActiveBase.label_object(label)
-          fail_missing_constraint_or_index!(:index, label, property) if !label_object.index?(property)
+          fail_missing_constraint_or_index!(:index, label, property) if !options[:force] && !label_object.index?(property)
           label_object.drop_index(property)
         end
 

--- a/lib/neo4j/migrations/migration_file.rb
+++ b/lib/neo4j/migrations/migration_file.rb
@@ -8,9 +8,9 @@ module Neo4j
         extract_data!
       end
 
-      def create
+      def create(options = {})
         require @file_name
-        class_name.constantize.new(@version)
+        class_name.constantize.new(@version, options)
       end
 
       private

--- a/lib/neo4j/shared/callbacks.rb
+++ b/lib/neo4j/shared/callbacks.rb
@@ -24,7 +24,7 @@ module Neo4j
       rescue
         @_deleted = false
         @attributes = @attributes.dup
-        tx.mark_failed
+        tx.mark_failed if tx
         raise
       ensure
         tx.close if tx

--- a/spec/e2e/migrations_spec.rb
+++ b/spec/e2e/migrations_spec.rb
@@ -61,15 +61,15 @@ module Neo4j
       end
 
       describe Runner do
-        describe '#pending_migrations?' do
-          it 'returns true if there are pending migrations' do
+        describe '#pending_migrations' do
+          it 'returns a list of pending migrations' do
             SchemaMigration.create! migration_id: '1234567890'
-            expect(described_class.new.pending_migrations?).to be_truthy
+            expect(described_class.new.pending_migrations).to eq(%w(9500000000 9500000001))
           end
 
-          it 'returns false if all migrations are up' do
+          it 'returns an empty list if all migrations are up' do
             all_migrations_on!
-            expect(described_class.new.pending_migrations?).to be_falsey
+            expect(described_class.new.pending_migrations).to be_empty
           end
         end
 


### PR DESCRIPTION

This pull introduces/changes:
 * `drop_constraint` and `drop_index` now accepts `force: true`
 * `PendingMigrationError` now shows which migrations are pending
 * Fixed `silenced: true`, not working properly
 * Removed "strange" inheritance between `Neo4j::Migrations::Base` and the legacy `Neo4j::Migration` class
 * Avoid creating the `SchemaMigration` model constraint when it already exists





Pings:
@cheerfulstoic
@subvertallchris
