### PR TITLE
Fix / upd: properties declared on parent after inheritance takes place are now passed to children

### DIFF
--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -11,6 +11,7 @@ require 'neo4j/active_base/session_registry'
 require 'active_model'
 require 'active_support/concern'
 require 'active_support/core_ext/class/attribute.rb'
+require 'active_support/core_ext/class/subclasses.rb'
 require 'json'
 
 require 'neo4j/errors'

--- a/lib/neo4j/shared/enum.rb
+++ b/lib/neo4j/shared/enum.rb
@@ -83,6 +83,10 @@ module Neo4j::Shared
         property_options = build_property_options(enum_keys, options)
         property property_name, property_options
         serialize property_name, Neo4j::Shared::TypeConverters::EnumConverter.new(enum_keys, property_options)
+
+        subclasses.each do |klass|
+          klass.serialized_properties = self.serialized_properties
+        end
       end
 
       def build_property_options(_enum_keys, options = {})

--- a/lib/neo4j/shared/enum.rb
+++ b/lib/neo4j/shared/enum.rb
@@ -84,6 +84,7 @@ module Neo4j::Shared
         property property_name, property_options
         serialize property_name, Neo4j::Shared::TypeConverters::EnumConverter.new(enum_keys, property_options)
 
+        # If class has already been inherited, make sure subclasses fully inherit enum
         subclasses.each do |klass|
           klass.serialized_properties = self.serialized_properties
         end

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -169,6 +169,10 @@ module Neo4j::Shared
           yield name
           constraint_or_index(name, options)
         end
+
+        subclasses.each do |klass|
+          klass.inherit_property name, prop.clone, declared_properties[name].options
+        end
       end
 
       def undef_property(name)

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -163,7 +163,7 @@ module Neo4j::Shared
       end
 
       def build_property(name, options)
-        DeclaredProperty.new(name, options).tap do |prop|
+        prop = DeclaredProperty.new(name, options).tap do |prop|
           prop.register
           declared_properties.register(prop)
           yield name
@@ -173,6 +173,8 @@ module Neo4j::Shared
         subclasses.each do |klass|
           klass.inherit_property name, prop.clone, declared_properties[name].options
         end
+
+        prop
       end
 
       def undef_property(name)

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -163,18 +163,19 @@ module Neo4j::Shared
       end
 
       def build_property(name, options)
-        prop = DeclaredProperty.new(name, options).tap do |prop|
+        decl_prop = DeclaredProperty.new(name, options).tap do |prop|
           prop.register
           declared_properties.register(prop)
           yield name
           constraint_or_index(name, options)
         end
 
+        # If this class has already been inherited, make sure subclasses inherit property
         subclasses.each do |klass|
-          klass.inherit_property name, prop.clone, declared_properties[name].options
+          klass.inherit_property name, decl_prop.clone, declared_properties[name].options
         end
 
-        prop
+        decl_prop
       end
 
       def undef_property(name)

--- a/spec/e2e/inheritance_spec.rb
+++ b/spec/e2e/inheritance_spec.rb
@@ -98,4 +98,40 @@ describe 'Inheritance', type: :e2e do
       expect(Car.associations_keys).to include(:models)
     end
   end
+
+  describe 'property declared on parent after inheritence' do
+    before(:each) do
+      stub_named_class('MiniCooper', Car) do
+        property :cost
+      end
+
+      Car.property :technical_specs
+      Car.serialize :technical_specs
+      Car.enum doors: [:four_door, :two_door], _index: false
+    end
+
+    let(:mini) { MiniCooper.new }
+
+    it 'child inherites setters' do
+      expect(mini.technical_specs = {very: 'technical'}).to eq(very: 'technical')
+      expect(mini.doors = :four_door).to eq(:four_door)
+    end
+
+    it 'child inherites getters' do
+      mini.technical_specs = {very: 'technical'}
+      mini.doors = :four_door
+
+      expect(mini.technical_specs).to eq(very: 'technical')
+      expect(mini.doors).to eq(:four_door)
+    end
+
+    it 'persists values' do
+      mini.technical_specs = {very: 'technical'}
+      mini.doors = :four_door
+      mini.save!
+
+      expect(MiniCooper.first.doors).to eq(:four_door)
+      expect(MiniCooper.first.technical_specs).to eq('very' => 'technical')
+    end
+  end
 end


### PR DESCRIPTION
I'm not sure if this is a bug or intended behavior, but currently: if an ActiveNode class `A` is inherited by `B`, and then an ActiveNode `property` is subsequently declared on `A`, `B` will not have that property (i.e. properties are only be transferred at inheritance).

This PR makes it so that every property declared on a parent is also present on the children (unless `undef_property` was explicitly called on a child).
 
In achieving this, I plucked `ActiveSupport/core_ext/class/subclasses` and added the `subclasses` method to `Class`.

This pull introduces/changes:
 * properties declared on parent classes after inheritance has taken place are properly inherited by subclasses
 * all classes now have `subclasses` method

### Example

```
class Person
  include Neo4j::ActiveNode

  class Superhero < Person
  end

  property :name
end

hero = Person::Superhero.new
hero.name = 'John'
hero.name
#=> 'John'
```

Pings:
@cheerfulstoic
@subvertallchris