### PR TITLE
Implementing after_commit hooks

### DIFF
--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -221,10 +221,6 @@ describe 'Neo4j::ActiveNode' do
           attr_reader :"before_#{verb}_called", :"after_#{verb}_called"
         end
 
-        %w(update_commit create_commit destroy_commit).each do |verb|
-          attr_reader :"after_#{verb}_called"
-        end
-
         attr_reader :after_find_called, :after_initialize_called
 
         property :name
@@ -242,10 +238,6 @@ describe 'Neo4j::ActiveNode' do
         after_destroy { @after_destroy_called = true }
         before_validation { @before_validation_called = true }
         after_validation { @after_validation_called = true }
-
-        after_create_commit { @after_create_commit_called = true }
-        after_update_commit { @after_update_commit_called = true }
-        after_destroy_commit { @after_destroy_commit_called = true }
       end
     end
 
@@ -287,9 +279,9 @@ describe 'Neo4j::ActiveNode' do
         expect { c.destroy }.to change { true_results?(c, :destroy) }
       end
 
-      include_context 'after_commit', transactions_count: 0
-      include_context 'after_commit', transactions_count: 2
-      include_context 'after_commit', transactions_count: 2, fail_transaction: true
+      include_context 'after_commit', :c, transactions_count: 0
+      include_context 'after_commit', :c, transactions_count: 2
+      include_context 'after_commit', :c, transactions_count: 2, fail_transaction: true
     end
 
 

--- a/spec/e2e/active_model_spec.rb
+++ b/spec/e2e/active_model_spec.rb
@@ -221,6 +221,10 @@ describe 'Neo4j::ActiveNode' do
           attr_reader :"before_#{verb}_called", :"after_#{verb}_called"
         end
 
+        %w(update_commit create_commit destroy_commit).each do |verb|
+          attr_reader :"after_#{verb}_called"
+        end
+
         attr_reader :after_find_called, :after_initialize_called
 
         property :name
@@ -238,6 +242,10 @@ describe 'Neo4j::ActiveNode' do
         after_destroy { @after_destroy_called = true }
         before_validation { @before_validation_called = true }
         after_validation { @after_validation_called = true }
+
+        after_create_commit { @after_create_commit_called = true }
+        after_update_commit { @after_update_commit_called = true }
+        after_destroy_commit { @after_destroy_commit_called = true }
       end
     end
 
@@ -278,6 +286,10 @@ describe 'Neo4j::ActiveNode' do
       it 'handles destroy callbacks' do
         expect { c.destroy }.to change { true_results?(c, :destroy) }
       end
+
+      include_context 'after_commit', transactions_count: 0
+      include_context 'after_commit', transactions_count: 2
+      include_context 'after_commit', transactions_count: 2, fail_transaction: true
     end
 
 

--- a/spec/shared_examples/after_commit.rb
+++ b/spec/shared_examples/after_commit.rb
@@ -1,0 +1,45 @@
+shared_context 'after_commit' do |options|
+  let(:transactions_count) { options[:transactions_count] }
+  let(:fail_transaction) { options[:fail_transaction] }
+
+  let(:transactions) { Array.new(transactions_count) { Neo4j::ActiveBase.new_transaction } }
+  let(:close_inner_transactions!) { transactions.reverse.first(transactions_count - 1).each(&:close) }
+  let(:to_or_not_to) { options[:fail_transaction] ? :not_to : :to }
+
+  it 'handles after_create_commit callbacks' do
+    company = Company.new
+
+    if transactions.empty?
+      expect { company.save }.to change { c.after_create_commit_called }
+    else
+      company.save
+      transactions.last.mark_failed if fail_transaction
+      close_inner_transactions!
+      expect { transactions.first.close }.send(to_or_not_to, change { c.after_create_commit_called })
+    end
+  end
+
+  it 'handles after_update_commit callbacks' do
+    c
+    if transactions.empty?
+      expect { c.update(name: 'some') }.to change { c.after_update_commit_called }
+    else
+      c.update(name: 'some')
+      transactions.last.mark_failed if fail_transaction
+      close_inner_transactions!
+      expect { transactions.first.close }.send(to_or_not_to, change { c.after_update_commit_called })
+    end
+  end
+
+  it 'handles after_destroy_commit callbacks' do
+    c
+    if transactions.empty?
+      expect { c.destroy }.to change { c.after_destroy_commit_called }
+    else
+      c.destroy
+      transactions.last.mark_failed if fail_transaction
+      close_inner_transactions!
+      expect { transactions.first.close }.send(to_or_not_to, change { c.after_destroy_commit_called })
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1218

This pull introduces/changes:
 * `after_create_commit`, `after_update_commit` and `after_destroy` commit hooks


It's pretty raw, but functional (at least in my tests).

I made a PR on neo4j-core as well:
https://github.com/neo4jrb/neo4j-core/pull/277


Pings:
@cheerfulstoic
@subvertallchris
