### PR TITLE
Allow enums to be created without associated indexes

### DIFF
--- a/lib/neo4j/active_node/enum.rb
+++ b/lib/neo4j/active_node/enum.rb
@@ -8,7 +8,7 @@ module Neo4j::ActiveNode
 
       def define_property(property_name, *args)
         super
-        Neo4j::ModelSchema.add_required_index(self, property_name)
+        Neo4j::ModelSchema.add_required_index(self, property_name) unless args[1][:_index] == false
       end
 
       def define_enum_methods(property_name, enum_keys, options)


### PR DESCRIPTION
As far as I can tell, the `_index` option for enums doesn't currently do anything. I'm using it to suppress the `Neo4j::ModelSchema.add_required_index` exception, which IMO is expected behavior.

Fixes #1259

This pull introduces/changes:
 * ` enum _index: false` now suppresses `Neo4j::ModelSchema.add_required_index`


Pings:
@cheerfulstoic
@subvertallchris