### PR TITLE
Issue 1560 fix for preserving schema integrity for has_one relationship through ActiveRel

### DIFF
--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -229,6 +229,11 @@ module Neo4j::ActiveNode
       end
     end
 
+    def delete_has_one_rel(rel)
+      rel_name = self.class.associations.find { |_key, assoc| assoc.relationship_type == rel.type.to_sym && assoc.type == :has_one }
+      self.send("#{rel_name.first}=", nil) if rel_name
+    end
+
     private
 
     def fresh_association_proxy(name, options = {}, result_cache_proc = nil)

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -229,9 +229,21 @@ module Neo4j::ActiveNode
       end
     end
 
-    def delete_has_one_rel(rel)
-      rel_name = self.class.associations.find { |_key, assoc| assoc.relationship_type == rel.type.to_sym && assoc.type == :has_one }
-      self.send("#{rel_name.first}=", nil) if rel_name
+    def delete_has_one_rel(active_rel, direction, target_class)
+      rel = active_rel_corresponding_rel(active_rel, direction, target_class)
+      delete_rel(rel.last) if rel && rel.last.type == :has_one
+    end
+
+    def delete_rel(rel)
+      send("#{rel.name}=", nil)
+      association_proxy_cache.clear
+    end
+
+    def active_rel_corresponding_rel(active_rel, direction, target_class)
+      self.class.associations.find do |_key, assoc|
+        assoc.relationship_class_name == active_rel.class.name ||
+          (assoc.relationship_type == active_rel.type.to_sym && assoc.target_class == target_class && assoc.direction == direction)
+      end
     end
 
     private

--- a/lib/neo4j/active_node/rels.rb
+++ b/lib/neo4j/active_node/rels.rb
@@ -10,11 +10,13 @@ module Neo4j::ActiveNode
 
     def delete_reverse_relationship(association)
       reverse_assoc = reverse_association(association)
-      self.send("#{reverse_assoc.name}=", nil) if reverse_assoc && reverse_assoc.type == :has_one
+      delete_rel(reverse_assoc) if reverse_assoc && reverse_assoc.type == :has_one
     end
 
     def reverse_association(association)
-      reverse_assoc = self.class.associations.find { |_key, assoc| association.inverse_of?(assoc) }
+      reverse_assoc = self.class.associations.find do |_key, assoc|
+        association.inverse_of?(assoc) || assoc.inverse_of?(association)
+      end
       reverse_assoc && reverse_assoc.last
     end
   end

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -53,8 +53,8 @@ module Neo4j::ActiveRel
     end
 
     def delete_has_one_rel
-      @to_node.delete_has_one_rel(self)
-      @from_node.delete_has_one_rel(self)
+      to_node.delete_has_one_rel(self, :in, from_node.class) if to_node.persisted?
+      from_node.delete_has_one_rel(self, :out, to_node.class) if from_node.persisted?
     end
 
     def query_as(var)

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -45,10 +45,18 @@ module Neo4j::ActiveRel
 
     def create_model
       validate_node_classes!
+      delete_has_one_rel
       rel = _create_rel
       return self unless rel.respond_to?(:props)
       init_on_load(rel, from_node, to_node, @rel_type)
       true
+    end
+
+    def delete_has_one_rel
+      to_node_rel_name = @to_node.class.associations.find {|key, assoc| assoc.relationship_type == type.to_sym && assoc.type == :has_one  }&.first
+      @to_node.send("#{to_node_rel_name}=",nil) if to_node_rel_name
+      from_node_rel_name = @from_node.class.associations.find {|key, assoc| assoc.relationship_type == type.to_sym && assoc.type == :has_one  }&.first
+      @from_node.send("#{from_node_rel_name}=",nil) if from_node_rel_name
     end
 
     def query_as(var)

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -53,10 +53,18 @@ module Neo4j::ActiveRel
     end
 
     def delete_has_one_rel
-      to_node_rel_name = @to_node.class.associations.find {|key, assoc| assoc.relationship_type == type.to_sym && assoc.type == :has_one  }
-      @to_node.send("#{to_node_rel_name.first}=",nil) if to_node_rel_name
-      from_node_rel_name = @from_node.class.associations.find {|key, assoc| assoc.relationship_type == type.to_sym && assoc.type == :has_one  }
-      @from_node.send("#{from_node_rel_name.first}=",nil) if from_node_rel_name
+      
+      
+    end
+
+    def delete_has_one_to_node_rel
+      to_node_rel_name = @to_node.class.associations.find { |_key, assoc| assoc.relationship_type == type.to_sym && assoc.type == :has_one }
+      @to_node.send("#{to_node_rel_name.first}=", nil) if to_node_rel_name
+    end
+
+    def delete_has_one_from_node_rel
+      from_node_rel_name = @from_node.class.associations.find { |_key, assoc| assoc.relationship_type == type.to_sym && assoc.type == :has_one }
+      @from_node.send("#{from_node_rel_name.first}=", nil) if from_node_rel_name
     end
 
     def query_as(var)

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -53,8 +53,8 @@ module Neo4j::ActiveRel
     end
 
     def delete_has_one_rel
-      
-      
+      delete_has_one_to_node_rel
+      delete_has_one_from_node_rel
     end
 
     def delete_has_one_to_node_rel

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -53,18 +53,8 @@ module Neo4j::ActiveRel
     end
 
     def delete_has_one_rel
