### PR TITLE
fixes ordering when with_association used

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -95,13 +95,16 @@ module Neo4j
         #
         #   student.lessons.query_as(:l).with('your cypher here...')
         def query_as(var, with_labels = true)
-          result_query = @chain.inject(base_query(var, with_labels).params(@params)) do |query, link|
+          query_from_chain(chain, base_query(var, with_labels).params(@params), var)
+            .tap { |query| query.proxy_chain_level = _chain_level }
+        end
+
+        def query_from_chain(chain, base_query, var)
+          chain.inject(base_query) do |query, link|
             args = link.args(var, rel_var)
 
             args.is_a?(Array) ? query.send(link.clause, *args) : query.send(link.clause, args)
           end
-
-          result_query.tap { |query| query.proxy_chain_level = _chain_level }
         end
 
         def base_query(var, with_labels = true)

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -221,7 +221,6 @@ describe 'Association Proxy' do
     it 'supports before with_association' do
       expect(Lesson.order(:subject).with_associations(:students).map(&:subject)).to eq(%w(math science))
       expect(Lesson.order(subject: :desc).with_associations(:students).map(&:subject)).to eq(%w(science math))
-
     end
 
     it 'supports after with_association' do

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -217,6 +217,19 @@ describe 'Association Proxy' do
     end
   end
 
+  describe 'ordering' do
+    it 'supports before with_association' do
+      expect(Lesson.order(:subject).with_associations(:students).map(&:subject)).to eq(%w(math science))
+      expect(Lesson.order(subject: :desc).with_associations(:students).map(&:subject)).to eq(%w(science math))
+
+    end
+
+    it 'supports after with_association' do
+      expect(Lesson.all.with_associations(:students).order(:subject).map(&:subject)).to eq(%w(math science))
+      expect(Lesson.all.with_associations(:students).order(subject: :desc).map(&:subject)).to eq(%w(science math))
+    end
+  end
+
   describe 'issue reported by @andrewhavens in #881' do
     it 'does not break' do
       l1 = Lesson.create!.tap { |l| l.exams_given = [Exam.create!] }


### PR DESCRIPTION
Fixes #
when `with_associations` is used in any query chain any order clause (before or after with association) generates cypher which makes ordering ineffective.
This pull introduces/changes:
 * makes sure that ordering happens as the last step in the query after `with_association` has been processed
 * 



