### PR TITLE
Fix: out of date API usage

### DIFF
--- a/docs/Testing.rst
+++ b/docs/Testing.rst
@@ -82,6 +82,15 @@ If you are using RSpec you can perform tests in a transaction as you would using
 
 .. code-block:: ruby
 
+  # For the `neo4j-core` gem
+  config.around do |example|
+    session.transaction do |tx|
+      example.run
+      tx.mark_failed
+    end
+  end
+  
+  # For the `neo4j` gem
   config.around do |example|
     Neo4j::ActiveBase.run_transaction do |tx|
       example.run

--- a/docs/Testing.rst
+++ b/docs/Testing.rst
@@ -83,7 +83,7 @@ If you are using RSpec you can perform tests in a transaction as you would using
 .. code-block:: ruby
 
   config.around do |example|
-    Neo4j::Transaction.run do |tx|
+    Neo4j::ActiveBase.run_transaction do |tx|
       example.run
       tx.mark_failed
     end


### PR DESCRIPTION
`Neo4j::Transaction.run` no longer works (at least generally) in the neo4j gem. `Neo4j::ActiveBase.run_transaction` does.

However, I'm not sure if `Neo4j::ActiveBase` is present in neo4j-core. Maybe in neo4j-core `Neo4j::Transaction` is still correct?

Fixes @JakubA3informatics's question that came up in Gitter
