### PR TITLE
fixing unreliable order of relationships in labels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ env:
   global:
     - JRUBY_OPTS="-J-Xmx1280m -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
   matrix:
-    - NEO4J_URL="http://localhost:7474" NEO4J_VERSION=community-3.1.2
+    - NEO4J_URL="http://localhost:7474" NEO4J_VERSION=community-3.1.5
+    - NEO4J_URL="http://localhost:7474" NEO4J_VERSION=community-3.2.1
 matrix:
   include:
     - rvm: 2.3.1
@@ -31,32 +32,25 @@ matrix:
 
     # Testing bolt
     - rvm: 2.3.1
-      env: NEO4J_URL="bolt://localhost:7472" NEO4J_VERSION=community-3.0.9
+      env: NEO4J_URL="bolt://localhost:7472" NEO4J_VERSION=community-3.1.5
     - rvm: 2.3.1
-      env: NEO4J_URL="bolt://localhost:7472" NEO4J_VERSION=community-3.1.2
+      env: NEO4J_URL="bolt://localhost:7472" NEO4J_VERSION=community-3.2.1
 
     # Older versions of Neo4j with latest version of Ruby
     - rvm: 2.3.1
-      env: NEO4J_VERSION=community-3.0.9
-    - rvm: 2.3.1
-      env: NEO4J_VERSION=community-2.3.9
-    - rvm: 2.3.1
-      env: NEO4J_VERSION=community-2.2.10
-    - rvm: 2.3.1
-      env: NEO4J_VERSION=community-2.1.8
+      env: NEO4J_VERSION=community-2.3.11
 
     # Older versions of Neo4j with latest version of jRuby
     - rvm: jruby-9.0.5.0
-      env: NEO4J_VERSION=community-3.0.9
-    - rvm: jruby-9.0.5.0
-      env: NEO4J_VERSION=community-2.3.9
-    - rvm: jruby-9.0.5.0
-      env: NEO4J_VERSION=community-2.2.10
-    - rvm: jruby-9.0.5.0
-      env: NEO4J_VERSION=community-2.1.8
+      env: NEO4J_VERSION=community-2.3.11
 
-    # Latest
+    # Enterprise
     - rvm: 2.3.1
-      env: NEO4J_URL="http://localhost:7474" NEO4J_VERSION=community-3.2.1
+      env: NEO4J_URL="http://localhost:7474" NEO4J_VERSION=enterprise-3.2.1
+
+  allow_failures:
+    # Fix most likely coming in neo4j 3.2.2
     - rvm: 2.3.1
-      env: NEO4J_URL="bolt://localhost:7472" NEO4J_VERSION=community-3.2.1
+      env: NEO4J_URL="http://localhost:7474" NEO4J_VERSION=enterprise-3.2.1
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ env:
   matrix:
     - NEO4J_URL="http://localhost:7474" NEO4J_VERSION=community-3.1.5
     - NEO4J_URL="http://localhost:7474" NEO4J_VERSION=community-3.2.1
-    - NEO4J_URL="bolt://localhost:7474" NEO4J_VERSION=community-3.1.5
-    - NEO4J_URL="bolt://localhost:7474" NEO4J_VERSION=community-3.2.1
+    - NEO4J_URL="bolt://localhost:7472" NEO4J_VERSION=community-3.1.5
+    - NEO4J_URL="bolt://localhost:7472" NEO4J_VERSION=community-3.2.1
 matrix:
   include:
     - rvm: 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 before_script:
   - "bin/rake neo4j:install[$NEO4J_VERSION] --trace"
   - "bin/rake neo4j:config[development,7474] --trace"
+  - "if [ -f ./db/neo4j/development/conf/neo4j-wrapper.conf ]; then WRAPPER=-wrapper; fi"
   - "echo 'dbms.memory.pagecache.size=600m' >> ./db/neo4j/development/conf/neo4j.conf"
-  - "echo 'dbms.memory.heap.max_size=600' >> ./db/neo4j/development/conf/neo4j-wrapper.conf"
-  - "echo 'dbms.memory.heap.initial_size=600' >> ./db/neo4j/development/conf/neo4j-wrapper.conf"
+  - "echo 'dbms.memory.heap.max_size=600' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
+  - "echo 'dbms.memory.heap.initial_size=600' >> ./db/neo4j/development/conf/neo4j$WRAPPER.conf"
   - "bin/rake neo4j:start --trace"
   - "sleep 20"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,15 @@ jdk: oraclejdk8
 rvm:
   - 2.3.1
   - 2.2.5
