### PR TITLE
Add: ability to create association with `labels: false` by default

### DIFF
--- a/docs/ActiveNode.rst
+++ b/docs/ActiveNode.rst
@@ -512,6 +512,32 @@ The two orphan-destruction options are unique to Neo4j.rb. As an example of when
   and
   #has_one http://www.rubydoc.info/gems/neo4j/Neo4j/ActiveNode/HasN/ClassMethods#has_one-instance_method
 
+Association Options
+~~~~~~~~~~~~~~~~~~~~~~
+
+By default, when you call an association ``ActiveNode`` will add the ``model_class`` labels to the query (as a filter). For example:
+
+.. code-block:: ruby
+
+    person.friends
+    # =>
+    # MATCH (person125)
+    # WHERE (ID(person125) = {ID_person125})
+    # MATCH (person125)-[rel1:`FRIEND`]->(node3:`Person`)
+
+The exception to this is if ``model_class: false``, in which case ``MATCH (person125)-[rel1:`FRIEND`]->(node3)``.
+More advanced Neo4j users may prefer to skip adding labels to the target node, even if ``model_class != false``.
+This can be accomplished on a case-by-case basis by calling the association with a `labels: false`` options argument.
+For example: ``person.friends(labels: false)``.
+
+You can also make ``labels: false`` the default settings by
+creating the association with a ``labels: false`` option. For example:
+
+.. code-block:: ruby
+
+    class Person
+      has_many :out, :friends, type: :FRIEND, model_class: self, labels: false
+    end
 
 Creating Unique Relationships
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/neo4j/active_node/has_n/association.rb
+++ b/lib/neo4j/active_node/has_n/association.rb
@@ -201,7 +201,9 @@ module Neo4j
           check_valid_type_and_dir(type, direction)
         end
 
-        VALID_ASSOCIATION_OPTION_KEYS = [:type, :origin, :model_class, :rel_class, :dependent, :before, :after, :unique]
+        # the ":labels" option is not used by the association per-say.
+        # Instead, if provided,it is used by the association getter as a default getter options argument
+        VALID_ASSOCIATION_OPTION_KEYS = [:type, :origin, :model_class, :rel_class, :dependent, :before, :after, :unique, :labels]
 
         def validate_association_options!(_association_name, options)
           ClassArguments.validate_argument!(options[:model_class], 'model_class')

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -387,12 +387,28 @@ describe 'has_many' do
 
   describe 'association "getter" options' do
     before do
+      Person.has_many :out, :best_friend, model_class: 'Person', type: nil, labels: false
       node.knows << friend1
       friend1.knows << friend2
     end
 
     it 'allows passing only a hash of options when naming node/rel is not needed' do
       expect(node.knows(rel_length: :any).to_a).to match_array([friend1, friend2])
+    end
+
+    it 'honors default options' do
+      expect(node.knows.instance_variable_get('@query_proxy').instance_variable_get('@association_labels')).to eq(nil)
+      expect(node.best_friend.instance_variable_get('@query_proxy').instance_variable_get('@association_labels')).to eq(false)
+    end
+
+    it 'allows overriding of default options' do
+      expect(node.knows(labels: false).instance_variable_get('@query_proxy').instance_variable_get('@association_labels')).to eq(false)
+      expect(node.best_friend(labels: true).instance_variable_get('@query_proxy').instance_variable_get('@association_labels')).to eq(true)
+    end
+
+    it 'provided options are merged into default options' do
+      expect(node.knows({}).instance_variable_get('@query_proxy').instance_variable_get('@association_labels')).to eq(nil)
+      expect(node.best_friend({}).instance_variable_get('@query_proxy').instance_variable_get('@association_labels')).to eq(false)
     end
   end
 

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -397,18 +397,18 @@ describe 'has_many' do
     end
 
     it 'honors default options' do
-      expect(node.knows.instance_variable_get('@query_proxy').instance_variable_get('@association_labels')).to eq(nil)
-      expect(node.best_friend.instance_variable_get('@query_proxy').instance_variable_get('@association_labels')).to eq(false)
+      expect(node.as(:person).knows(:known, :r).to_cypher).to include('MATCH (person)-[r:`KNOWS`]->(known:`Person`)')
+      expect(node.as(:person).best_friend(:best, :r).to_cypher).to include('MATCH (person)-[r:`BEST_FRIEND`]->(best)')
     end
 
     it 'allows overriding of default options' do
-      expect(node.knows(labels: false).instance_variable_get('@query_proxy').instance_variable_get('@association_labels')).to eq(false)
-      expect(node.best_friend(labels: true).instance_variable_get('@query_proxy').instance_variable_get('@association_labels')).to eq(true)
+      expect(node.as(:person).knows(:known, :r, labels: false).to_cypher).to include('MATCH (person)-[r:`KNOWS`]->(known)')
+      expect(node.as(:person).best_friend(:best, :r, labels: true).to_cypher).to include('MATCH (person)-[r:`BEST_FRIEND`]->(best:`Person`)')
     end
 
     it 'provided options are merged into default options' do
-      expect(node.knows({}).instance_variable_get('@query_proxy').instance_variable_get('@association_labels')).to eq(nil)
-      expect(node.best_friend({}).instance_variable_get('@query_proxy').instance_variable_get('@association_labels')).to eq(false)
+      expect(node.as(:person).knows(:known, :r, {}).to_cypher).to include('MATCH (person)-[r:`KNOWS`]->(known:`Person`)')
+      expect(node.as(:person).best_friend(:best, :r, {}).to_cypher).to include('MATCH (person)-[r:`BEST_FRIEND`]->(best)')
     end
   end
 

--- a/spec/e2e/has_one_spec.rb
+++ b/spec/e2e/has_one_spec.rb
@@ -197,6 +197,8 @@ describe 'has_one' do
         has_many :out, :subordinates, type: nil, model_class: self
         has_one :in, :manager, model_class: self, origin: :subordinates
       end
+
+      Person.has_one :out, :favorite_subordinate, type: :FAVORITE, model_class: 'Person', labels: false
     end
 
     let(:manager) { Person.create }
@@ -206,6 +208,41 @@ describe 'has_one' do
       manager.subordinates << employee
       expect(employee.manager(rel_length: 1)).to eq(manager)
     end
+
+    # since chainable: true is an option, this test both checks to see that default options
+    # are honored, and checks to make sure the provided options are merged into the default options
+    it 'honors default options' do
+      expect(
+        employee.manager(chainable: true)
+          .instance_variable_get('@query_proxy')
+          .instance_variable_get('@association_labels')
+      ).to eq(nil)
+
+      expect(
+        manager.favorite_subordinate(chainable: true)
+          .instance_variable_get('@query_proxy')
+          .instance_variable_get('@association_labels')
+      ).to eq(false)
+    end
+
+    # This is failing with a "NameError: undefined local variable or method `node'".
+    # As far as I can tell, this exact test works fine in console testing, making me think this is
+    # just a problem with the spec. My guess is it has to do with
+    # how the class is stubbed ?
+
+    # it 'allows overriding of default options' do
+    #   expect(
+    #     node.manager(labels: false, chainable: true)
+    #       .instance_variable_get('@query_proxy')
+    #       .instance_variable_get('@association_labels')
+    #   ).to eq(false)
+
+    #   expect(
+    #     node.favorite_subordinate(labels: true, chainable: true)
+    #       .instance_variable_get('@query_proxy')
+    #       .instance_variable_get('@association_labels')
+    #   ).to eq(true)
+    # end
   end
 
   describe 'id methods' do

