### PR TITLE
Fixing specs

### DIFF
--- a/spec/unit/migrations/helpers_spec.rb
+++ b/spec/unit/migrations/helpers_spec.rb
@@ -54,14 +54,14 @@ describe Neo4j::Migrations::Helpers do
   describe '#add_labels' do
     it 'adds labels to a node' do
       add_labels :Book, [:Item, :Readable]
-      expect(Book.first.labels).to eq([:Book, :Item, :Readable])
+      expect(Book.first.labels.sort).to eq([:Book, :Item, :Readable])
     end
   end
 
   describe '#remove_labels' do
     it 'removes labels from a node' do
       add_label :Book, :Item
-      expect(Book.first.labels).to eq([:Book, :Item])
+      expect(Book.first.labels.sort).to eq([:Book, :Item])
       remove_label :Book, :Item
       expect(Book.first.labels).to eq([:Book])
     end

--- a/spec/unit/migrations/helpers_spec.rb
+++ b/spec/unit/migrations/helpers_spec.rb
@@ -54,14 +54,14 @@ describe Neo4j::Migrations::Helpers do
   describe '#add_labels' do
     it 'adds labels to a node' do
       add_labels :Book, [:Item, :Readable]
-      expect(Book.first.labels.sort).to eq([:Book, :Item, :Readable])
+      expect(Book.first.labels).to match_array([:Book, :Item, :Readable])
     end
   end
 
   describe '#remove_labels' do
     it 'removes labels from a node' do
       add_label :Book, :Item
-      expect(Book.first.labels.sort).to eq([:Book, :Item])
+      expect(Book.first.labels).to match_array([:Book, :Item])
       remove_label :Book, :Item
       expect(Book.first.labels).to eq([:Book])
     end


### PR DESCRIPTION
Fixes #1320 


This pull introduces/changes:
 * Removes uuid order dependency for returned node labels in specs




Pings:
@cheerfulstoic
@subvertallchris

