### PR TITLE
Query proxy where or

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [9.5.0] 2019-01-21
+
+## Added
+
+- `where_or` method for QueryProxy
+
 ## [9.4.0] 2018-12-20
 
 ## Added

--- a/docs/QueryClauseMethods.rst
+++ b/docs/QueryClauseMethods.rst
@@ -715,6 +715,51 @@ Neo4j::Core::Query
 
 ------------
 
+#where_or
+~~~~~~~~~~
+
+:Ruby:
+  .. code-block:: ruby
+
+    .where_or(q: {age: 30, name: 'Chunky'})
+
+:Cypher:
+  .. code-block:: cypher
+
+    WHERE (q.age = {q_age} OR q.name = {q_name})
+
+**Parameters:** ``{:q_age=>30, :q_name=>"Chunky"}``
+
+------------
+
+:Ruby:
+  .. code-block:: ruby
+
+    .where_or(q: {age: 30, name: 'Chunky'}).where('q.age > 10')
+
+:Cypher:
+  .. code-block:: cypher
+
+    WHERE (q.age = {q_age} OR q.name = {q_name}) AND (q.age > 10)
+
+**Parameters:** ``{:q_age=>30, :q_name=>"Chunky"}``
+
+------------
+
+:Ruby:
+  .. code-block:: ruby
+
+    .where_or(q: {age: 20, name: 'Bacon'}).where_not(q: {age: 30, name: 'Chunky'})
+
+:Cypher:
+  .. code-block:: cypher
+
+    WHERE (q.age = {q_age} OR q.name = {q_name}) AND NOT(q.age = {q_age2} AND q.name = {q_name2})
+
+**Parameters:** ``{:q_age2=>30, :q_name2=>'Chunky', :q_age=>20, :q_name=>'Bacon'}``
+
+------------
+
 #match_nodes
 ~~~~~~~~~~~~
 

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -144,7 +144,7 @@ module Neo4j
           @model.current_scope = previous
         end
 
-        METHODS = %w(where where_not rel_where rel_where_not rel_order order skip limit)
+        METHODS = %w(where where_not where_or rel_where rel_where_not rel_where_or rel_order order skip limit)
 
         METHODS.each do |method|
           define_method(method) { |*args| build_deeper_query_proxy(method.to_sym, args) }

--- a/lib/neo4j/active_node/query/query_proxy_link.rb
+++ b/lib/neo4j/active_node/query/query_proxy_link.rb
@@ -51,6 +51,12 @@ module Neo4j
               end
             end
 
+            def for_where_or_clause(*args)
+              for_where_clause(*args).each do |link|
+                link.instance_variable_set('@clause', :where_or)
+              end
+            end
+
             def new_for_key_and_value(model, key, value)
               key = converted_key(model, key)
 
@@ -90,6 +96,12 @@ module Neo4j
               end
             end
 
+            def for_rel_where_or_clause(*args)
+              for_rel_where_clause(*args).each do |link|
+                link.instance_variable_set('@clause', :where_or)
+              end
+            end
+
             def for_rel_order_clause(arg, _)
               [new(:order, ->(_, v) { arg.is_a?(String) ? arg : {v => arg} })]
             end
@@ -99,9 +111,9 @@ module Neo4j
             end
 
             def for_args(model, clause, args, association = nil)
-              if [:where, :where_not].include?(clause) && args[0].is_a?(String) # Better way?
+              if [:where, :where_not, :where_or].include?(clause) && args[0].is_a?(String) # Better way?
                 [for_arg(model, clause, args[0], *args[1..-1])]
-              elsif [:rel_where, :rel_where_not].include?(clause)
+              elsif [:rel_where, :rel_where_not, :rel_where_or].include?(clause)
                 args.map { |arg| for_arg(model, clause, arg, association) }
               else
                 args.map { |arg| for_arg(model, clause, arg) }

--- a/lib/neo4j/version.rb
+++ b/lib/neo4j/version.rb
@@ -1,3 +1,3 @@
 module Neo4j
-  VERSION = '9.4.0'
+  VERSION = '9.5.0'
 end

--- a/spec/e2e/id_property_spec.rb
+++ b/spec/e2e/id_property_spec.rb
@@ -513,6 +513,14 @@ describe Neo4j::ActiveNode::IdProperty do
       end
     end
 
+    describe 'where_or' do
+      it 'should find complement' do
+        node = NeoIdTest.create
+        excluded = NeoIdTest.create
+        expect(NeoIdTest.where_or(id: node, name: 'Test')).to eq([node])
+      end
+    end
+
     describe 'order' do
       it 'should order by neo_id' do
         # ascending neo_ids during insertion cannot be guaranteed anymore in community version'

--- a/spec/e2e/query_spec.rb
+++ b/spec/e2e/query_spec.rb
@@ -833,6 +833,20 @@ describe 'Query API' do
         end
       end
 
+      describe '#rel_where_or' do
+        context 'with a rel_class present' do
+          let(:math_lesson) { Student.lessons.rel_where_or(grade: '65', name: 'math').to_a }
+          let(:science_lesson) { Student.lessons.rel_where_or(grade: '99'.to_f, name: 'science').to_a }
+
+          it 'includes the nodes with relationships that match the condition' do
+            expect(math_lesson.count).to eq 1
+            expect(math_lesson.first.subject).to eq 'Math'
+            expect(science_lesson.count).to eq 1
+            expect(science_lesson.first.subject).to eq 'Science'
+          end
+        end
+      end
+
       describe '#rel_order' do
         it 'allows ordering by relationships with rel_order' do
           expect(Student.lessons(:l, :rel).rel_order(:grade).pluck('rel.grade')).to eq([65, 99])


### PR DESCRIPTION
Fixes #

This pull introduces/changes:
 * This PR will introduce `.where_or` method to `QueryProxy` objects
This will be a logical or for conditions passed to `.where_or` call
eg.
` User.where_or(name: 'CEO', title: 'sd')`
will produce a query like
```
MATCH (result_user:`User`)
WHERE (result_user.name = {result_user_name}) OR (result_user.title = {result_user_title})
RETURN result_user | {:result_user_name=>"CEO", :result_user_title=>"sd"}
```