--- a/spec/e2e/has_one_spec.rb
+++ b/spec/e2e/has_one_spec.rb
@@ -212,37 +212,19 @@ describe 'has_one' do
     # since chainable: true is an option, this test both checks to see that default options
     # are honored, and checks to make sure the provided options are merged into the default options
     it 'honors default options' do
-      expect(
-        employee.manager(chainable: true)
-          .instance_variable_get('@query_proxy')
-          .instance_variable_get('@association_labels')
-      ).to eq(nil)
-
-      expect(
-        manager.favorite_subordinate(chainable: true)
-          .instance_variable_get('@query_proxy')
-          .instance_variable_get('@association_labels')
-      ).to eq(false)
+      expect(employee.as(:employee).manager(:manager, :r, chainable: true).to_cypher).to include('MATCH (employee)<-[r:`SUBORDINATES`]-(manager:`Person`)')
+      expect(manager.as(:manager).favorite_subordinate(:favorite, :r, chainable: true).to_cypher).to include('MATCH (manager)-[r:`FAVORITE`]->(favorite)')
     end
 
-    # This is failing with a "NameError: undefined local variable or method `node'".
-    # As far as I can tell, this exact test works fine in console testing, making me think this is
-    # just a problem with the spec. My guess is it has to do with
-    # how the class is stubbed ?
+    it 'allows overriding of default options' do
+      expect(employee.as(:employee).manager(:manager, :r, labels: false, chainable: true).to_cypher).to include('MATCH (employee)<-[r:`SUBORDINATES`]-(manager)')
 
-    # it 'allows overriding of default options' do
-    #   expect(
-    #     node.manager(labels: false, chainable: true)
-    #       .instance_variable_get('@query_proxy')
-    #       .instance_variable_get('@association_labels')
-    #   ).to eq(false)
-
-    #   expect(
-    #     node.favorite_subordinate(labels: true, chainable: true)
-    #       .instance_variable_get('@query_proxy')
-    #       .instance_variable_get('@association_labels')
-    #   ).to eq(true)
-    # end
+      expect(
+        manager.as(:manager)
+               .favorite_subordinate(:favorite, :r, labels: true, chainable: true)
+               .to_cypher
+      ).to include('MATCH (manager)-[r:`FAVORITE`]->(favorite:`Person`)')
+    end
   end
 
   describe 'id methods' do


### PR DESCRIPTION
As brought up on Gitter, this PR adds the ability to create an association where `model_class != false` but the cypher generated still does not specify labels for the target node. Currently, the only way to have an association's cypher not specify labels for the target node by default is to use`model_class: false`, which prevents someone from easily query chaining.

***Update: below is fixed***
~~_Note: I've commented out one spec I added for the has_one association which is failing. As far as I can tell, the problem is not with the code, and is only a problem with the spec (the exact same test works fine in the console). I think it has to do with how the class in the spec is being stubbed, but I really just guessing. I don't know much about stubbing. See the code for more info_~~

### Additional

As I discovered while writing this PR, the ability to remove the target node labels on a case-by-case basis already existed as an association getter option (e.g. `person.friends(labels: false)`). What this PR does is add the ability to specify default association getter options when you create the association.

In this PR, the only configurable default option is `:labels`, but this can easily be changed in the future. I also added a section to the docs covering this PR
