### PR TITLE
Require Forwardable module

### DIFF
--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -1,3 +1,4 @@
+require 'forwardable'
 require 'neo4j/version'
 
 require 'neo4j-core'


### PR DESCRIPTION
Not sure whether this is the most proper fix (and fix location), but the Forwardable module is missing from the `require` statements. That results in an error

> /usr/local/lib/ruby/gems/2.5.0/gems/neo4j-9.4.0/lib/neo4j/shared/property.rb:119:in `<module:ClassMethods>': uninitialized constant Neo4j::Shared::Property::ClassMethods::Forwardable (NameError)

when including a Neo4j module, as reported in #1535.

Fixes #1535