### PR TITLE
Model generator update to fix #1387

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ docs_site/
 
 # dotenv
 .env
+
+# Ignore vagrant files
+Vagrantfile
+/.vagrant/
+ubuntu-xenial*

--- a/lib/rails/generators/neo4j/model/templates/migration.erb
+++ b/lib/rails/generators/neo4j/model/templates/migration.erb
@@ -1,6 +1,6 @@
 class <%= @migration_class_name.underscore.camelize %> < Neo4j::Migrations::Base
   def up
-    add_constraint :<%= class_name %>, :uuid
+    add_constraint :<%= class_name %>, :uuid, force: true
   end
 
   def down


### PR DESCRIPTION
Aims to fix #1387 by prefixing the migration automatically created when generating a model with "Constrain" and adding `force: true` to the migration. i.e.:

`rails g model Person` will create
```
app/models/person.rb
db/neo4j/migrate/xxxxxx_constrain_person.rb
```
with `db/neo4j/migrate/xxxxxx_constrain_person.rb` containing
```
class ConstrainPerson < Neo4j::Migrations::Base
  def up
    add_constraint :Person, :uuid, force: true
  end

  def down
    drop_constraint :Person, :uuid
  end
end
```

This is incomplete. So far all I've done is add `force: true` to the model migration template. I imagine I can update the name of the migration file created by `rails g model` by updating the model generator code, but I haven't found where in the code the model generator calls the migration generator.

Pings:
@cheerfulstoic
@subvertallchris
