### PR TITLE
Rails 5.2 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ matrix:
       script: "bundle exec rubocop"
       env: "RUBOCOP=true"
 
+    # Testing older versions of ActiveModel
+    - rvm: 2.4.2
+      env: NEO4J_URL="http://localhost:7474" NEO4J_VERSION=community-3.2.8 ACTIVE_MODEL_VERSION=5.1.0
+
     # Older versions of Neo4j with latest version of Ruby
     - rvm: 2.4.2
       env: NEO4J_URL="http://localhost:7474" NEO4J_VERSION=community-3.2.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ sudo: false
 jdk: oraclejdk8
 rvm:
   - 2.4.2
-  - 2.1.10
+  - 2.2.10
   - jruby-9.1.14.0
 env:
   global:

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,9 @@ end
 
 gem 'listen', '< 3.1'
 
+active_model_version = ENV['ACTIVE_MODEL_VERSION']
+gem 'activemodel', "~> #{active_model_version}" if active_model_version
+
 if RUBY_VERSION.to_f < 2.2
   gem 'activemodel', '~> 4.2'
   gem 'activesupport', '~> 4.2'

--- a/lib/neo4j/active_node/initialize.rb
+++ b/lib/neo4j/active_node/initialize.rb
@@ -10,7 +10,7 @@ module Neo4j::ActiveNode::Initialize
   def init_on_load(persisted_node, properties)
     self.class.extract_association_attributes!(properties)
     @_persisted_obj = persisted_node
-    changed_attributes_clear!
+    clear_changes_information
     @attributes = convert_and_assign_attributes(properties)
   end
 

--- a/lib/neo4j/active_node/initialize.rb
+++ b/lib/neo4j/active_node/initialize.rb
@@ -10,7 +10,7 @@ module Neo4j::ActiveNode::Initialize
   def init_on_load(persisted_node, properties)
     self.class.extract_association_attributes!(properties)
     @_persisted_obj = persisted_node
-    changed_attributes && changed_attributes.clear
+    changed_attributes_clear!
     @attributes = convert_and_assign_attributes(properties)
   end
 

--- a/lib/neo4j/active_node/initialize.rb
+++ b/lib/neo4j/active_node/initialize.rb
@@ -10,7 +10,7 @@ module Neo4j::ActiveNode::Initialize
   def init_on_load(persisted_node, properties)
     self.class.extract_association_attributes!(properties)
     @_persisted_obj = persisted_node
-    clear_changes_information
+    changed_attributes_clear!
     @attributes = convert_and_assign_attributes(properties)
   end
 

--- a/lib/neo4j/active_rel/initialize.rb
+++ b/lib/neo4j/active_rel/initialize.rb
@@ -11,7 +11,7 @@ module Neo4j::ActiveRel
     def init_on_load(persisted_rel, from_node_id, to_node_id, type)
       @rel_type = type
       @_persisted_obj = persisted_rel
-      clear_changes_information
+      changed_attributes_clear!
       @attributes = convert_and_assign_attributes(persisted_rel.props)
       load_nodes(from_node_id, to_node_id)
     end

--- a/lib/neo4j/active_rel/initialize.rb
+++ b/lib/neo4j/active_rel/initialize.rb
@@ -11,7 +11,7 @@ module Neo4j::ActiveRel
     def init_on_load(persisted_rel, from_node_id, to_node_id, type)
       @rel_type = type
       @_persisted_obj = persisted_rel
-      changed_attributes_clear!
+      clear_changes_information
       @attributes = convert_and_assign_attributes(persisted_rel.props)
       load_nodes(from_node_id, to_node_id)
     end

--- a/lib/neo4j/active_rel/initialize.rb
+++ b/lib/neo4j/active_rel/initialize.rb
@@ -11,7 +11,7 @@ module Neo4j::ActiveRel
     def init_on_load(persisted_rel, from_node_id, to_node_id, type)
       @rel_type = type
       @_persisted_obj = persisted_rel
