### PR TITLE
ActiveRel find_by_id should throw RecordNotFound when no results

### DIFF
--- a/spec/e2e/active_rel_spec.rb
+++ b/spec/e2e/active_rel_spec.rb
@@ -569,6 +569,10 @@ describe 'ActiveRel' do
       it 'returns the rel' do
         expect(MyRelClass.find(rel1.neo_id)).to eq rel1
       end
+
+      it 'with no results' do
+        expect { MyRelClass.find(8_675_309) }.to raise_error(Neo4j::RecordNotFound)
+      end
     end
 
     describe 'first, last' do


### PR DESCRIPTION
Currently when doing `ActiveRel.find(999)`, the method throws `undefined method r for nil`.

This PR handles `ActiveRel.find` similar to `ActiveNode.find` throwing a `Neo4j::RecordNotFound`.