### PR TITLE
Add: ability for active node instances to use class scopes

### DIFF
--- a/lib/neo4j/active_node.rb
+++ b/lib/neo4j/active_node.rb
@@ -57,6 +57,14 @@ module Neo4j
       _persisted_obj || fail('Tried to access native neo4j object on a non persisted object')
     end
 
+    def method_missing(name, *params, &block)
+      if self.class.full_scopes.keys.include? name
+        self.as(:a).public_send(name, *params, &block)
+      else
+        super
+      end
+    end
+
     LOADED_CLASSES = []
 
     def self.loaded_classes

--- a/lib/neo4j/active_node.rb
+++ b/lib/neo4j/active_node.rb
@@ -57,12 +57,16 @@ module Neo4j
       _persisted_obj || fail('Tried to access native neo4j object on a non persisted object')
     end
 
-    def method_missing(name, *params, &block)
-      if self.class.full_scopes.keys.include? name
-        self.as(:a).public_send(name, *params, &block)
+    def method_missing(method, *params, &block)
+      if self.class.full_scopes.keys.include? method
+        self.as(:a).public_send(method, *params, &block)
       else
         super
       end
+    end
+
+    def respond_to_missing?(method, *)
+      self.class.full_scopes.keys.include?(method) || super
     end
 
     LOADED_CLASSES = []


### PR DESCRIPTION
This is a helpful patch I added to my own app, which may or may not be appropriate to add to `ActiveNode`.

Currently, the following fails:
```
class Person
  include Neo4j::ActiveNode

  property :country

  has_many :out, :friends, type: :FRIEND, model_class: "Person"

  scope :american_friends, ->{ where(country: 'United States') }
end

Person.american_friends # works

Person.first.american_friends #=> error, unknown method 'american_friends'

Person.first.as(:a).american_friends # works
```

This can be annoying. For example: 

```
Employers.where(fun: true).jobs.employees.first.american_friends.phone_number
# => error on `first.american_friends`

Employers.where(fun: true).jobs.employees.first.as(:e).american_friends.phone_number
# => works
```

This PR overloads `method_missing` to check if the missing method is a scope in the ancestor's chain. This allows:
```
Employers.where(fun: true).jobs.employees.first.american_friends.phone_number

# or

person = Person.create
person.american_friends
```

If you think this is appropriate to add, I'll make specs / update the docs for it.

