### PR TITLE
Populates relationship with with already retrieved node

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy_enumerable.rb
+++ b/lib/neo4j/active_node/query/query_proxy_enumerable.rb
@@ -28,6 +28,9 @@ module Neo4j
           result.each do |object|
             object.instance_variable_set('@source_query_proxy', self)
             object.instance_variable_set('@source_proxy_result_cache', result)
+            if node && rel && object.last.is_a?(Neo4j::ActiveRel)
+              object.last.instance_variable_set(association.direction == :in ? '@from_node' : '@to_node', object.first)
+            end
           end
 
           @result_cache[[node, rel]] ||= result

--- a/spec/unit/active_node/query/query_proxy_spec.rb
+++ b/spec/unit/active_node/query/query_proxy_spec.rb
@@ -20,8 +20,15 @@ describe Neo4j::ActiveNode::Query::QueryProxy do
 
   describe 'each_with_rel' do
     it 'yields a node and rel object' do
-      expect(qp).to receive(:pluck).and_return([node, rel])
-      expect(qp.each_with_rel {}).to eq [node, rel]
+      expect(qp).to receive(:pluck).and_return([[node, rel]])
+      expect(qp.each_with_rel {}).to eq [[node, rel]]
+    end
+
+    it 'sets node on rel object' do
+      rel = stub_active_rel_class('MyRelClass').new
+      expect(qp).to receive(:pluck).and_return([[node, rel]])
+      allow(qp).to receive(:association).and_return(double(name: 'abc', direction: :out))
+      expect(qp.each_with_rel {}.first.last.to_node).to eq(node)
     end
   end
 
@@ -64,8 +71,8 @@ describe Neo4j::ActiveNode::Query::QueryProxy do
       end
 
       it 'calls pluck and executes the block' do
-        expect(qp).to receive(:pluck).and_return([node, rel])
-        expect(node).to receive(:name)
+        expect(qp).to receive(:pluck).and_return([[node, rel]])
+        expect(node).to receive(:name).and_return('name')
         expect(rel).to receive(:name)
         qp.each_with_rel { |n, r| n.name && r.name }
       end


### PR DESCRIPTION
Fixes # https://github.com/neo4jrb/neo4j/issues/1392

This pull introduces/changes:
 *  each_with_rel make sure that the relationship of type ActiveRel references the corresponding node rather than just id to avoid additional queries
 * 




Pings:
@cheerfulstoic
@subvertallchris
