### PR TITLE
Optimize ActiveNode deserialization

### DIFF
--- a/lib/neo4j/shared/declared_property.rb
+++ b/lib/neo4j/shared/declared_property.rb
@@ -10,7 +10,7 @@ module Neo4j::Shared
     attr_reader :name, :name_string, :name_sym, :options, :magic_typecaster, :type, :typecaster, :default_value
     alias default default_value
 
-    def initialize(name, type: nil, **options)
+    def initialize(name, **options)
       fail IllegalPropertyError, "#{name} is an illegal property" if ILLEGAL_PROPS.include?(name.to_s)
       fail TypeError, "can't convert #{name.class} into Symbol" unless name.respond_to?(:to_sym)
       @name = @name_sym = name.to_sym

--- a/lib/neo4j/shared/declared_property.rb
+++ b/lib/neo4j/shared/declared_property.rb
@@ -80,7 +80,7 @@ module Neo4j::Shared
 
     # Tweaks properties
     def register_magic_properties
-      @type ||= options[:type] = Neo4j::Config.timestamp_type if timestamp_prop?
+      @type ||= Neo4j::Config.timestamp_type if timestamp_prop?
 
       register_magic_typecaster
       register_type_converter
@@ -93,9 +93,9 @@ module Neo4j::Shared
     def register_magic_typecaster
       found_typecaster = Neo4j::Shared::TypeConverters.typecaster_for(type)
       return unless found_typecaster && found_typecaster.respond_to?(:primitive_type)
-      @typecaster = options[:type] = found_typecaster
+      @typecaster = found_typecaster
       @magic_typecaster = type
-      @type = options[:type] = found_typecaster.primitive_type
+      @type = found_typecaster.primitive_type
     end
 
     def register_type_converter

--- a/lib/neo4j/shared/declared_property.rb
+++ b/lib/neo4j/shared/declared_property.rb
@@ -7,13 +7,17 @@ module Neo4j::Shared
     include Neo4j::Shared::DeclaredProperty::Index
 
     ILLEGAL_PROPS = %w(from_node to_node start_node end_node)
-    attr_reader :name, :name_string, :name_sym, :options, :magic_typecaster
+    attr_reader :name, :name_string, :name_sym, :options, :magic_typecaster, :type, :typecaster, :default_value
+    alias default default_value
 
-    def initialize(name, options = {})
+    def initialize(name, type: nil, typecaster: nil, default_value: nil, default: default_value, **options)
       fail IllegalPropertyError, "#{name} is an illegal property" if ILLEGAL_PROPS.include?(name.to_s)
       fail TypeError, "can't convert #{name.class} into Symbol" unless name.respond_to?(:to_sym)
       @name = @name_sym = name.to_sym
       @name_string = name.to_s
+      @type = type
+      @typecaster = typecaster
+      @default_value = default
       @options = options
       fail_invalid_options!
     end
@@ -54,19 +58,6 @@ module Neo4j::Shared
     def register
       register_magic_properties
     end
-
-    def type
-      options[:type]
-    end
-
-    def typecaster
-      options[:typecaster]
-    end
-
-    def default_value
-      options[:default]
-    end
-    alias default default_value
 
     def fail_invalid_options!
       case

--- a/lib/neo4j/shared/declared_property.rb
+++ b/lib/neo4j/shared/declared_property.rb
@@ -17,7 +17,7 @@ module Neo4j::Shared
       @name_string = name.to_s
       @type = options[:type]
       @typecaster = options[:typecaster]
-      @default_value = options[:default] || options[:default_value]
+      @default_value = options[:default]
       @options = options
       fail_invalid_options!
     end
@@ -80,7 +80,7 @@ module Neo4j::Shared
 
     # Tweaks properties
     def register_magic_properties
-      options[:type] ||= Neo4j::Config.timestamp_type if timestamp_prop?
+      @type ||= options[:type] = Neo4j::Config.timestamp_type if timestamp_prop?
 
       register_magic_typecaster
       register_type_converter
@@ -91,18 +91,18 @@ module Neo4j::Shared
     end
 
     def register_magic_typecaster
-      found_typecaster = Neo4j::Shared::TypeConverters.typecaster_for(options[:type])
+      found_typecaster = Neo4j::Shared::TypeConverters.typecaster_for(type)
       return unless found_typecaster && found_typecaster.respond_to?(:primitive_type)
-      options[:typecaster] = found_typecaster
-      @magic_typecaster = options[:type]
-      options[:type] = found_typecaster.primitive_type
+      @typecaster = options[:type] = found_typecaster
+      @magic_typecaster = type
+      @type = options[:type] = found_typecaster.primitive_type
     end
 
     def register_type_converter
       converter = options[:serializer]
       return unless converter
-      options[:type]        = converter.convert_type
-      options[:typecaster]  = Neo4j::Shared::TypeConverters::ObjectConverter
+      @type        = converter.convert_type
+      @typecaster  = Neo4j::Shared::TypeConverters::ObjectConverter
       Neo4j::Shared::TypeConverters.register_converter(converter)
     end
   end

--- a/lib/neo4j/shared/declared_property.rb
+++ b/lib/neo4j/shared/declared_property.rb
@@ -10,14 +10,14 @@ module Neo4j::Shared
     attr_reader :name, :name_string, :name_sym, :options, :magic_typecaster, :type, :typecaster, :default_value
     alias default default_value
 
