### PR TITLE
fix: Neo4j::ActiveNode::Scope::ClassMethods#full_scopes

### DIFF
--- a/lib/neo4j/active_node/scope.rb
+++ b/lib/neo4j/active_node/scope.rb
@@ -55,16 +55,21 @@ module Neo4j::ActiveNode
       end
       # rubocop:enable Style/PredicateName
 
+      # @return [Boolean] true if model has access to scope with this name
       def scope?(name)
         full_scopes.key?(name.to_sym)
       end
 
+      # @return [Hash] of scopes assigned to this model. Keys are scope name, value is scope callable.
       def scopes
         @scopes ||= {}
       end
 
+      # @return [Hash] of scopes available to this model. Keys are scope name, value is scope callable.
       def full_scopes
-        self.superclass.respond_to?(:scopes) ? self.superclass.scopes.merge(scopes) : scopes
+        self.ancestors.find_all { |a| a.respond_to?(:scopes) }.reverse.inject({}) do |scopes, a|
+          scopes.merge(a.scopes)
+        end
       end
 
       def _call_scope_context(eval_context, query_params, proc)

--- a/spec/e2e/scope_spec.rb
+++ b/spec/e2e/scope_spec.rb
@@ -31,20 +31,32 @@ describe 'Neo4j::NodeMixin::Scope' do
   end
 
   describe 'Inherited scope' do
-    before { stub_named_class('Mutant', Person) }
+    before do
+      stub_named_class('Mutant', Person)
+      stub_named_class('Sidekick', Mutant)
+    end
 
-    let!(:alive) { Mutant.create name: 'aa' }
-    let!(:dead)  { Mutant.create name: 'bb', date_of_death: 'yesterday' }
+    let!(:alive_mutant) { Mutant.create name: 'aa' }
+    let!(:dead_mutant)  { Mutant.create name: 'bb', date_of_death: 'yesterday' }
+    let!(:alive_sidekick) { Sidekick.create name: 'aa' }
+    let!(:dead_sidekick)  { Sidekick.create name: 'bb', date_of_death: 'yesterday' }
 
-    it 'has the scope of the parent class' do
+    it 'has the scopes of the parent class' do
       expect(Mutant.scope?(:only_living)).to be true
-      expect(Mutant.all.only_living.to_a).to eq([alive])
+      expect(Mutant.all.only_living.to_a).to contain_exactly(alive_mutant, alive_sidekick)
+    end
+
+    it 'has the scopes of the ancestor classes' do
+      expect(Sidekick.scope?(:only_living)).to be true
+      expect(Sidekick.all.only_living.to_a).to eq([alive_sidekick])
     end
 
     it 'inherits correctly overwritten scopes' do
       Mutant.scope :only_living, -> { where('1=0') }
       expect(Mutant.scope?(:only_living)).to be true
       expect(Mutant.all.only_living.to_a).to eq([])
+      expect(Sidekick.scope?(:only_living)).to be true
+      expect(Sidekick.all.only_living.to_a).to eq([])
     end
   end
 


### PR DESCRIPTION
ActiveNode models now properly inherit all ancestor's scopes.

Fixes #1413, #1412 

Pings:
@cheerfulstoic
@subvertallchris
