### PR TITLE
Optimize property declaration

### DIFF
--- a/lib/neo4j/shared/attributes.rb
+++ b/lib/neo4j/shared/attributes.rb
@@ -165,8 +165,10 @@ module Neo4j::Shared
       #
       # @return [false, String] False or the conflicting method name
       def dangerous_attribute?(name)
+        methods = instance_methods
+
         attribute_methods(name).detect do |method_name|
-          !DEPRECATED_OBJECT_METHODS.include?(method_name.to_s) && allocate.respond_to?(method_name, true)
+          !DEPRECATED_OBJECT_METHODS.include?(method_name.to_s) && methods.include?(method_name)
         end unless attribute_names.include? name.to_s
       end
 


### PR DESCRIPTION
Previously, the call to `property` was invoking ActiveModel's `respond_to?` method, which is actually quite expensive - it depends on `ActiveModel::AttributeMethods#matched_attribute_method`, which was painfully slow on giant nodes.

With this commit, loading the definition for an enormous node with 234 properties (don't ask) went from 1450ms down to 145ms simply by foregoing the `respond_to?` call with `instance_methods.include?`. On a slower machine, loading those properties took over 7 seconds before this commit and only 169ms after.

The main issue seemed to be that `ActiveModel::AttributeMethods#matched_attribute_method` was invoking `attributes` 25x _per call_, resulting in 5850 hashes generated for 234 properties. You can see this in the `ruby-prof` output here:

<img width="905" alt="screen shot 2018-03-17 at 6 05 06 pm" src="https://user-images.githubusercontent.com/108205/37560409-c29d0894-2a0d-11e8-9e57-5452dc8f6d85.png">

After this commit, the call stack looks like this:

<img width="921" alt="screen shot 2018-03-17 at 6 08 09 pm" src="https://user-images.githubusercontent.com/108205/37560428-37caec80-2a0e-11e8-81ef-a31f5c0e292f.png">