-    def initialize(name, type: nil, typecaster: nil, default_value: nil, default: default_value, **options)
+    def initialize(name, type: nil, **options)
       fail IllegalPropertyError, "#{name} is an illegal property" if ILLEGAL_PROPS.include?(name.to_s)
       fail TypeError, "can't convert #{name.class} into Symbol" unless name.respond_to?(:to_sym)
       @name = @name_sym = name.to_sym
       @name_string = name.to_s
-      @type = type
-      @typecaster = typecaster
-      @default_value = default
+      @type = options[:type]
+      @typecaster = options[:typecaster]
+      @default_value = options[:default] || options[:default_value]
       @options = options
       fail_invalid_options!
     end

--- a/lib/neo4j/shared/declared_property.rb
+++ b/lib/neo4j/shared/declared_property.rb
@@ -10,7 +10,7 @@ module Neo4j::Shared
     attr_reader :name, :name_string, :name_sym, :options, :magic_typecaster, :type, :typecaster, :default_value
     alias default default_value
 
-    def initialize(name, **options)
+    def initialize(name, options = {})
       fail IllegalPropertyError, "#{name} is an illegal property" if ILLEGAL_PROPS.include?(name.to_s)
       fail TypeError, "can't convert #{name.class} into Symbol" unless name.respond_to?(:to_sym)
       @name = @name_sym = name.to_sym

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -362,7 +362,7 @@ module Neo4j::Shared
 
     def converted_property(type, value, direction)
       return nil if value.nil?
-      type.respond_to?(:db_type) || CONVERTERS[type] ? TypeConverters.to_other(direction, value, type) : value
+      CONVERTERS[type] || type.respond_to?(:db_type) ? TypeConverters.to_other(direction, value, type) : value
     end
 
     # If the attribute is to be typecast using a custom converter, which converter should it use? If no, returns the type to find a native serializer.

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -379,7 +379,7 @@ module Neo4j::Shared
 
     # Returns true if the property isn't defined in the model or if it is nil
     def skip_conversion?(obj, attr, value)
-      !obj.class.attributes[attr] || value.nil?
+      value.nil? || !obj.class.attributes.key?(attr)
     end
 
     class << self

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -101,7 +101,7 @@ module Neo4j::Shared
     end
 
     class BooleanConverter < BaseConverter
-      FALSE_VALUES = %w(n N no No NO false False FALSE off Off OFF f F)
+      FALSE_VALUES = %w(n N no No NO false False FALSE off Off OFF f F).to_set
 
       class << self
         def converted?(value)

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -362,18 +362,18 @@ module Neo4j::Shared
 
     def converted_property(type, value, direction)
       return nil if value.nil?
-      type.respond_to?(:db_type) || TypeConverters::CONVERTERS[type] ? TypeConverters.to_other(direction, value, type) : value
+      type.respond_to?(:db_type) || CONVERTERS[type] ? TypeConverters.to_other(direction, value, type) : value
     end
 
     # If the attribute is to be typecast using a custom converter, which converter should it use? If no, returns the type to find a native serializer.
     def primitive_type(attr)
       case
-      when self.serialized_properties_keys.include?(attr)
+      when serialized_properties_keys.include?(attr)
         serialized_properties[attr]
-      when self.magic_typecast_properties_keys.include?(attr)
-        self.magic_typecast_properties[attr]
+      when magic_typecast_properties_keys.include?(attr)
+        magic_typecast_properties[attr]
       else
-        self.fetch_upstream_primitive(attr)
+        fetch_upstream_primitive(attr)
       end
     end
 

--- a/lib/neo4j/shared/type_converters.rb
+++ b/lib/neo4j/shared/type_converters.rb
@@ -368,9 +368,9 @@ module Neo4j::Shared
     # If the attribute is to be typecast using a custom converter, which converter should it use? If no, returns the type to find a native serializer.
     def primitive_type(attr)
       case
-      when serialized_properties_keys.include?(attr)
+      when serialized_properties.include?(attr)
         serialized_properties[attr]
-      when magic_typecast_properties_keys.include?(attr)
+      when magic_typecast_properties.include?(attr)
         magic_typecast_properties[attr]
       else
         fetch_upstream_primitive(attr)


### PR DESCRIPTION
I had some relatively simple queries returning large data sets taking several seconds on my machine. `Benchmark.measure` indicates that CPU time in Ruby was 87% of the time spent in the query (76% of which was underneath `Neo4j::Shared::Initialize#convert_and_assign_attributes`), so I wanted to see what I could do to streamline it.

Several micro-optimizations involved here:
- Optimizing short-circuit conditionals by putting the condition most likely to trigger the short circuit first
- Set inclusion over array inclusion
- Extract instance variables+attr_readers instead of hash dereferencing for things like `Neo4j::Shared::DeclaredProperty#type`, `#typecaster`, and `#default`
- Remove intermediate-array generation

With these micro-optimizations, because these methods are called so many times, I got a 12-18% performance boost on some of my simpler queries where the DB isn't working hard but there's a lot of data to deserialize (like `MATCH (foo:Foo)-[bar:BAR]-(baz:Baz) RETURN foo, bar, baz`). For queries that are not bottlenecked by Ruby (for example, waiting longer for the DB response), this PR has a reduced effect (but still measurable). The idea here was to improve throughput for things like Sidekiq jobs by releasing the GIL more quickly, and for longer-running queries it will still have a throughput benefit (though less likely a latency benefit) depending primarily on the DB load.

There are other ways I think this can be improved, but I'll file a separate issue.