### PR TITLE
fix: add helpful error message to AssociationTree

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
+++ b/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
@@ -23,6 +23,8 @@ module Neo4j
           end
 
           def add_spec(spec)
+            fail "Cannot eager load \"past\" a polymorphic association. (since the association can return multiple models, we don't how to handle the \"#{spec}\" association." unless model
+            
             if spec.is_a?(Array)
               spec.each { |s| add_spec(s) }
             elsif spec.is_a?(Hash)

--- a/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
+++ b/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
@@ -23,8 +23,11 @@ module Neo4j
           end
 
           def add_spec(spec)
-            fail "Cannot eager load \"past\" a polymorphic association. (since the association can return multiple models, we don't how to handle the \"#{spec}\" association." unless model
-            
+            unless model
+              fail "Cannot eager load \"past\" a polymorphic association. \
+              (Since the association can return multiple models, we don't how to handle the \"#{spec}\" association.)"
+            end
+
             if spec.is_a?(Array)
               spec.each { |s| add_spec(s) }
             elsif spec.is_a?(Hash)

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -8,6 +8,7 @@ describe 'Association Proxy' do
       has_many :out, :lessons, rel_class: :LessonEnrollment
       has_many :in, :exams, model_class: :Exam, origin: :students
       has_one :out, :favorite_lesson, type: nil, model_class: :Lesson
+      has_many :out, :homework, type: :HOMEWORK, model_class: %w[Lesson Exam]
     end
 
     stub_active_rel_class('LessonEnrollment') do
@@ -177,6 +178,10 @@ describe 'Association Proxy' do
     expect_queries(1) do
       science.students.with_associations(lessons: :exams_given).flat_map(&:lessons).flat_map(&:exams_given)
     end
+  end
+
+  it 'Raises error if attempting to deep eager load "past" a polymorphic association' do
+    expect{math.students.with_associations(homework: :lessons)}.to raise_error
   end
 
   it 'Queries limited times in depth two loops' do

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -181,7 +181,7 @@ describe 'Association Proxy' do
   end
 
   it 'Raises error if attempting to deep eager load "past" a polymorphic association' do
-    expect{math.students.with_associations(homework: :lessons)}.to raise_error
+    expect { math.students.with_associations(homework: :lessons) }.to raise_error
   end
 
   it 'Queries limited times in depth two loops' do


### PR DESCRIPTION
Add helpful error message when trying to eager load "past" a polymorphic association. Currently, trying to eager load past a polymorphic association in the console receives:

```
NoMethodError: undefined method `associations' for nil:NilClass
	from (irb):2
```

Which is difficult to diagnose.

