### PR TITLE
Add rake as non-development dependency

### DIFF
--- a/neo4j.gemspec
+++ b/neo4j.gemspec
@@ -39,6 +39,7 @@ DESCRIPTION
   s.add_dependency('neo4j-community', '~> 2.0') if RUBY_PLATFORM =~ /java/
   s.add_dependency('neo4j-core', '>= 9.0.0')
   s.add_dependency('orm_adapter', '~> 0.5.0')
+  s.add_dependency('rake')
   s.add_development_dependency('guard')
   s.add_development_dependency('guard-rspec')
   s.add_development_dependency('guard-rubocop')
@@ -46,7 +47,6 @@ DESCRIPTION
   s.add_development_dependency('os')
   s.add_development_dependency('pry')
   s.add_development_dependency('railties', '>= 4.0')
-  s.add_development_dependency('rake')
   s.add_development_dependency('rubocop', '~> 0.56.0')
   s.add_development_dependency('yard')
 end


### PR DESCRIPTION
Rake is needed in any project requiring the gem, but is not in the
gemspec or Gemfileas a dependency. Most projects have it already, so I guess this
flew under the radar

This pull introduces/changes:
 * removes rake as development dependency
 * adds rake as a fully fledged dependency



