### PR TITLE
1376 dependent delete orphans

### DIFF
--- a/lib/neo4j/active_node/dependent/association_methods.rb
+++ b/lib/neo4j/active_node/dependent/association_methods.rb
@@ -28,7 +28,8 @@ module Neo4j
         end
 
         def dependent_delete_orphans_callback(object)
-          object.as(:self).unique_nodes(self, :self, :n, :other_rel).query.delete(:n, :other_rel).exec
+          unique_query = object.as(:self).unique_nodes(self, :self, :n, :other_rel)
+          unique_query.query.detach_delete(:n).exec if unique_query
         end
 
         def dependent_destroy_callback(object)

--- a/spec/e2e/association_dependency_spec.rb
+++ b/spec/e2e/association_dependency_spec.rb
@@ -58,7 +58,7 @@ describe 'association dependent delete/destroy' do
     stub_active_node_class('Comment') do
       property :note
       # In the real world, there would be no reason to setup a dependency here since you'd never want to delete
-      # the topic of a comment just because the topic is destroyed.
+      # the topic of a comment just because the comment is destroyed.
       # For the purpose of these tests, we're setting this to demonstrate that we are protected against loops.
       has_one :in, :topic, model_class: false, type: 'HAS_COMMENT', dependent: :destroy
     end
@@ -95,7 +95,7 @@ describe 'association dependent delete/destroy' do
       end
     end
 
-    context 'a node with relationshpis' do
+    context 'a node with relationships' do
       let(:band) { Band.create }
       before { node.bands << band }
 

--- a/spec/e2e/association_dependency_spec.rb
+++ b/spec/e2e/association_dependency_spec.rb
@@ -36,7 +36,7 @@ describe 'association dependent delete/destroy' do
       after_destroy lambda { CALL_COUNT[:called] += 1 }
       property :city
       has_many :in, :routes, model_class: 'Route', origin: :stops
-      has_many :out, :comments, model_class: 'Comment', type: 'HAS_COMMENT', dependent: :destroy
+      has_many :out, :comments, model_class: 'Comment', type: 'HAS_COMMENT', dependent: :delete_orphans
       has_one :out, :poorly_modeled_thing, model_class: 'BadModel', type: 'HAS_TERRIBLE_MODEL', dependent: :delete
       has_many :out, :poorly_modeled_things, model_class: 'BadModel', type: 'HAS_TERRIBLE_MODELS', dependent: :delete
     end


### PR DESCRIPTION
Fixes #1376 

This pull introduces/changes:
 * Fixes the `dependent: :delete_orphans` option so that it deletes the orphaned node if it exists, without raising an error.

Pings:
@cheerfulstoic
@subvertallchris
