### PR TITLE
Add #rel_where_not to filter by relationships that do not match conditions

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -141,7 +141,7 @@ module Neo4j
           @model.current_scope = previous
         end
 
-        METHODS = %w(where where_not rel_where rel_order order skip limit)
+        METHODS = %w(where where_not rel_where rel_where_not rel_order order skip limit)
 
         METHODS.each do |method|
           define_method(method) { |*args| build_deeper_query_proxy(method.to_sym, args) }

--- a/lib/neo4j/active_node/query/query_proxy_link.rb
+++ b/lib/neo4j/active_node/query/query_proxy_link.rb
@@ -84,6 +84,12 @@ module Neo4j
               end
             end
 
+            def for_rel_where_not_clause(*args)
+              for_rel_where_clause(*args).each do |link|
+                link.instance_variable_set('@clause', :where_not)
+              end
+            end
+
             def for_rel_order_clause(arg, _)
               [new(:order, ->(_, v) { arg.is_a?(String) ? arg : {v => arg} })]
             end
@@ -95,7 +101,7 @@ module Neo4j
             def for_args(model, clause, args, association = nil)
               if [:where, :where_not].include?(clause) && args[0].is_a?(String) # Better way?
                 [for_arg(model, clause, args[0], *args[1..-1])]
-              elsif clause == :rel_where
+              elsif [:rel_where, :rel_where_not].include?(clause)
                 args.map { |arg| for_arg(model, clause, arg, association) }
               else
                 args.map { |arg| for_arg(model, clause, arg) }

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -819,6 +819,20 @@ describe 'Query API' do
         end
       end
 
+      describe '#rel_where_not' do
+        context 'with a rel_class present' do
+          let(:not_math_lesson) { Student.lessons.rel_where_not(grade: '65').to_a }
+          let(:not_science_lesson) { Student.lessons.rel_where_not(grade: '99'.to_f).to_a }
+
+          it 'excludes the nodes with relationships that match the condition' do
+            expect(not_math_lesson.count).to eq 1
+            expect(not_math_lesson.first.subject).to eq 'Science'
+            expect(not_science_lesson.count).to eq 1
+            expect(not_science_lesson.first.subject).to eq 'Math'
+          end
+        end
+      end
+
       describe '#rel_order' do
         it 'allows ordering by relationships with rel_order' do
           expect(Student.lessons(:l, :rel).rel_order(:grade).pluck('rel.grade')).to eq([65, 99])


### PR DESCRIPTION
Fixes #1091

This pull introduces/changes:
 * Adds `#rel_where_not` to allow filtering by relationships that do not match conditions. 

Pings:
@cheerfulstoic
@subvertallchris