-      delete_has_one_to_node_rel
-      delete_has_one_from_node_rel
-    end
-
-    def delete_has_one_to_node_rel
-      to_node_rel_name = @to_node.class.associations.find { |_key, assoc| assoc.relationship_type == type.to_sym && assoc.type == :has_one }
-      @to_node.send("#{to_node_rel_name.first}=", nil) if to_node_rel_name
-    end
-
-    def delete_has_one_from_node_rel
-      from_node_rel_name = @from_node.class.associations.find { |_key, assoc| assoc.relationship_type == type.to_sym && assoc.type == :has_one }
-      @from_node.send("#{from_node_rel_name.first}=", nil) if from_node_rel_name
+      @to_node.delete_has_one_rel(self)
+      @from_node.delete_has_one_rel(self)
     end
 
     def query_as(var)

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -53,10 +53,10 @@ module Neo4j::ActiveRel
     end
 
     def delete_has_one_rel
-      to_node_rel_name = @to_node.class.associations.find {|key, assoc| assoc.relationship_type == type.to_sym && assoc.type == :has_one  }&.first
-      @to_node.send("#{to_node_rel_name}=",nil) if to_node_rel_name
-      from_node_rel_name = @from_node.class.associations.find {|key, assoc| assoc.relationship_type == type.to_sym && assoc.type == :has_one  }&.first
-      @from_node.send("#{from_node_rel_name}=",nil) if from_node_rel_name
+      to_node_rel_name = @to_node.class.associations.find {|key, assoc| assoc.relationship_type == type.to_sym && assoc.type == :has_one  }
+      @to_node.send("#{to_node_rel_name.first}=",nil) if to_node_rel_name
+      from_node_rel_name = @from_node.class.associations.find {|key, assoc| assoc.relationship_type == type.to_sym && assoc.type == :has_one  }
+      @from_node.send("#{from_node_rel_name.first}=",nil) if from_node_rel_name
     end
 
     def query_as(var)

--- a/spec/e2e/active_rel/persistence/query_factory_spec.rb
+++ b/spec/e2e/active_rel/persistence/query_factory_spec.rb
@@ -77,16 +77,16 @@ describe Neo4j::ActiveRel::Persistence::QueryFactory do
       end
 
       it 'deleted previous has_one rel from to_node before creating new one' do
-        from_node_2 = FromClass.new(name: 'foo-2')
+        from_node_two = FromClass.new(name: 'foo-2')
         rel.save
-        RelClass.new(from_node: from_node_2, to_node: to_node, score: 10).save
+        RelClass.new(from_node: from_node_two, to_node: to_node, score: 10).save
         expect(from_node.reload.to_classes).to be_empty
       end
 
       it 'deleted previous has_one rel from from_node before creating new one' do
-        to_node_2 = ToClass.new(name: 'bar-2')
+        to_node_two = ToClass.new(name: 'bar-2')
         Rel2Class.new(from_node: from_node, to_node: to_node, score: 10).save
-        Rel2Class.new(from_node: from_node, to_node: to_node_2, score: 10).save
+        Rel2Class.new(from_node: from_node, to_node: to_node_two, score: 10).save
         expect(to_node.reload.from_classes).to be_empty
       end
     end

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -391,12 +391,11 @@ describe 'Association Proxy' do
     end
 
     it 'updates inverse has_one association correctly in case of two relationships with same type' do
-      person_1 = Person.create(name: 'person-1')
-      person_2 = Person.create(name: 'person-2')
-      comment_1 = Comment.create(text: 'test-comment-1', owner: person_1)
-      comment_2 = Comment.create(text: 'test-comment-2', comment_owner: person_1)
-      person_2.owner_comments = [comment_2]
-      expect(comment_2.as(:c).comment_owner.count).to eq(1)
+      person1 = Person.create(name: 'person-1')
+      person2 = Person.create(name: 'person-2')
+      comment = Comment.create(text: 'test-comment-2', comment_owner: person1)
+      person2.owner_comments = [comment]
+      expect(comment.as(:c).comment_owner.count).to eq(1)
     end
   end
 end

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -297,6 +297,7 @@ describe 'Association Proxy' do
         has_many :in, :comments, type: :comments
         has_one :out, :parent, type: :parent, model_class: 'Person', dependent: :delete
         has_many :in, :children, origin: :parent, model_class: 'Person'
+        has_many :out, :owner_comments, type: :comments, model_class: 'Comment'
       end
 
       stub_active_node_class('Post') do
@@ -310,6 +311,7 @@ describe 'Association Proxy' do
         property :text
 
         has_one :out, :owner, origin: :comments, model_class: 'Person'
+        has_one :in, :comment_owner, origin: :owner_comments, model_class: 'Person'
         has_one :out, :post, origin: :comments, model_class: 'Post'
       end
     end
@@ -386,6 +388,15 @@ describe 'Association Proxy' do
       person1 = Person.create(name: '1', children: [person2])
       person1.update(children: [person2, person3.id])
       expect(person3.as(:p).parent.count).to eq(1)
+    end
+
+    it 'updates inverse has_one association correctly in case of two relationships with same type' do
+      person_1 = Person.create(name: 'person-1')
+      person_2 = Person.create(name: 'person-2')
+      comment_1 = Comment.create(text: 'test-comment-1', owner: person_1)
+      comment_2 = Comment.create(text: 'test-comment-2', comment_owner: person_1)
+      person_2.owner_comments = [comment_2]
+      expect(comment_2.as(:c).comment_owner.count).to eq(1)
     end
   end
 end


### PR DESCRIPTION


Fixes #1560 

This pull introduces/changes:
 * Code change to delete existing has_one relation before creating new one.



