### PR TITLE
Fix wait_for_connection not waiting for connection

### DIFF
--- a/lib/neo4j/session_manager.rb
+++ b/lib/neo4j/session_manager.rb
@@ -7,15 +7,12 @@ module Neo4j
       def open_neo4j_session(type, url_or_path, wait_for_connection = false, options = {})
         enable_unlimited_strength_crypto! if java_platform? && session_type_is_embedded?(type)
 
-        wait_for_value(wait_for_connection, Neo4j::Core::CypherSession::ConnectionFailedError) do
-          verbose_query_logs = Neo4j::Config.fetch(:verbose_query_logs, false)
-          adaptor = cypher_session_adaptor(type, url_or_path, options.merge(wrap_level: :proc,
-                                                                            verbose_query_logs: verbose_query_logs))
-          session = Neo4j::Core::CypherSession.new(adaptor)
-          # NOTE: query version to test if connection is available
-          session.version if wait_for_connection
-          session
-        end
+        verbose_query_logs = Neo4j::Config.fetch(:verbose_query_logs, false)
+        adaptor = cypher_session_adaptor(type, url_or_path, options.merge(wrap_level: :proc,
+                                                                          verbose_query_logs: verbose_query_logs))
+        session = Neo4j::Core::CypherSession.new(adaptor)
+        wait_and_retry(session) if wait_for_connection
+        session
       end
 
       def adaptor_class(type, options)
@@ -44,23 +41,17 @@ module Neo4j
         RUBY_PLATFORM =~ /java/
       end
 
-      def wait_for_value(wait, exception_class)
-        value = nil
+      def wait_and_retry(session)
         Timeout.timeout(60) do
-          until value
-            begin
-              if value = yield
-                # puts
-                return value
-              end
-            rescue exception_class => e
-              raise e if !wait
-
-              # putc '.'
-              sleep(1)
-            end
+          begin
+            session.version
+          rescue Neo4j::Core::CypherSession::ConnectionFailedError
+            sleep(1)
+            retry
           end
         end
+      rescue Timeout::Error
+        raise Timeout::Error, 'Timeout while waiting for connection to neo4j database'
       end
 
       private

--- a/lib/neo4j/session_manager.rb
+++ b/lib/neo4j/session_manager.rb
@@ -44,7 +44,7 @@ module Neo4j
       def wait_and_retry(session)
         Timeout.timeout(60) do
           begin
-            session.version
+            session.constraints
           rescue Neo4j::Core::CypherSession::ConnectionFailedError
             sleep(1)
             retry


### PR DESCRIPTION
To reproduce the bug, before applying the patch, run the script bellow
and note that the migration task will fail immediately, without retrying
for 60 seconds.

```
rails new asd -O -m http://neo4jrb.io/neo4j/neo4j.rb
cd asd
patch -p0 <<EOF
--- config/application.rb       2019-03-18 17:06:49.587351900 +0000
+++ config/application.rb       2019-03-18 17:06:51.999351958 +0000
@@ -20,6 +20,7 @@

 module Asd
   class Application < Rails::Application
+    config.neo4j.wait_for_connection = true

     config.generators do |g|
       g.orm             :neo4j
EOF
time rake neo4j:migrate:all
```

