### PR TITLE
1330 fix

### DIFF
--- a/docs/UpgradeGuide.rst
+++ b/docs/UpgradeGuide.rst
@@ -141,7 +141,7 @@ Previously a connection with be established with ``Neo4j::Session.open`` and the
 
 .. code-block:: ruby
 
-  adaptor = Neo4j::Core::CypherSession::Adaptors::HTTP.new('http://username:password@localhost:7474')
+  adaptor = Neo4j::Core::CypherSession::Adaptors::HTTP.new('http://username:password@localhost:7474', wrap_level: :proc)
 
   session = Neo4j::Core::CypherSession.new(adaptor)
 
@@ -156,7 +156,7 @@ If you are using multiple threads, you should use the `on_establish_session` met
 .. code-block:: ruby
 
   Neo4j::ActiveBase.on_establish_session do
-    adaptor = Neo4j::Core::CypherSession::Adaptors::HTTP.new('http://username:password@localhost:7474')
+    adaptor = Neo4j::Core::CypherSession::Adaptors::HTTP.new('http://username:password@localhost:7474', wrap_level: :proc)
 
     Neo4j::Core::CypherSession.new(adaptor)
   end

--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -101,6 +101,8 @@ module Neo4j
   autoload :Migration
 end
 
+load 'neo4j/tasks/migration.rake'
+
 require 'neo4j/active_node/orm_adapter'
 if defined?(Rails)
   require 'rails/generators'

--- a/lib/neo4j/railtie.rb
+++ b/lib/neo4j/railtie.rb
@@ -36,10 +36,6 @@ module Neo4j
       config.i18n.load_path += Dir[File.join(File.dirname(__FILE__), '..', '..', '..', 'config', 'locales', '*.{rb,yml}')]
     end
 
-    rake_tasks do
-      load 'neo4j/tasks/migration.rake'
-    end
-
     console do
       Neo4j::Config[:logger] = ActiveSupport::Logger.new(STDOUT)
     end

--- a/lib/neo4j/tasks/migration.rake
+++ b/lib/neo4j/tasks/migration.rake
@@ -9,7 +9,7 @@ if !defined?(Rails) && !Rake::Task.task_defined?('environment')
     neo4j_url = ENV['NEO4J_URL'] || 'http://localhost:7474'
     $:.unshift File.dirname('./')
     Neo4j::ActiveBase.on_establish_session do
-      type = neo4j_url.match(/^bolt/) ? :bolt : http
+      type = neo4j_url.match(/^bolt/) ? :bolt : :http
       Neo4j::SessionManager.open_neo4j_session(type, neo4j_url)
     end
   end

--- a/lib/neo4j/tasks/migration.rake
+++ b/lib/neo4j/tasks/migration.rake
@@ -6,7 +6,12 @@ if !defined?(Rails) && !Rake::Task.task_defined?('environment')
   task :environment do
     require 'neo4j/session_manager'
     require 'ostruct'
-    Neo4j::Railtie.setup!
+    neo4j_url = ENV['NEO4J_URL'] || 'http://localhost:7474'
+    $:.unshift File.dirname('./')
+    Neo4j::ActiveBase.on_establish_session do
+      type = neo4j_url.match(/^bolt/) ? :bolt : http
+      Neo4j::SessionManager.open_neo4j_session(type, neo4j_url)
+    end
   end
 end
 

--- a/lib/neo4j/tasks/migration.rake
+++ b/lib/neo4j/tasks/migration.rake
@@ -7,9 +7,9 @@ if !defined?(Rails) && !Rake::Task.task_defined?('environment')
     require 'neo4j/session_manager'
     require 'ostruct'
     neo4j_url = ENV['NEO4J_URL'] || 'http://localhost:7474'
-    $:.unshift File.dirname('./')
+    $LOAD_PATH.unshift File.dirname('./')
     Neo4j::ActiveBase.on_establish_session do
-      type = neo4j_url.match(/^bolt/) ? :bolt : :http
+      type = neo4j_url =~ /^bolt/ ? :bolt : :http
       Neo4j::SessionManager.open_neo4j_session(type, neo4j_url)
     end
   end


### PR DESCRIPTION
Fixes #1330

This pull introduces/changes:
 * Migration rake tasks are always loaded since they are needed for anybody using the `neo4j` gem (not just rails apps)
 * Removed dependency on the `Railtie` for loading an environment for non-Rails apps (I'd still like this to be able to look for the `neo4j.yml`, but this should work for now)


Pings:
@subvertallchris
@ProGM 
