### PR TITLE
README: Use SVG badges, drop defunct badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 ## Code Status
 
 [![Actively Maintained](https://img.shields.io/badge/Maintenance%20Level-Actively%20Maintained-green.svg)](https://gist.github.com/cheerfulstoic/d107229326a01ff0f333a1d3476e068d)
-[![Build Status](https://secure.travis-ci.org/neo4jrb/neo4j.png?branch=master)](http://travis-ci.org/neo4jrb/neo4j)
-[![Coverage Status](https://coveralls.io/repos/neo4jrb/neo4j/badge.png?branch=master)](https://coveralls.io/r/neo4jrb/neo4j?branch=master)
-[![Code Climate](https://codeclimate.com/github/neo4jrb/neo4j.png)](https://codeclimate.com/github/neo4jrb/neo4j)
-[![PullReview stats](https://www.pullreview.com/github/neo4jrb/neo4j/badges/master.svg?)](https://www.pullreview.com/github/neo4jrb/neo4j/reviews/master)
+[![Build Status](https://secure.travis-ci.org/neo4jrb/neo4j.svg?branch=master)](http://travis-ci.org/neo4jrb/neo4j)
+[![Coverage Status](https://coveralls.io/repos/neo4jrb/neo4j/badge.svg?branch=master)](https://coveralls.io/r/neo4jrb/neo4j?branch=master)
+[![Code Climate](https://codeclimate.com/github/neo4jrb/neo4j.svg)](https://codeclimate.com/github/neo4jrb/neo4j)
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,6 @@
 [![Coverage Status](https://coveralls.io/repos/neo4jrb/neo4j/badge.svg?branch=master)](https://coveralls.io/r/neo4jrb/neo4j?branch=master)
 [![Code Climate](https://codeclimate.com/github/neo4jrb/neo4j.svg)](https://codeclimate.com/github/neo4jrb/neo4j)
 
-## Issues
-
-[![Next Release](https://badge.waffle.io/neo4jrb/neo4j.png?label=Next%20Release&title=Next%20Release) ![In Progress](https://badge.waffle.io/neo4jrb/neo4j.png?label=In%20Progress&title=In%20Progress) ![In Master](https://badge.waffle.io/neo4jrb/neo4j.png?label=In%20Master&title=In%20Master)](https://waffle.io/neo4jrb/neo4j)
-
-[![Post an issue](https://img.shields.io/badge/Bug%3F-Post%20an%20issue!-blue.svg)](https://waffle.io/neo4jrb/neo4j)
-
 ## Get Support
 
 ### Documentation


### PR DESCRIPTION
This PR changes the build badges to SVG for sharper readability ✨

Also: drops badges for services no longer active.

- `www.pullreview.com` is no longer.
- `waffle.io` is no longer.