### PR TITLE
Update RakeTasks.rst

### DIFF
--- a/docs/RakeTasks.rst
+++ b/docs/RakeTasks.rst
@@ -66,7 +66,7 @@ The ``neo4j-rake_tasks`` gem includes some rake tasks which make it easy to inst
 
   .. _rake_tasks-neo4j_start_no_wait:
 
-  **neo4j:start**
+  **neo4j:shell**
     **Arguments:** ``environment``
 
     **Example:** ``rake neo4j:shell[development]``


### PR DESCRIPTION
Fixed typo for neo4j:shell

Changed neo4j:start to neo4j:shell (there were two neo4j:start sections)



