### PR TITLE
Issue 1543 fix variable length relationship deprecation in cypher

### DIFF
--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -122,7 +122,7 @@ module Neo4j
         end
 
         def path_var
-          "p#{_chain_level - 1}"
+          "path#{_chain_level - 1}"
         end
 
         # param [TrueClass, FalseClass] with_labels This param is used by certain QueryProxy methods that already have the neo_id and

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -116,15 +116,6 @@ module Neo4j
           end
         end
 
-        def query_path(chain_var, var)
-          path = "(#{chain_var})#{_association_arrow}(#{var}#{_model_label_string})"
-          @rel_length ? "#{path_var}=#{path}" : path
-        end
-
-        def path_var
-          "path#{_chain_level - 1}"
-        end
-
         # param [TrueClass, FalseClass] with_labels This param is used by certain QueryProxy methods that already have the neo_id and
         # therefore do not need labels.
         # The @association_labels instance var is set during init and used during association chaining to keep labels out of Cypher queries.
@@ -355,6 +346,15 @@ module Neo4j
 
         def _rel_chain_var
           :"rel#{_chain_level - 1}"
+        end
+
+        def query_path(chain_var, var)
+          path = "(#{chain_var})#{_association_arrow}(#{var}#{_model_label_string})"
+          @rel_length ? "#{path_var}=#{path}" : path
+        end
+
+        def path_var
+          "path#{_chain_level - 1}"
         end
 
         attr_writer :context

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -110,11 +110,19 @@ module Neo4j
         def base_query(var, with_labels = true)
           if @association
             chain_var = _association_chain_var
-            (_association_query_start(chain_var) & _query).break.send(@match_type,
-                                                                      "(#{chain_var})#{_association_arrow}(#{var}#{_model_label_string})")
+            (_association_query_start(chain_var) & _query).break.send(@match_type, query_path(chain_var, var))
           else
             starting_query ? starting_query : _query_model_as(var, with_labels)
           end
+        end
+
+        def query_path(chain_var, var)
+          path = "(#{chain_var})#{_association_arrow}(#{var}#{_model_label_string})"
+          @rel_length ? "#{path_var}=#{path}" : path
+        end
+
+        def path_var
+          "p#{_chain_level - 1}"
         end
 
         # param [TrueClass, FalseClass] with_labels This param is used by certain QueryProxy methods that already have the neo_id and
@@ -320,7 +328,8 @@ module Neo4j
         end
 
         def _association_arrow(properties = {}, create = false)
-          @association && @association.arrow_cypher(@rel_var, properties, create, false, @rel_length)
+          var = @rel_length ? nil : @rel_var
+          @association && @association.arrow_cypher(var, properties, create, false, @rel_length)
         end
 
         def _chain_level

--- a/lib/neo4j/active_node/query/query_proxy_enumerable.rb
+++ b/lib/neo4j/active_node/query/query_proxy_enumerable.rb
@@ -91,8 +91,12 @@ module Neo4j
         def pluck_vars(node, rel)
           vars = []
           vars << ensure_distinct(identity) if node
-          vars << @rel_var if rel
+          vars << relation_variable if rel
           pluck(*vars)
+        end
+
+        def relation_variable
+          @rel_length ? "relationships(#{path_var})" : @rel_var
         end
 
         def set_instance_caches(instance, node, rel)

--- a/lib/neo4j/active_node/query/query_proxy_enumerable.rb
+++ b/lib/neo4j/active_node/query/query_proxy_enumerable.rb
@@ -96,7 +96,7 @@ module Neo4j
         end
 
         def relation_variable
-          @rel_length ? "relationships(#{path_var})" : @rel_var
+          @rel_length ? "relationships(#{path_var}) as #{@rel_var}" : @rel_var
         end
 
         def set_instance_caches(instance, node, rel)

--- a/lib/neo4j/active_node/query/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods.rb
@@ -10,7 +10,7 @@ module Neo4j
         def rels
           fail 'Cannot get rels without a relationship variable.' if !@rel_var
 
-          pluck(@rel_var)
+          pluck_vars(false, true)
         end
 
         def rel

--- a/spec/e2e/has_many_spec.rb
+++ b/spec/e2e/has_many_spec.rb
@@ -394,6 +394,7 @@ describe 'has_many' do
 
     it 'allows passing only a hash of options when naming node/rel is not needed' do
       expect(node.knows(rel_length: :any).to_a).to match_array([friend1, friend2])
+      expect(node.as(:person).knows(rel_length: :any).to_cypher).to include('MATCH path1=(person)-[:`KNOWS`*]->(result_knows3:`Person`)')
     end
 
     it 'honors default options' do


### PR DESCRIPTION
Fixes #1543 

This pull introduces/changes:
 * The cypher generated for `user.roles(rel_length: :any)` as `MATCH (user)-[rel1:role*]->(result_roles:Role) RETURN result_roles` to `MATCH p=(user)-[:role*]->(result_roles:Role) RETURN result_roles`

This is required as `()-[r:relation_name*]->()` syntax is going to be deprecated in neo4j cypher.



