### PR TITLE
ensure branch and with_association methods propagate distinct

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,3 +79,8 @@ Style/Lambda:
 # Reason: I'm proud to be part of the double negative Ruby tradition
 Style/DoubleNegation:
   Enabled: false
+
+# Reason: It's OK if the spec files get long as long as they're well factored
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
+++ b/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
@@ -74,6 +74,7 @@ module Neo4j
         end
 
         def propagate_context(query_proxy)
+          super
           query_proxy.instance_variable_set('@with_associations_tree', @with_associations_tree)
         end
 
@@ -142,7 +143,7 @@ module Neo4j
 
         def query_from_association_tree
           previous_with_variables = []
-          with_associations_tree.paths.inject(query_as(identity).with(identity)) do |query, path|
+          with_associations_tree.paths.inject(query_as(identity).with(ensure_distinct(identity))) do |query, path|
             with_association_query_part(query, path, previous_with_variables).tap do
               previous_with_variables << path_name(path)
             end

--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -47,6 +47,10 @@ module Neo4j
           end
         end
 
+        def propagate_context(query_proxy)
+          query_proxy.instance_variable_set(:@distinct, @distinct)
+        end
+
         # @return [Integer] number of nodes of this class
         def count(distinct = nil, target = nil)
           return 0 if unpersisted_start_object?

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -378,7 +378,7 @@ describe 'query_proxy_methods' do
         frank.lessons.teachers.distinct.branch { lessons }.to_a
       end
 
-      it 'with_associoations perserves distinct in a select query' do
+      it 'with_associations perserves distinct in a select query' do
         frank.lessons.teachers.distinct.with_associations(:lessons).to_a
       end
     end

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -360,21 +360,36 @@ describe 'query_proxy_methods' do
     end
 
     context 'when building the query' do
+      before do
+        @subscription = Neo4j::Core::CypherSession::Adaptors::Base.subscribe_to_query do |query|
+          expect(query).to include('DISTINCT')
+        end
+      end
+
       after do
         ActiveSupport::Notifications.unsubscribe(@subscription) if @subscription
       end
 
       it 'adds distinct to a select query' do
-        @subscription = Neo4j::Core::CypherSession::Adaptors::Base.subscribe_to_query do |query|
-          expect(query).to include('DISTINCT')
-        end
         frank.lessons.teachers.distinct.to_a
+      end
+
+      it 'branch perserves distinct in a select query' do
+        frank.lessons.teachers.distinct.branch { lessons }.to_a
+      end
+
+      it 'with_associoations perserves distinct in a select query' do
+        frank.lessons.teachers.distinct.with_associations(:lessons).to_a
       end
     end
 
     it 'counts values without duplicates' do
       expect(frank.lessons.teachers.count).to eq(2)
       expect(frank.lessons.teachers.distinct.count).to eq(1)
+    end
+
+    it 'counts values without duplicates in a branch query' do
+      expect(frank.lessons.teachers.distinct.branch { lessons }.count).to eq(1)
     end
 
     it 'selects values without duplicates' do


### PR DESCRIPTION
Fixes #
As suspected there are more cases where context has to be propagated. Here distinct was suppressed by both branch and with_associations.
This pull introduces/changes:
 * 
 * 




Pings:
@cheerfulstoic
@subvertallchris
