### PR TITLE
make RecordNotFound consistent in providing the model

### DIFF
--- a/lib/neo4j/active_node/labels.rb
+++ b/lib/neo4j/active_node/labels.rb
@@ -115,7 +115,7 @@ module Neo4j
 
         # Like find_by, except that if no record is found, raises a RecordNotFound error.
         def find_by!(values)
-          find_by(values) || fail(RecordNotFound, "#{self.query_as(:n).where(n: values).limit(1).to_cypher} returned no results")
+          find_by(values) || fail(RecordNotFound.new("#{self.query_as(:n).where(n: values).limit(1).to_cypher} returned no results", name))
         end
 
         # Deletes all nodes and connected relationships from Cypher.

--- a/spec/integration/label_spec.rb
+++ b/spec/integration/label_spec.rb
@@ -129,7 +129,8 @@ describe 'Labels' do
       end
 
       it 'raises an error if no results match' do
-        expect { IndexedTestClass.find_by!(name: 'foo') }.to raise_exception Neo4j::ActiveNode::Labels::RecordNotFound
+        expect { IndexedTestClass.find_by!(name: 'foo') }
+          .to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound) { |e| expect(e.model).to eq 'IndexedTestClass' }
       end
     end
   end


### PR DESCRIPTION
Fixes inconsistency between `.find_by!` and `.find` when a `RecordNotFound` is thrown so that they both provide the `model`.

This pull introduces/changes:
 * consistency with `RecordNotFound` having a `#model`

Pings:
@cheerfulstoic
@subvertallchris
