### PR TITLE
Adding section in Doc for helper gems

### DIFF
--- a/docs/HelperGems.rst
+++ b/docs/HelperGems.rst
@@ -1,0 +1,9 @@
+Helper Gems
+====================
+
+cancancan-neo4j
+--------------------
+
+This is the neo4j adapter for the `CanCanCan <https://github.com/canCanCommunity/cancancan>` authorisation library. This gem will help you seamlessly integrate cancan gem to your Ruby/Rails app wich has Neo4j as database.
+
+https://github.com/ProjectVegas/cancancan-neo4j

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,8 @@ Contents:
 
    AdditionalResources
 
+   HelperGems
+
    api/index
 
 Neo4j.rb (the `neo4j <https://github.com/neo4jrb/neo4j>`_ and `neo4j-core <https://github.com/neo4jrb/neo4j-core>`_ gems) is a `Ruby <https://www.ruby-lang.org/en/>`_ Object-Graph-Mapper (OGM) for the `Neo4j <http://neo4j.com/>`_ graph database. It tries to follow API conventions established by `ActiveRecord <http://guides.rubyonrails.org/active_record_basics.html>`_ and familiar to most Ruby developers but with a Neo4j flavor.


### PR DESCRIPTION
Fixes #

This pull introduces/changes:
 * A documentation section for ruby gems that help integrate neo4j with other ruby gems/libraries.
 * 



