### PR TITLE
If the model isn't defined, fallback to the key

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy_link.rb
+++ b/lib/neo4j/active_node/query/query_proxy_link.rb
@@ -115,7 +115,11 @@ module Neo4j
             end
 
             def converted_key(model, key)
-              (model && key.to_sym == :id) ? model.id_property_name : key
+              if key.to_sym == :id
+                model ? model.id_property_name : :uuid
+              else
+                key
+              end
             end
 
             def converted_value(model, key, value)

--- a/lib/neo4j/active_node/query/query_proxy_link.rb
+++ b/lib/neo4j/active_node/query/query_proxy_link.rb
@@ -115,7 +115,7 @@ module Neo4j
             end
 
             def converted_key(model, key)
-              key.to_sym == :id ? model.id_property_name : key
+              (model && key.to_sym == :id) ? model.id_property_name : key
             end
 
             def converted_value(model, key, value)


### PR DESCRIPTION
Fixes #1425

This pull introduces/changes:
 * When there is an association with an array for the `model_class` argument, you can get an error when plucking `:id`.