### PR TITLE
order with limit and with_association bug

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
+++ b/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
@@ -157,11 +157,10 @@ module Neo4j
         end
 
         def build_query
-          before_pluck.pluck(identity, "[#{with_associations_return_clause}]")
+          before_pluck(query_from_association_tree).pluck(identity, "[#{with_associations_return_clause}]")
         end
 
-        def before_pluck
-          query = query_from_association_tree # has side effects and cannot be inlined
+        def before_pluck(query)
           query_from_chain(@order_chain, query, identity)
         end
 

--- a/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
+++ b/lib/neo4j/active_node/query/query_proxy_eager_loading.rb
@@ -183,9 +183,8 @@ module Neo4j
         end
 
         def chain
-          @order_chain, other_chain =
-            with_associations_tree.empty? ? [[], @chain] : @chain.partition { |link| link.clause == :order }
-          other_chain
+          @order_chain = @chain.select { |link| link.clause == :order } unless with_associations_tree.empty?
+          @chain
         end
       end
     end

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -234,6 +234,13 @@ describe 'Association Proxy' do
     end
   end
 
+  describe 'ordering with limit' do
+    it 'supports ordering with limit and with_associations' do
+      expect(Lesson.order(:subject).limit(1).with_associations(:students).map(&:subject)).to eq(%w(math))
+      expect(Lesson.order(subject: :desc).limit(1).with_associations(:students).map(&:subject)).to eq(%w(science))
+    end
+  end
+
   describe 'issue reported by @andrewhavens in #881' do
     it 'does not break' do
       l1 = Lesson.create!.tap { |l| l.exams_given = [Exam.create!] }


### PR DESCRIPTION
Fixes #
There is a bug when all 3 order, limit and with_associations is used. The limit is applied before order by. 
The main problem around order and `with_associations` is that the `collect` used in `with_associations` reshuffles already sorted set. So the order has to come at the end. Since however, the `with_associations` is very expensive since it potentially touches and returns a large amount of data it would be nice that the result is already limited before it is processed by with_associations, which requires order and limit happening before. 
The approach I have taken here is to repeat the order at the end of the query. Another approach would be to move the `limit` to the very end. Both approaches are functionally the same. But the former is more performant in general case. 
I am open for suggestions either way. But one thing is clear that it cannot stay the way it is as pagination would return totally wrong results.

This pull introduces/changes:
 * 
 * 



