### PR TITLE
Replace Fixnum with Integer to fix ruby 2.4 deprecations

### DIFF
--- a/docs/Properties.rst
+++ b/docs/Properties.rst
@@ -71,7 +71,6 @@ The ``type`` option has some interesting qualities that are worth being aware of
 
 - String
 - Integer
-- Fixnum
 - BigDecimal
 - Date
 - Time

--- a/docs/Querying.rst
+++ b/docs/Querying.rst
@@ -196,7 +196,7 @@ There are many ways to provide the length information to generate all the variou
 
 .. code-block:: ruby
 
-  # As a Fixnum:
+  # As a Integer:
   ## Cypher: -[:`FRIENDS`*2]->
   student.friends(rel_length: 2)
 

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -454,7 +454,7 @@ module Neo4j::ActiveNode
 
           # Return all results if a variable-length relationship length was given
           association_proxy = association_proxy(name, {node: node, rel: rel}.merge!(options))
-          if options[:rel_length] && !options[:rel_length].is_a?(Fixnum)
+          if options[:rel_length] && !options[:rel_length].is_a?(Integer)
             association_proxy
           else
             target_class = self.class.send(:association_target_class, name)

--- a/lib/neo4j/active_node/has_n/association_cypher_methods.rb
+++ b/lib/neo4j/active_node/has_n/association_cypher_methods.rb
@@ -53,7 +53,7 @@ module Neo4j
 
           case length
           when Symbol then VALID_REL_LENGTH_SYMBOLS[length]
-          when Fixnum then "*#{length}"
+          when Integer then "*#{length}"
           when Range then cypher_for_range_rel_length(length)
           when Hash then cypher_for_hash_rel_length(length)
           end
@@ -79,11 +79,11 @@ module Neo4j
 
         def rel_length_error_message(length)
           case length
-          when Fixnum then 'cannot be negative' if length < 0
+          when Integer then 'cannot be negative' if length < 0
           when Symbol then rel_length_symbol_error_message(length)
           when Range then rel_length_range_error_message(length)
           when Hash then rel_length_hash_error_message(length)
-          else 'should be a Symbol, Fixnum, Range or Hash'
+          else 'should be a Symbol, Integer, Range or Hash'
           end
         end
 

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -31,7 +31,7 @@ module Neo4j
         # @param [Hash] options Additional options pertaining to the QueryProxy object. These may include:
         # @option options [String, Symbol] :node_var A string or symbol to be used by Cypher within its query string as an identifier
         # @option options [String, Symbol] :rel_var Same as above but pertaining to a relationship identifier
-        # @option options [Range, Fixnum, Symbol, Hash] :rel_length A Range, a Fixnum, a Hash or a Symbol to indicate the variable-length/fixed-length
+        # @option options [Range, Integer, Symbol, Hash] :rel_length A Range, a Integer, a Hash or a Symbol to indicate the variable-length/fixed-length
         #   qualifier of the relationship. See http://neo4jrb.readthedocs.org/en/latest/Querying.html#variable-length-relationships.
         # @option options [Neo4j::Session] :session The session to be used for this query
         # @option options [Neo4j::ActiveNode] :source_object The node instance at the start of the QueryProxy chain

--- a/lib/neo4j/config.rb
+++ b/lib/neo4j/config.rb
@@ -11,7 +11,7 @@ module Neo4j
       # timestamp inclusion.
       # @return [Boolean] the true/false value specified.
 
-      # @return [Fixnum] The location of the default configuration file.
+      # @return [Integer] The location of the default configuration file.
       def default_file
         @default_file ||= DEFAULT_FILE
       end

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -396,7 +396,7 @@ describe 'has_many' do
       end
     end
 
-    context 'as Fixnum' do
+    context 'as Integer' do
       it 'returns related nodes at exactly `length` hops from start node' do
         expect(node.knows(:n, :r, rel_length: 1).to_a).to match_array([friend1])
         expect(node.knows(:n, :r, rel_length: 2).to_a).to match_array([friend2])

--- a/spec/unit/active_node/has_n/association_spec.rb
+++ b/spec/unit/active_node/has_n/association_spec.rb
@@ -157,7 +157,7 @@ describe Neo4j::ActiveNode::HasN::Association do
           end
         end
 
-        context 'as Fixnum' do
+        context 'as Integer' do
           context 'positive' do
             let(:length) { 42 }
 
@@ -235,7 +235,7 @@ describe Neo4j::ActiveNode::HasN::Association do
           let(:length) { 'any' }
 
           it 'raises an error' do
-            expect { subject }.to raise_error ArgumentError, 'Invalid value for rel_length ("any"): should be a Symbol, Fixnum, Range or Hash'
+            expect { subject }.to raise_error ArgumentError, 'Invalid value for rel_length ("any"): should be a Symbol, Integer, Range or Hash'
           end
         end
 
@@ -353,10 +353,10 @@ describe Neo4j::ActiveNode::HasN::Association do
       end
 
       context 'target_class_names defines class which exists, but is not ActiveNode' do
-        let(:options) { {type: nil, model_class: 'Fixnum'} }
+        let(:options) { {type: nil, model_class: 'Integer'} }
 
         context 'with invalid target class name' do
-          it { expect { subject }.to raise_error ArgumentError, /Fixnum.* is not an ActiveNode model/ }
+          it { expect { subject }.to raise_error ArgumentError, /Integer.* is not an ActiveNode model/ }
         end
       end
     end


### PR DESCRIPTION
Fixes #1359 

This pull introduces/changes:
 * Substitutes Integer for Fixnum

Pings:
@cheerfulstoic
@subvertallchris