-      changed_attributes && changed_attributes.clear
+      changed_attributes_clear!
       @attributes = convert_and_assign_attributes(persisted_rel.props)
       load_nodes(from_node_id, to_node_id)
     end

--- a/lib/neo4j/shared/initialize.rb
+++ b/lib/neo4j/shared/initialize.rb
@@ -25,6 +25,10 @@ module Neo4j::Shared
       end
     end
 
+    def changed_attributes_clear!
+      @attributes_changed_by_setter = ActiveSupport::HashWithIndifferentAccess.new
+    end
+
     def changed_attributes_selective_clear!(hash_to_clear)
       attributes_changed_by_setter = ActiveSupport::HashWithIndifferentAccess.new(changed_attributes)
       hash_to_clear.keys.each { |k| attributes_changed_by_setter.delete(k) }

--- a/lib/neo4j/shared/initialize.rb
+++ b/lib/neo4j/shared/initialize.rb
@@ -25,10 +25,6 @@ module Neo4j::Shared
       end
     end
 
-    def changed_attributes_clear!
-      @attributes_changed_by_setter = ActiveSupport::HashWithIndifferentAccess.new
-    end
-
     def changed_attributes_selective_clear!(hash_to_clear)
       attributes_changed_by_setter = ActiveSupport::HashWithIndifferentAccess.new(changed_attributes)
       hash_to_clear.keys.each { |k| attributes_changed_by_setter.delete(k) }

--- a/lib/neo4j/shared/initialize.rb
+++ b/lib/neo4j/shared/initialize.rb
@@ -24,5 +24,15 @@ module Neo4j::Shared
         attr[key.freeze] = v
       end
     end
+
+    def changed_attributes_clear!
+      @attributes_changed_by_setter = ActiveSupport::HashWithIndifferentAccess.new
+    end
+
+    def changed_attributes_selective_clear!(hash_to_clear)
+      attributes_changed_by_setter = ActiveSupport::HashWithIndifferentAccess.new(changed_attributes)
+      hash_to_clear.keys.each { |k| attributes_changed_by_setter.delete(k) }
+      @attributes_changed_by_setter = attributes_changed_by_setter
+    end
   end
 end

--- a/lib/neo4j/shared/initialize.rb
+++ b/lib/neo4j/shared/initialize.rb
@@ -25,6 +25,8 @@ module Neo4j::Shared
       end
     end
 
+    # We should be using #clear_changes_information
+    # but right now we don't use `ActiveModel` attributes correctly and so it doesn't work
     def changed_attributes_clear!
       @attributes_changed_by_setter = ActiveSupport::HashWithIndifferentAccess.new
     end

--- a/lib/neo4j/shared/initialize.rb
+++ b/lib/neo4j/shared/initialize.rb
@@ -28,13 +28,27 @@ module Neo4j::Shared
     # We should be using #clear_changes_information
     # but right now we don't use `ActiveModel` attributes correctly and so it doesn't work
     def changed_attributes_clear!
-      @attributes_changed_by_setter = ActiveSupport::HashWithIndifferentAccess.new
+      return if changed_attributes.nil?
+
+      # changed_attributes is frozen starting with ActiveModel 5.2.0
+      # Not a good long term solution
+      if changed_attributes.frozen?
+        @attributes_changed_by_setter = ActiveSupport::HashWithIndifferentAccess.new
+      else
+        changed_attributes && changed_attributes.clear
+      end
     end
 
     def changed_attributes_selective_clear!(hash_to_clear)
