### PR TITLE
Add `AssociationProxy#to_ary` method

### DIFF
--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -52,8 +52,8 @@ module Neo4j::ActiveNode
       def empty?(*args)
         @deferred_objects.empty? && @enumerable.empty?(*args)
       end
-      
-      alias_method :to_ary, :to_a
+
+      alias to_ary to_a
 
       def ==(other)
         self.to_a == other.to_a

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -53,9 +53,7 @@ module Neo4j::ActiveNode
         @deferred_objects.empty? && @enumerable.empty?(*args)
       end
       
-      def to_ary
-        self
-      end
+      alias_method :to_ary, :to_a
 
       def ==(other)
         self.to_a == other.to_a

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -52,6 +52,10 @@ module Neo4j::ActiveNode
       def empty?(*args)
         @deferred_objects.empty? && @enumerable.empty?(*args)
       end
+      
+      def to_ary
+        self
+      end
 
       def ==(other)
         self.to_a == other.to_a


### PR DESCRIPTION
Some libraries, like [active_model_serializers](https://github.com/rails-api/active_model_serializers), use the presence of this method to determine if an object should be treated as a collection instead of as a scalar value.

This PR fixes the integration of neo4j.rb being used alongside active_model_serializers in the same project. In particular when using json-api adapter, the serializers don't generate correct json-api responses without this fix.

This pull introduces:
 * New `#to_ary` method in class `Neo4j::ActiveNode::HasN::AssociationProxy`.

More information:
* See [here](https://github.com/rails-api/active_model_serializers/blob/d31d741f4369c891532b5d178f2bd1b9ac52f704/lib/active_model/serializer.rb#L44) where the presence of this method makes a difference in active_model_serializers.