-  - jruby-9.0.5.0
+  - jruby-9.1.12.0
 env:
   global:
     - JRUBY_OPTS="-J-Xmx1280m -Xcompile.invokedynamic=false -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-noverify -Xcompile.mode=OFF"
   matrix:
     - NEO4J_URL="http://localhost:7474" NEO4J_VERSION=community-3.1.5
     - NEO4J_URL="http://localhost:7474" NEO4J_VERSION=community-3.2.1
+    - NEO4J_URL="bolt://localhost:7474" NEO4J_VERSION=community-3.1.5
+    - NEO4J_URL="bolt://localhost:7474" NEO4J_VERSION=community-3.2.1
 matrix:
   include:
     - rvm: 2.3.1
@@ -30,18 +32,12 @@ matrix:
       script: "bundle exec rubocop"
       env: "RUBOCOP=true"
 
-    # Testing bolt
-    - rvm: 2.3.1
-      env: NEO4J_URL="bolt://localhost:7472" NEO4J_VERSION=community-3.1.5
-    - rvm: 2.3.1
-      env: NEO4J_URL="bolt://localhost:7472" NEO4J_VERSION=community-3.2.1
-
     # Older versions of Neo4j with latest version of Ruby
     - rvm: 2.3.1
       env: NEO4J_VERSION=community-2.3.11
 
     # Older versions of Neo4j with latest version of jRuby
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.12.0
       env: NEO4J_VERSION=community-2.3.11
 
     # Enterprise

--- a/lib/neo4j/active_node/labels.rb
+++ b/lib/neo4j/active_node/labels.rb
@@ -72,6 +72,7 @@ module Neo4j
       # Finds an appropriate matching model given a set of labels
       # which are assigned to a node
       def self.model_for_labels(labels)
+        labels.sort!
         return MODELS_FOR_LABELS_CACHE[labels] if MODELS_FOR_LABELS_CACHE[labels]
 
         models = WRAPPED_CLASSES.select do |model|

--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -573,11 +573,11 @@ describe 'ActiveRel' do
 
     describe 'first, last' do
       it 'returns the first-ish result' do
-        expect(MyRelClass.first).to eq rel1
+        expect(MyRelClass.first).to eq(rel1).or eq(rel2)
       end
 
       it 'returns the last-ish result' do
-        expect(MyRelClass.last).to eq rel2
+        expect(MyRelClass.last).to eq(rel1).or eq(rel2)
       end
 
       context 'with from_class and to_class as strings and constants' do

--- a/spec/e2e/id_property_spec.rb
+++ b/spec/e2e/id_property_spec.rb
@@ -472,7 +472,7 @@ describe Neo4j::ActiveNode::IdProperty do
         nodes = Array.new(3) { NeoIdTest.create }
         NeoIdTest.create
 
-        expect(NeoIdTest.find_by_ids(nodes.map(&:id))).to eq(nodes)
+        expect(NeoIdTest.find_by_ids(nodes.map(&:id))).to match_array(nodes)
       end
 
       it 'does not find it if it does not exist' do

--- a/spec/e2e/module_handling_spec.rb
+++ b/spec/e2e/module_handling_spec.rb
@@ -85,7 +85,7 @@ describe 'Module handling from config: :module_handling option' do
       ModuleTest::Student.create
       ModuleTest::Student.first
       expect(cache).not_to be_empty
-      expect(cache[[:Student, :Clazz]]).to eq ModuleTest::Student
+      expect(cache[[:Clazz, :Student]]).to eq ModuleTest::Student
     end
   end
 


### PR DESCRIPTION
Fixes #
unreliable order of relationships in the enterprise version, relationship ids not necessarily assigned in ascending order.
labels appear to be sorted alphabetically in enterprise-3.2.1
This pull introduces/changes:
 * weakened specs for first and last on ActiveRel. Those methods can no longer be relied on. 
 * sorting labels before adding to cache
 * additionally proposing to limit the build matrix to the neo4j versions which are available on https://neo4j.com/download/other-releases/ and rather test significant functional differences between community and enterprise editions




Pings:
@cheerfulstoic
@subvertallchris
