### PR TITLE
Add: notes about ActiveBase transactions

### DIFF
--- a/docs/UpgradeGuide.rst
+++ b/docs/UpgradeGuide.rst
@@ -80,7 +80,7 @@ Or via the `Neo4j::Core::Query` class
 
   neo4j_session.query(query_obj)
 
-Making multiple queries with one request is support with the HTTP Adaptor:
+Making multiple queries with one request is supported with the HTTP Adaptor:
 
 .. code-block:: ruby
 
@@ -101,6 +101,15 @@ When doing batched queries, there is also a shortcut for getting a new `Neo4j::C
   end
 
   results[0] # result
+  
+With your session object, you can wrap multiple queries inside a transaction like so:
+
+.. code-block:: ruby
+
+  neo4j_session.transaction do |tx|
+    # do stuff
+    tx.mark_failed
+  end
 
 The ``neo4j`` gem
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -123,16 +132,16 @@ If you are using version ``8.0`` of the ``neo4j`` gem, that will be accessible, 
 Transactions
 ^^^^^^^^^^^^
 
-In ``neo4j-core``, you now interact with transactions through a ``session`` object like so:
+Because of the changes to the current session API in ``neo4j``, the transactions API has also changed. Previously you might have created a transaction like so:
 
 .. code-block:: ruby
 
-  neo4j_session.transaction do |tx|
+  Neo4j::Transaction.run do |tx|
     # do stuff
     tx.mark_failed
   end
 
-In ``neo4j``, you now interact with transactions through ``Neo4j::ActiveBase`` like so:
+Now, you now interact with transactions through ``Neo4j::ActiveBase`` like so:
 
 .. code-block:: ruby
 

--- a/docs/UpgradeGuide.rst
+++ b/docs/UpgradeGuide.rst
@@ -120,19 +120,19 @@ If you are using version ``8.0`` of the ``neo4j`` gem, that will be accessible, 
 
   Neo4j::ActiveBase.current_session
   
- Transactions
- ^^^^^^^^^^^^
+Transactions
+^^^^^^^^^^^^
 
-In version ``8.0`` of the ``neo4j`` gem, the recommended API for interacting with transactions has changed. In ``7.0``, the API looked like
+In ``neo4j-core``, you now interact with transactions through a ``session`` object like so:
 
 .. code-block:: ruby
 
-  Neo4j::Transaction.run do |tx|
+  neo4j_session.transaction do |tx|
     # do stuff
     tx.mark_failed
   end
-  
-In ``8.0``, the API for interacting with transactions looks like
+
+In ``neo4j``, you now interact with transactions through ``Neo4j::ActiveBase`` like so:
 
 .. code-block:: ruby
 
@@ -145,16 +145,6 @@ In ``8.0``, the API for interacting with transactions looks like
   .. raw:: html
 
     Check out the ActiveBase source code to learn about some other neat helper methods <a href='https://github.com/neo4jrb/neo4j/blob/master/lib/neo4j/active_base.rb'>ActiveBase has</a>
-    
-In ``7.0`` of the ``neo4j-core`` gem, you interact with transactions through a ``session`` object like so:
-
-.. code-block:: ruby
-
-  a_session_object.transaction do |tx|
-    # do stuff
-    tx.mark_failed
-  end
-
 
 server_db
 ^^^^^^^^^

--- a/docs/UpgradeGuide.rst
+++ b/docs/UpgradeGuide.rst
@@ -119,6 +119,42 @@ If you are using version ``8.0`` of the ``neo4j`` gem, that will be accessible, 
 .. code-block:: ruby
 
   Neo4j::ActiveBase.current_session
+  
+ Transactions
+ ^^^^^^^^^^^^
+
+In version ``8.0`` of the ``neo4j`` gem, the recommended API for interacting with transactions has changed. In ``7.0``, the API looked like
+
+.. code-block:: ruby
+
+  Neo4j::Transaction.run do |tx|
+    # do stuff
+    tx.mark_failed
+  end
+  
+In ``8.0``, the API for interacting with transactions looks like
+
+.. code-block:: ruby
+
+  Neo4j::ActiveBase.run_transaction do |tx|
+    # do stuff
+    tx.mark_failed
+  end
+
+.. seealso::
+  .. raw:: html
+
+    Check out the ActiveBase source code to learn about some other neat helper methods <a href='https://github.com/neo4jrb/neo4j/blob/master/lib/neo4j/active_base.rb'>ActiveBase has</a>
+    
+In ``7.0`` of the ``neo4j-core`` gem, you interact with transactions through a ``session`` object like so:
+
+.. code-block:: ruby
+
+  a_session_object.transaction do |tx|
+    # do stuff
+    tx.mark_failed
+  end
+
 
 server_db
 ^^^^^^^^^


### PR DESCRIPTION
I added some notes about `ActiveBase.run_transaction` to the upgrade guide. I also referenced the recommended `neo4j-core` transaction API which you added to the testing guide (though it's unclear to me if that API is different in version 7.0 of `neo4j-core` vs version 6.0)

