### PR TITLE
Fix JSON serialization of Strings

### DIFF
--- a/docs/ActiveNode.rst
+++ b/docs/ActiveNode.rst
@@ -137,7 +137,7 @@ If you would like to use multiple labels you can use class inheritance.  In the 
 Serialization
 ~~~~~~~~~~~~~
 
-Pass a property name as a symbol to the serialize method if you want to save a hash or an array with mixed object types* to the database.
+Pass a property name as a symbol to the serialize method if you want to save JSON serializable data (strings, numbers, hash, array,  array with mixed object types*, etc.) to the database.
 
 .. code-block:: ruby
 

--- a/lib/neo4j/active_node/query/query_proxy_enumerable.rb
+++ b/lib/neo4j/active_node/query/query_proxy_enumerable.rb
@@ -19,19 +19,8 @@ module Neo4j
           @result_cache ||= {}
           return result_cache_for(node, rel) if result_cache?(node, rel)
 
-          pluck_vars = []
-          pluck_vars << ensure_distinct(identity) if node
-          pluck_vars << @rel_var if rel
-
-          result = pluck(*pluck_vars)
-
-          result.each do |object|
-            object.instance_variable_set('@source_query_proxy', self)
-            object.instance_variable_set('@source_proxy_result_cache', result)
-            if node && rel && object.last.is_a?(Neo4j::ActiveRel)
-              object.last.instance_variable_set(association.direction == :in ? '@from_node' : '@to_node', object.first)
-            end
-          end
+          result = pluck_vars(node, rel)
+          set_instance_caches(result, node, rel)
 
           @result_cache[[node, rel]] ||= result
         end
@@ -95,6 +84,25 @@ module Neo4j
 
         def ensure_distinct(node, force = false)
           @distinct || force ? "DISTINCT(#{node})" : node
+        end
+
+        private
+
+        def pluck_vars(node, rel)
+          vars = []
+          vars << ensure_distinct(identity) if node
+          vars << @rel_var if rel
+          pluck(*vars)
+        end
+
+        def set_instance_caches(instance, node, rel)
+          instance.each do |object|
+            object.instance_variable_set('@source_query_proxy', self)
+            object.instance_variable_set('@source_proxy_result_cache', instance)
+            if node && rel && object.last.is_a?(Neo4j::ActiveRel)
+              object.last.instance_variable_set(association.direction == :in ? '@from_node' : '@to_node', object.first)
+            end
+          end
         end
       end
     end

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -245,6 +245,10 @@ module Neo4j::Shared
     # Converts hash to/from JSON
     class JSONConverter < BaseConverter
       class << self
+        def converted?(_value)
+          false
+        end
+
         def convert_type
           JSON
         end
@@ -407,7 +411,7 @@ module Neo4j::Shared
       # @param value The value for conversion.
       def formatted_for_db?(found_converter, value)
         return false unless found_converter.respond_to?(:db_type)
-        found_converter.respond_to?(:converted) ? found_converter.converted?(value) : value.is_a?(found_converter.db_type)
+        found_converter.respond_to?(:converted?) ? found_converter.converted?(value) : value.is_a?(found_converter.db_type)
       end
 
       def register_converter(converter)

--- a/spec/integration/type_converters/type_converters_spec.rb
+++ b/spec/integration/type_converters/type_converters_spec.rb
@@ -287,6 +287,39 @@ describe Neo4j::Shared::TypeConverters do
       expect(ruby_value.class).to eq Hash
       expect(ruby_value['neo4j']).to eq 'http://www.neo4j.org'
     end
+
+    context 'various type combinations' do
+      before do
+        stub_active_node_class('JsonData') do
+          property :serialized_property
+          serialize :serialized_property
+        end
+      end
+
+      let(:json_data) { JsonData.create(serialized_property: value) }
+
+      subject { JsonData.find(json_data.id).serialized_property }
+
+      let_context value: 123 do
+        it { is_expected.to eq 123 }
+      end
+
+      let_context value: %i(array of symbols) do
+        it { is_expected.to eq %w(array of symbols) }
+      end
+
+      let_context value: 'expected string' do
+        it { is_expected.to eq 'expected string' }
+      end
+
+      let_context value: {hashy: :mc_hasher} do
+        it { is_expected.to eq('hashy' => 'mc_hasher') }
+      end
+
+      let_context value: ['mixed', :values, 1337, {of: :things}] do
+        it { is_expected.to eq ['mixed', 'values', 1337, {'of' => 'things'}] }
+      end
+    end
   end
 
   describe Neo4j::Shared::TypeConverters::YAMLConverter do


### PR DESCRIPTION
Fixes #

This pull introduces/changes:
 * adds ability to serialize `String` value only
 * adds specs around leveraging `JSONConverter`

Prior to this change, if you had a model defined like this:

```ruby
class MuhData
  include Neo4j::ActiveNode
  property :thing
  serialize :thing
end
```

If you were to `MuhData.create(thing: 'explodo')` it would be very angry with you. This is because the `db_type` of the `JSONConverter` was _already_ a `String` and the `BaseConverter` thought it didn't have to do anything with it. This is problematic when you try to:

```ruby
JSON.parse 'explodo'
JSON::ParserError: 765: unexpected token at 'explodo'
```

Rather than bypassing, I've modified the `JSONConverter` to `def converted?(_value); false; end` so that it _always_ does a `to_json` in the `to_db`.

The other issue I noticed is that `converted?` was _always_ being bypassed because it was doing `found_converter.respond_to(:converted)` vs. `found_converter.respond_to(:converted?)`.

Feedback welcome.

Pings:
@cheerfulstoic
@subvertallchris
