### PR TITLE
`exists?` performance, primary key, response, tests

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -99,8 +99,8 @@ module Neo4j
           end
           query_with_target(target) do |var|
             start_q = exists_query_start(node_condition, var)
-            result = start_q.query.reorder.return("ID(#{var}) AS found_ids LIMIT 1").first
-            !!result && result.found_ids > 0
+            result = start_q.query.reorder.return("ID(#{var}) AS proof_of_life LIMIT 1").first
+            !!result
           end
         end
 

--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -94,7 +94,7 @@ module Neo4j
         end
 
         def exists?(node_condition = nil, target = nil)
-          unless [Integer, String, Hash, NilClass].include?(node_condition.class)
+          unless [Integer, Fixnum, String, Hash, NilClass].include?(node_condition.class)
             fail(Neo4j::InvalidParameterError, ':exists? only accepts ids or conditions')
           end
           query_with_target(target) do |var|

--- a/lib/neo4j/active_node/query_methods.rb
+++ b/lib/neo4j/active_node/query_methods.rb
@@ -7,8 +7,8 @@ module Neo4j
         end
         query_start = exists_query_start(node_condition)
         start_q = query_start.respond_to?(:query_as) ? query_start.query_as(:n) : query_start
-        result = start_q.return('ID(n) AS found_ids LIMIT 1').first
-        !!result && result.found_ids > 0
+        result = start_q.return('ID(n) AS proof_of_life LIMIT 1').first
+        !!result
       end
 
       # Returns the first node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.

--- a/lib/neo4j/active_node/query_methods.rb
+++ b/lib/neo4j/active_node/query_methods.rb
@@ -2,7 +2,7 @@ module Neo4j
   module ActiveNode
     module QueryMethods
       def exists?(node_condition = nil)
-        unless [Integer, String, Hash, NilClass].include?(node_condition.class)
+        unless [Integer, Fixnum, String, Hash, NilClass].include?(node_condition.class)
           fail(Neo4j::InvalidParameterError, ':exists? only accepts ids or conditions')
         end
         query_start = exists_query_start(node_condition)

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -239,17 +239,22 @@ describe 'query_proxy_methods' do
       end
 
       it 'does not fail from an ordered context' do
-        expect(Lesson.order(:name).empty?).to be_falsey
+        expect(Lesson.order(:name).empty?).to eq false
       end
 
       it 'can be called with a property and value' do
-        expect(Lesson.exists?(name: 'math')).to be_truthy
-        expect(Lesson.exists?(name: 'boat repair')).to be_falsey
+        expect(Lesson.exists?(name: 'math')).to eq true
+        expect(Lesson.exists?(name: 'boat repair')).to eq false
       end
 
       it 'can be called on the class with a neo_id' do
-        expect(Lesson.exists?(math.neo_id)).to be_truthy
-        expect(Lesson.exists?(8_675_309)).to be_falsey
+        expect(Lesson.exists?(math.neo_id)).to eq true
+        expect(Lesson.exists?(8_675_309)).to eq false
+      end
+
+      it 'can be called on a class with a primary key value' do
+        expect(Lesson.exists?(math.id)).to eq true
+        expect(Lesson.exists?('this_other_value')).to eq false
       end
 
       it 'raises an error if something other than a neo id is given' do
@@ -259,33 +264,38 @@ describe 'query_proxy_methods' do
 
     context 'QueryProxy methods' do
       it 'can be called on a query' do
-        expect(Lesson.where(name: 'history').exists?).to be_falsey
-        expect(Lesson.where(name: 'math').exists?).to be_truthy
+        expect(Lesson.where(name: 'history').exists?).to eq false
+        expect(Lesson.where(name: 'math').exists?).to eq true
       end
 
       it 'can be called with property and value' do
-        expect(jimmy.lessons.exists?(name: 'science')).to be_falsey
+        expect(jimmy.lessons.exists?(name: 'science')).to eq false
         jimmy.lessons << science
-        expect(jimmy.lessons.exists?(name: 'science')).to be_truthy
-        expect(jimmy.lessons.exists?(name: 'bomb disarming')).to be_falsey
+        expect(jimmy.lessons.exists?(name: 'science')).to eq true
+        expect(jimmy.lessons.exists?(name: 'bomb disarming')).to eq false
       end
 
       it 'can be called with a neo_id' do
-        expect(Lesson.where(name: 'math').exists?(math.neo_id)).to be_truthy
-        expect(Lesson.where(name: 'math').exists?(science.neo_id)).to be_falsey
+        expect(Lesson.where(name: 'math').exists?(math.neo_id)).to eq true
+        expect(Lesson.where(name: 'math').exists?(science.neo_id)).to eq false
+      end
+
+      it 'can be called with a primary key' do
+        expect(Lesson.where(name: 'math').exists?(math.id)).to eq true
+        expect(Lesson.where(name: 'math').exists?(science.id)).to eq false
       end
 
       it 'is called by :blank? and :empty?' do
-        expect(jimmy.lessons.blank?).to be_truthy
-        expect(jimmy.lessons.empty?).to be_truthy
+        expect(jimmy.lessons.blank?).to eq true
+        expect(jimmy.lessons.empty?).to eq true
         jimmy.lessons << science
-        expect(jimmy.lessons.blank?).to be_falsey
-        expect(jimmy.lessons.empty?).to be_falsey
+        expect(jimmy.lessons.blank?).to eq false
+        expect(jimmy.lessons.empty?).to eq false
       end
 
       it 'does not fail from an ordered context' do
-        expect(jimmy.lessons.order(:name).blank?).to be_truthy
-        expect(jimmy.lessons.order(:name).empty?).to be_truthy
+        expect(jimmy.lessons.order(:name).blank?).to eq true
+        expect(jimmy.lessons.order(:name).empty?).to eq true
       end
     end
   end


### PR DESCRIPTION
* Look for presence of a single value instead of counting all matches
* Allow String arguments, which will check for primary_key
* Fix response, only return boolean, no more `nil`

#1338 