### PR TITLE
Drop deprecated rubygems prop "has_rdoc"

### DIFF
--- a/neo4j.gemspec
+++ b/neo4j.gemspec
@@ -23,7 +23,6 @@ DESCRIPTION
   s.require_path = 'lib'
   s.files = Dir.glob('{bin,lib,config}/**/*') + %w(README.md CHANGELOG.md CONTRIBUTORS Gemfile neo4j.gemspec)
   s.executables = ['neo4j-jars']
-  s.has_rdoc = true
   s.extra_rdoc_files = %w( README.md )
   s.rdoc_options = ['--quiet', '--title', 'Neo4j.rb', '--line-numbers', '--main', 'README.rdoc', '--inline-source']
   s.metadata = {


### PR DESCRIPTION
This PR:
 * Drops an unused property in the rubygems package spec 

Warning message emitted: `NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.`




