### PR TITLE
Remove before and after association callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Removed `before` and `after` callback options from assoications (model callbacks still exist)
+
 ## [8.0.5] 2016-01-05
 
 ### Fixed

--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -103,15 +103,6 @@ module Neo4j
           @target_class = class_const
         end
 
-        def callback(type)
-          @callbacks[type]
-        end
-
-        def perform_callback(caller, other_node, type)
-          return if callback(type).nil?
-          caller.send(callback(type), other_node)
-        end
-
         def relationship_type(create = false)
           case
           when relationship_class
@@ -191,7 +182,6 @@ module Neo4j
           @relationship_type = options[:type] && options[:type].to_sym
 
           @model_class = options[:model_class]
-          @callbacks = {before: options[:before], after: options[:after]}
           @origin = options[:origin] && options[:origin].to_sym
           @dependent = options[:dependent].try(:to_sym)
           @unique = options[:unique]

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -201,13 +201,9 @@ module Neo4j
             other_nodes.each do |other_node|
               other_node.save unless other_node.neo_id
 
-              return false if @association.perform_callback(@start_object, other_node, :before) == false
-
               @start_object.association_proxy_cache.clear
 
               _create_relationship(other_node, properties)
-
-              @association.perform_callback(@start_object, other_node, :after)
             end
           end
         end
@@ -258,6 +254,7 @@ module Neo4j
           self.clone.tap do |new_query_proxy|
             new_query_proxy.instance_variable_set('@result_cache', nil)
             new_query_proxy.instance_variable_set('@node_var', node_var) if node_var
+            new_query_proxy.instance_variable_set('@distinct', @distinct) if @distinct
           end
         end
 

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -217,50 +217,6 @@ describe 'has_many' do
     end
   end
 
-  describe 'callbacks' do
-    before do
-      stub_active_node_class('ClazzC') do
-        property :name
-
-        has_many :out, :knows, type: nil, model_class: self, before: :before_callback
-        has_many :in, :knows_me, origin: :knows, model_class: self, after: :after_callback
-        has_many :in, :will_fail, origin: :knows, model_class: self, before: :false_callback
-
-        def before_callback(_other)
-        end
-
-        def after_callback(_other)
-        end
-
-        def false_callback(_other)
-          false
-        end
-      end
-    end
-
-    let(:node) { Person.create }
-    let(:friend1) { Person.create }
-    let(:friend2) { Person.create }
-
-    let(:callback_friend1) { ClazzC.create }
-    let(:callback_friend2) { ClazzC.create }
-
-    it 'calls before_callback when node added to #knows association' do
-      expect(callback_friend1).to receive(:before_callback).with(callback_friend2) { expect(callback_friend1.knows.to_a.size).to eq(0) }
-      callback_friend1.knows << callback_friend2
-    end
-
-    it 'calls after_callback when node added to #knows association' do
-      expect(callback_friend1).to receive(:after_callback).with(callback_friend2) { expect(callback_friend2.knows.to_a.size).to eq(1) }
-      callback_friend1.knows_me << callback_friend2
-    end
-
-    it 'prevents the association from being created if before returns "false" explicitly' do
-      callback_friend1.will_fail << callback_friend2
-      expect(callback_friend1.knows_me.to_a.size).to eq 0
-    end
-  end
-
   describe 'model_class' do
     before(:each) do
       mc = model_class

--- a/spec/e2e/has_one_spec.rb
+++ b/spec/e2e/has_one_spec.rb
@@ -186,44 +186,6 @@ describe 'has_one' do
     end
   end
 
-  describe 'callbacks' do
-    before(:each) do
-      stub_active_node_class('CallbackUser') do
-        has_one :out, :best_friend, type: nil, model_class: 'CallbackUser', before: :before_callback
-        has_one :in, :best_friend_of, origin: :best_friend, model_class: 'CallbackUser', after: :after_callback
-        has_one :in, :failing_assoc,  origin: :best_friend, model_class: 'CallbackUser', before: :false_before_callback
-
-        def before_callback(_other)
-        end
-
-        def after_callback(_other)
-        end
-
-        def false_before_callback(_other)
-          false
-        end
-      end
-    end
-
-    let(:node1) { CallbackUser.create }
-    let(:node2) { CallbackUser.create }
-
-    it 'calls before callback' do
-      expect(node1).to receive(:before_callback).with(node2)
-      node1.best_friend = node2
-    end
-
-    it 'calls after callback' do
-      expect(node1).to receive(:after_callback).with(node2)
-      node1.best_friend_of = node2
-    end
-
-    it 'prevents the relationship from beign created if a before callback returns false' do
-      node1.failing_assoc = node2
-      expect(node1.failing_assoc).to be_nil
-    end
-  end
-
   describe 'id methods' do
     before(:each) do
       stub_active_node_class('Post') do


### PR DESCRIPTION
This would technically be a breaking change, though I don't know if anybody uses this feature anymore

Pings:
@progm
@subvertallchris