-      attributes_changed_by_setter = ActiveSupport::HashWithIndifferentAccess.new(changed_attributes)
-      hash_to_clear.keys.each { |k| attributes_changed_by_setter.delete(k) }
-      @attributes_changed_by_setter = attributes_changed_by_setter
+      # changed_attributes is frozen starting with ActiveModel 5.2.0
+      # Not a good long term solution
+      if changed_attributes.frozen?
+        attributes_changed_by_setter = ActiveSupport::HashWithIndifferentAccess.new(changed_attributes)
+        hash_to_clear.keys.each { |k| attributes_changed_by_setter.delete(k) }
+        @attributes_changed_by_setter = attributes_changed_by_setter
+      else
+        hash_to_clear.each_key { |k| changed_attributes.delete(k) }
+      end
     end
   end
 end

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -14,7 +14,7 @@ module Neo4j::Shared
       props = props_for_update
       neo4j_query(query_as(:n).set(n: props))
       _persisted_obj.props.merge!(props)
-      clear_changes_information
+      changed_attributes_clear!
     end
 
     def skip_update?
@@ -164,7 +164,7 @@ module Neo4j::Shared
     def reload
       return self if new_record?
       association_proxy_cache.clear if respond_to?(:association_proxy_cache)
-      clear_changes_information
+      changed_attributes_clear!
       unless reload_from_database
         @_deleted = true
         freeze

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -14,7 +14,7 @@ module Neo4j::Shared
       props = props_for_update
       neo4j_query(query_as(:n).set(n: props))
       _persisted_obj.props.merge!(props)
-      changed_attributes.clear
+      changed_attributes_clear!
     end
 
     def skip_update?
@@ -164,7 +164,7 @@ module Neo4j::Shared
     def reload
       return self if new_record?
       association_proxy_cache.clear if respond_to?(:association_proxy_cache)
-      changed_attributes && changed_attributes.clear
+      changed_attributes_clear!
       unless reload_from_database
         @_deleted = true
         freeze
@@ -202,7 +202,7 @@ module Neo4j::Shared
         neo4j_query(query_as(:n).set(n: db_values))
         db_values.each_pair { |k, v| self.public_send(:"#{k}=", v) }
         _persisted_obj.props.merge!(db_values)
-        db_values.each_key { |k| changed_attributes.delete(k) }
+        changed_attributes_selective_clear!(db_values)
         true
       end
     end
@@ -242,7 +242,7 @@ module Neo4j::Shared
                                  .pluck("#{element_name}.`#{attribute}`").first
       return false unless new_attribute
       self[attribute] = new_attribute
-      changed_attributes.delete(attribute)
+      set_attribute_was(attribute, new_attribute)
       true
     end
 

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -14,7 +14,7 @@ module Neo4j::Shared
       props = props_for_update
       neo4j_query(query_as(:n).set(n: props))
       _persisted_obj.props.merge!(props)
-      changed_attributes_clear!
+      clear_changes_information
     end
 
     def skip_update?
@@ -164,7 +164,7 @@ module Neo4j::Shared
     def reload
       return self if new_record?
       association_proxy_cache.clear if respond_to?(:association_proxy_cache)
-      changed_attributes_clear!
+      clear_changes_information
       unless reload_from_database
         @_deleted = true
         freeze

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -11,6 +11,10 @@ module Neo4j::Shared
 
     attr_reader :_persisted_obj
 
+    def mutations_from_database
+      ActiveModel::NullMutationTracker.instance
+    end
+
     def inspect
       attribute_descriptions = inspect_attributes.map do |key, value|
         "#{Neo4j::ANSI::CYAN}#{key}: #{Neo4j::ANSI::CLEAR}#{value.inspect}"


### PR DESCRIPTION
Fixes #1496 

Supporting Rails 5.2 required two small changes.

The less significant is working around ActiveModel's (totally reasonable, IMO) [change](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/dirty.rb#L222) to make the output of `changed_attributes` immutable. Very straightforward. Would like better names for these methods.

The more significant is the workaround for the error causing all of the recent CI failures. The way I did it was to define our own [`mutations_from_database`](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/dirty.rb#L258). I know that we're testing aspects of `ActiveModel::Dirty` but I'm still concerned we might be missing out on expected behavior. I didn't have internet while working on this so I couldn't really dig into it. For that reason, I'd like some careful eyes on this before it's merged in.