### PR TITLE
ensure branch method propagets context like with_association_tree

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -187,7 +187,9 @@ module Neo4j
           # `as(identity)` is here to make sure we get the right variable
           # There might be a deeper problem of the variable changing when we
           # traverse an association
-          as(identity).instance_eval(&block).query.proxy_as(self.model, identity)
+          as(identity).instance_eval(&block).query.proxy_as(self.model, identity).tap do |new_query_proxy|
+            propagate_context(new_query_proxy)
+          end
         end
 
         def [](index)

--- a/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
+++ b/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
@@ -73,6 +73,10 @@ module Neo4j
           end
         end
 
+        def propagate_context(query_proxy)
+          query_proxy.instance_variable_set('@with_associations_tree', @with_associations_tree)
+        end
+
         def with_associations_tree
           @with_associations_tree ||= AssociationTree.new(model)
         end

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -106,6 +106,12 @@ describe 'Association Proxy' do
     end
   end
 
+  it 'Should allow for loading of associations with one query when method chain ends with branch' do
+    expect_queries(1) do
+      billy.as(:b).with_associations(:lessons).branch { lessons }.first.lessons.to_a
+    end
+  end
+
   it 'Should allow for loading of `has_one` association' do
     expect_queries(1) do
       grouped_students = science.students.with_associations(:favorite_lesson).group_by(&:name)


### PR DESCRIPTION
Fixes # 
makes sure `branch` method does not erase context created by `with_associations`
This pull introduces/changes:
 *  the `branch` method is implemented using the chain `query.proxy_as`. This construct does not carry over the context of the original QueryProxy. Should it? If so then this solution is probably not the best one as it only tackles the `branch` method.
 * 




Pings:
@cheerfulstoic
@subvertallchris
