### PR TITLE
Fix remove_property

### DIFF
--- a/lib/neo4j/migrations/helpers.rb
+++ b/lib/neo4j/migrations/helpers.rb
@@ -14,7 +14,7 @@ module Neo4j
                                  'To overwrite, call `remove_property(:%{label}, :%{new_property})` before this method.'.freeze
 
       def remove_property(label, property)
-        by_label(label).remove(n: property).exec
+        by_label(label).remove("n.#{property}").exec
       end
 
       def rename_property(label, old_property, new_property)

--- a/spec/unit/migrations/helpers_spec.rb
+++ b/spec/unit/migrations/helpers_spec.rb
@@ -28,7 +28,7 @@ describe Neo4j::Migrations::Helpers do
   describe '#remove_property' do
     it 'removes a property' do
       remove_property :Book, :name
-      expect(Book.all(:n).pluck('n.title')).to eq([nil, nil, nil])
+      expect(Book.all(:n).pluck('n.name')).to eq([nil, nil, nil])
     end
   end
 


### PR DESCRIPTION
Fixes #
When using `remove_property` as mentioned in the [docs](https://neo4jrb.readthedocs.io/en/stable/Migrations.html#remove-property):
```
remove_property(:User, :session_context)
```

It generates this Cypher, which doesn't work to remove the property
```
 CYPHER
  MATCH (n:`User`)
  REMOVE n:`session_context`
```

This pull introduces/changes:
 * Fix the spec which has an error that returns a false positive (it is removing `:name ` and it's testing for `:title`). This causes a failing spec.
 * Fix the `rename_property` to generate the correct Cypher:

```
 CYPHER
  MATCH (n:`User`)
  REMOVE n.`session_context`
```