### PR TITLE
Ensure underscore and camelize versions match up in migration classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [8.0.1] 2016-12-20
+
+### Fixed
+
+- Use UTC timezone for timestamps on migration files
+
 ## [8.0.0] 2016-12-14
 
 NO CHANGES FROM 8.0.0.rc.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Camelization of class names for migrations should now match the snake case of the migration file name (see #1329)
+
 ## [8.0.1] 2016-12-20
 
 ### Fixed

--- a/lib/neo4j/tasks/migration.rake
+++ b/lib/neo4j/tasks/migration.rake
@@ -101,7 +101,7 @@ namespace :neo4j do
     fail 'Label must be specified' if label.blank?
     fail 'Property name must be specified' if property_name.blank?
 
-    migration_class_name = "ForceCreate#{label.camelize}#{property_name.camelize}#{index_or_constraint.capitalize}".gsub('::', '')
+    migration_class_name = "ForceCreate#{label.camelize}#{property_name.camelize}#{index_or_constraint.capitalize}".gsub('::', '').underscore.camelize
 
     require 'fileutils'
     FileUtils.mkdir_p('db/neo4j/migrate')

--- a/lib/neo4j/version.rb
+++ b/lib/neo4j/version.rb
@@ -1,3 +1,3 @@
 module Neo4j
-  VERSION = '8.0.0'
+  VERSION = '8.0.1'
 end

--- a/lib/rails/generators/neo4j/migration/templates/migration.erb
+++ b/lib/rails/generators/neo4j/migration/templates/migration.erb
@@ -1,4 +1,4 @@
-class <%= @migration_class_name %> < Neo4j::Migrations::Base
+class <%= @migration_class_name.underscore.camelize %> < Neo4j::Migrations::Base
   def up
     <%= @content %>
   end

--- a/lib/rails/generators/neo4j/model/templates/migration.erb
+++ b/lib/rails/generators/neo4j/model/templates/migration.erb
@@ -1,4 +1,4 @@
-class <%= @migration_class_name %> < Neo4j::Migrations::Base
+class <%= @migration_class_name.underscore.camelize %> < Neo4j::Migrations::Base
   def up
     add_constraint :<%= class_name %>, :uuid
   end

--- a/lib/rails/generators/neo4j/upgrade_v8/templates/migration.erb
+++ b/lib/rails/generators/neo4j/upgrade_v8/templates/migration.erb
@@ -1,4 +1,4 @@
-class <%= @migration_class_name %> < Neo4j::Migrations::Base
+class <%= @migration_class_name.underscore.camelize %> < Neo4j::Migrations::Base
   def up
 <% @schema.each do |type, data|
      data.each do |element| %>

--- a/lib/rails/generators/neo4j_generator.rb
+++ b/lib/rails/generators/neo4j_generator.rb
@@ -10,7 +10,7 @@ module Neo4j::Generators::MigrationHelper
   extend ActiveSupport::Concern
 
   def migration_file_name(file_name)
-    "#{Time.zone.now.strftime('%Y%m%d%H%M%S')}_#{file_name.parameterize}.rb"
+    "#{Time.now.utc.strftime('%Y%m%d%H%M%S')}_#{file_name.parameterize}.rb"
   end
 
   def migration_template(template_name)


### PR DESCRIPTION
Fixes #

This pull introduces/changes:
 * Camelization of class names for migrations should now match the snake case of the migration file name


Pings:
@ProGM 
@subvertallchris
