### PR TITLE
Updating git link for `cancancan-neo4j` gem

### DIFF
--- a/docs/HelperGems.rst
+++ b/docs/HelperGems.rst
@@ -9,7 +9,7 @@ devise-neo4j
 cancancan-neo4j
 --------------------
 
-The `cancancan-neo4j gem <https://github.com/ProjectVegas/cancancan-neo4j>`_ is the neo4j adapter for the `CanCanCan <https://github.com/canCanCommunity/cancancan>`_ authorisation library. This gem will help you seamlessly integrate cancan gem to your Ruby/Rails app wich has Neo4j as database.
+The `cancancan-neo4j gem <https://github.com/CanCanCommunity/cancancan-neo4j>`_ is the neo4j adapter for the `CanCanCan <https://github.com/canCanCommunity/cancancan>`_ authorisation library. This gem will help you seamlessly integrate cancan gem to your Ruby/Rails app wich has Neo4j as database.
 
 neo4j-paperclip
 ---------------


### PR DESCRIPTION
Updating git link for `cancancan-neo4j` gem to CanCanCommunity repo.

Fixes #

This pull changes:
 * cancan-neo4j gem link from https://github.com/ProjectVegas/cancancan-neo4j to https://github.com/CanCanCommunity/cancancan-neo4j



