### PR TITLE
Issue 1566 enforce has one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [9.5.3] 2019-08-16
+
+## Fixed
+
+- Enforces has_one uniqness constraint on relationship with config flag. (#1566)
+
 ## [9.5.2] 2019-08-06
 
 ## Fixed

--- a/config/neo4j/config.yml
+++ b/config/neo4j/config.yml
@@ -34,5 +34,5 @@ cache_class_names: true
 
 transform_rel_type: :upcase
 
-# Enforce has_one relationship. When same reationship is created on reverse object with another object, delete the existing relationship.
+# Enforce has_one relationship. When same reationship is created on reverse object with another object, raise the error.
 enforce_has_one: false

--- a/config/neo4j/config.yml
+++ b/config/neo4j/config.yml
@@ -33,3 +33,6 @@ cache_class_names: true
 # class_name_property:  :_classname
 
 transform_rel_type: :upcase
+
+# Enforce has_one relationship. When same reationship is created on reverse object with another object, delete the existing relationship.
+enforce_has_one: false

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -105,6 +105,10 @@ Variables
     **Default:** ``false``
 
     Specifies that queries outputted to the log also get a source file / line outputted to aid debugging.
+  **enforce_has_one**
+    **Default:** ``false``
+
+    Enforce has_one relationship. When same reationship is created on reverse object with another object, raise the error.
 
 Instrumented events
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -108,7 +108,7 @@ Variables
   **enforce_has_one**
     **Default:** ``false``
 
-    Enforce has_one relationship. When same reationship is created on reverse object with another object, raise the error.
+    Enforce has_one relationship. When same relationship is created on reverse object with another object, raise the error.
 
 Instrumented events
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -108,7 +108,7 @@ Variables
   **enforce_has_one**
     **Default:** ``false``
 
-    Enforce has_one relationship. When same relationship is created on reverse object with another object, raise the error.
+    If true raises an error if any operation would violate the uniqueness of a `has_one` relationship. Requires that associations are defined from both sides and that one side uses `origin:` in the definition.
 
 Instrumented events
 ~~~~~~~~~~~~~~~~~~~

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -3,7 +3,7 @@ module Neo4j::ActiveNode
     extend ActiveSupport::Concern
 
     class NonPersistedNodeError < Neo4j::Error; end
-    class HasOneValidationError < Neo4j::Error; end
+    class HasOneConstraintError < Neo4j::Error; end
     # Return this object from associations
     # It uses a QueryProxy to get results
     # But also caches results and can have results cached on it

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -248,7 +248,7 @@ module Neo4j::ActiveNode
     end
 
     def validate_has_one_rel!(rel, other_node)
-      raise_error = (node = send("#{rel.name}")) && node != other_node
+      raise_error = (node = send(rel.name.to_s)) && node != other_node
       fail(HasOneValidationError, "node #{self.class}##{neo_id} has a has_one relationship with #{other_node.class}##{other_node.neo_id}") if raise_error
     end
 

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -249,7 +249,7 @@ module Neo4j::ActiveNode
 
     def validate_has_one_rel!(rel, other_node)
       raise_error = (node = send(rel.name.to_s)) && node != other_node
-      fail(HasOneValidationError, "node #{self.class}##{neo_id} has a has_one relationship with #{other_node.class}##{other_node.neo_id}") if raise_error
+      fail(HasOneConstraintError, "node #{self.class}##{neo_id} has a has_one relationship with #{other_node.class}##{other_node.neo_id}") if raise_error
     end
 
     def active_rel_corresponding_rel(active_rel, direction, target_class)

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -3,7 +3,7 @@ module Neo4j::ActiveNode
     extend ActiveSupport::Concern
 
     class NonPersistedNodeError < Neo4j::Error; end
-
+    class HasOneValidationError < Neo4j::Error; end
     # Return this object from associations
     # It uses a QueryProxy to get results
     # But also caches results and can have results cached on it
@@ -229,14 +229,27 @@ module Neo4j::ActiveNode
       end
     end
 
-    def delete_has_one_rel(active_rel, direction, target_class)
-      rel = active_rel_corresponding_rel(active_rel, direction, target_class)
-      delete_rel(rel.last) if rel && rel.last.type == :has_one
+    def validate_reverse_has_one_core_rel(association, other_node)
+      return unless Neo4j::Config[:enforce_has_one]
+      reverse_assoc = reverse_association(association)
+      validate_has_one_rel!(reverse_assoc, other_node) if reverse_assoc && reverse_assoc.type == :has_one
     end
 
-    def delete_rel(rel)
-      send("#{rel.name}=", nil)
-      association_proxy_cache.clear
+    def reverse_association(association)
+      reverse_assoc = self.class.associations.find do |_key, assoc|
+        association.inverse_of?(assoc) || assoc.inverse_of?(association)
+      end
+      reverse_assoc && reverse_assoc.last
+    end
+
+    def validate_reverse_has_one_active_rel(active_rel, direction, other_node)
+      rel = active_rel_corresponding_rel(active_rel, direction, other_node.class)
+      validate_has_one_rel!(rel.last, other_node) if rel && rel.last.type == :has_one
+    end
+
+    def validate_has_one_rel!(rel, other_node)
+      raise_error = (node = send("#{rel.name}")) && node != other_node
+      fail(HasOneValidationError, "node #{self.class}##{neo_id} has a has_one relationship with #{other_node.class}##{other_node.neo_id}") if raise_error
     end
 
     def active_rel_corresponding_rel(active_rel, direction, target_class)

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -208,7 +208,7 @@ module Neo4j
           Neo4j::ActiveBase.run_transaction do
             other_nodes.each do |other_node|
               if other_node.neo_id
-                other_node.try(:delete_reverse_relationship, association)
+                other_node.try(:validate_reverse_has_one_core_rel, association, @start_object)
               else
                 other_node.save
               end

--- a/lib/neo4j/active_node/rels.rb
+++ b/lib/neo4j/active_node/rels.rb
@@ -7,17 +7,5 @@ module Neo4j::ActiveNode
       fail "Can't access relationship on a non persisted node" unless _persisted_obj
       _persisted_obj
     end
-
-    def delete_reverse_relationship(association)
-      reverse_assoc = reverse_association(association)
-      delete_rel(reverse_assoc) if reverse_assoc && reverse_assoc.type == :has_one
-    end
-
-    def reverse_association(association)
-      reverse_assoc = self.class.associations.find do |_key, assoc|
-        association.inverse_of?(assoc) || assoc.inverse_of?(association)
-      end
-      reverse_assoc && reverse_assoc.last
-    end
   end
 end

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -45,16 +45,17 @@ module Neo4j::ActiveRel
 
     def create_model
       validate_node_classes!
-      delete_has_one_rel
+      validate_has_one_rel
       rel = _create_rel
       return self unless rel.respond_to?(:props)
       init_on_load(rel, from_node, to_node, @rel_type)
       true
     end
 
-    def delete_has_one_rel
-      to_node.delete_has_one_rel(self, :in, from_node.class) if to_node.persisted?
-      from_node.delete_has_one_rel(self, :out, to_node.class) if from_node.persisted?
+    def validate_has_one_rel
+      return unless Neo4j::Config[:enforce_has_one]
+      to_node.validate_reverse_has_one_active_rel(self, :in, from_node) if to_node.persisted?
+      from_node.validate_reverse_has_one_active_rel(self, :out, to_node) if from_node.persisted?
     end
 
     def query_as(var)

--- a/lib/neo4j/version.rb
+++ b/lib/neo4j/version.rb
@@ -1,3 +1,3 @@
 module Neo4j
-  VERSION = '9.5.2'
+  VERSION = '9.5.3'
 end

--- a/spec/e2e/active_rel/persistence/query_factory_spec.rb
+++ b/spec/e2e/active_rel/persistence/query_factory_spec.rb
@@ -96,30 +96,29 @@ describe Neo4j::ActiveRel::Persistence::QueryFactory do
         rel.save
       end
 
-      it 'deletes has_one rel from to_node before creating new one' do
+      it 'raises error when has_one rel from to_node is enforced' do
+        Neo4j::Config[:enforce_has_one] = true
         from_node_two = FromClass.new(name: 'foo-2')
         rel.save
-        RelClass.new(from_node: from_node_two, to_node: to_node, score: 10).save
-        expect(from_node.reload.to_classes).to be_empty
+        expect { RelClass.new(from_node: from_node_two, to_node: to_node, score: 10).save }.to raise_error(Neo4j::ActiveNode::HasN::HasOneValidationError)
       end
 
-      it 'deletes has_one rel from from_node before creating new one' do
+      it 'raises error when has_one rel from to_node is enforced' do
+        Neo4j::Config[:enforce_has_one] = true
         to_node_two = ToClass.new(name: 'bar-2')
         Rel2Class.new(from_node: from_node, to_node: to_node, score: 10).save
-        Rel2Class.new(from_node: from_node, to_node: to_node_two, score: 10).save
-        expect(to_node.reload.from_classes).to be_empty
+        expect { Rel2Class.new(from_node: from_node, to_node: to_node_two, score: 10).save }.to raise_error(Neo4j::ActiveNode::HasN::HasOneValidationError)
       end
 
-      it 'deletes correct has_one rel in case of two relationships with same type' do
+      it 'raises error when has_one rel is enforced and two relationships with same type' do
+        Neo4j::Config[:enforce_has_one] = true
         f1 = FromClass.new(name: 'foo-1')
         f2 = FromClass.new(name: 'foo-2')
         t1 = ToClass.new(name: 'bar-1')
         t2 = ToClass.new(name: 'bar-2')
         Rel3Class.new(from_node: f1, to_node: t1, score_3: 10).save
         Rel4Class.new(from_node: t2, to_node: f2, score_4: 10).save
-        Rel3Class.new(from_node: f2, to_node: t1, score_3: 100).save
-        expect(f1.reload.rel_3).to be_nil
-        expect(f2.reload.rel_3.id).to eq(t1.id)
+        expect { Rel3Class.new(from_node: f2, to_node: t1, score_3: 100).save }.to raise_error(Neo4j::ActiveNode::HasN::HasOneValidationError)
       end
     end
 

--- a/spec/e2e/active_rel/persistence/query_factory_spec.rb
+++ b/spec/e2e/active_rel/persistence/query_factory_spec.rb
@@ -100,14 +100,14 @@ describe Neo4j::ActiveRel::Persistence::QueryFactory do
         Neo4j::Config[:enforce_has_one] = true
         from_node_two = FromClass.new(name: 'foo-2')
         rel.save
-        expect { RelClass.new(from_node: from_node_two, to_node: to_node, score: 10).save }.to raise_error(Neo4j::ActiveNode::HasN::HasOneValidationError)
+        expect { RelClass.new(from_node: from_node_two, to_node: to_node, score: 10).save }.to raise_error(Neo4j::ActiveNode::HasN::HasOneConstraintError)
       end
 
       it 'raises error when has_one rel from to_node is enforced' do
         Neo4j::Config[:enforce_has_one] = true
         to_node_two = ToClass.new(name: 'bar-2')
         Rel2Class.new(from_node: from_node, to_node: to_node, score: 10).save
-        expect { Rel2Class.new(from_node: from_node, to_node: to_node_two, score: 10).save }.to raise_error(Neo4j::ActiveNode::HasN::HasOneValidationError)
+        expect { Rel2Class.new(from_node: from_node, to_node: to_node_two, score: 10).save }.to raise_error(Neo4j::ActiveNode::HasN::HasOneConstraintError)
       end
 
       it 'raises error when has_one rel is enforced and two relationships with same type' do
@@ -118,7 +118,7 @@ describe Neo4j::ActiveRel::Persistence::QueryFactory do
         t2 = ToClass.new(name: 'bar-2')
         Rel3Class.new(from_node: f1, to_node: t1, score_3: 10).save
         Rel4Class.new(from_node: t2, to_node: f2, score_4: 10).save
-        expect { Rel3Class.new(from_node: f2, to_node: t1, score_3: 100).save }.to raise_error(Neo4j::ActiveNode::HasN::HasOneValidationError)
+        expect { Rel3Class.new(from_node: f2, to_node: t1, score_3: 100).save }.to raise_error(Neo4j::ActiveNode::HasN::HasOneConstraintError)
       end
     end
 

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -382,20 +382,28 @@ describe 'Association Proxy' do
       end
     end
 
-    it 'updates inverse has_one association correctly' do
+    it 'raises error in case of inverse has_one rel is enforced' do
+      Neo4j::Config[:enforce_has_one] = true
       person3 = Person.create(name: '3')
       person2 = Person.create(name: '2', children: [person3])
       person1 = Person.create(name: '1', children: [person2])
-      person1.update(children: [person2, person3.id])
-      expect(person3.as(:p).parent.count).to eq(1)
+      expect { person1.update(children: [person2, person3.id]) }.to raise_error(Neo4j::ActiveNode::HasN::HasOneValidationError)
     end
 
-    it 'updates inverse has_one association correctly in case of two relationships with same type' do
+    it 'raises error in case of inverse has_one rel is enforced and two relationships with same type' do
+      Neo4j::Config[:enforce_has_one] = true
       person1 = Person.create(name: 'person-1')
       person2 = Person.create(name: 'person-2')
       comment = Comment.create(text: 'test-comment-2', comment_owner: person1)
-      person2.owner_comments = [comment]
-      expect(comment.as(:c).comment_owner.count).to eq(1)
+      expect { person2.owner_comments = [comment] }.to raise_error(Neo4j::ActiveNode::HasN::HasOneValidationError)
+    end
+
+    it 'does not raises error in case of inverse has_one rel is not enforced' do
+      Neo4j::Config[:enforce_has_one] = false
+      person3 = Person.create(name: '3')
+      person2 = Person.create(name: '2', children: [person3])
+      person1 = Person.create(name: '1', children: [person2])
+      expect { person1.update(children: [person2, person3.id]) }.not_to raise_error(Neo4j::ActiveNode::HasN::HasOneValidationError)
     end
   end
 end

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -387,7 +387,7 @@ describe 'Association Proxy' do
       person3 = Person.create(name: '3')
       person2 = Person.create(name: '2', children: [person3])
       person1 = Person.create(name: '1', children: [person2])
-      expect { person1.update(children: [person2, person3.id]) }.to raise_error(Neo4j::ActiveNode::HasN::HasOneValidationError)
+      expect { person1.update(children: [person2, person3.id]) }.to raise_error(Neo4j::ActiveNode::HasN::HasOneConstraintError)
     end
 
     it 'raises error in case of inverse has_one rel is enforced and two relationships with same type' do
@@ -395,7 +395,7 @@ describe 'Association Proxy' do
       person1 = Person.create(name: 'person-1')
       person2 = Person.create(name: 'person-2')
       comment = Comment.create(text: 'test-comment-2', comment_owner: person1)
-      expect { person2.owner_comments = [comment] }.to raise_error(Neo4j::ActiveNode::HasN::HasOneValidationError)
+      expect { person2.owner_comments = [comment] }.to raise_error(Neo4j::ActiveNode::HasN::HasOneConstraintError)
     end
 
     it 'does not raises error in case of inverse has_one rel is not enforced' do
@@ -403,7 +403,7 @@ describe 'Association Proxy' do
       person3 = Person.create(name: '3')
       person2 = Person.create(name: '2', children: [person3])
       person1 = Person.create(name: '1', children: [person2])
-      expect { person1.update(children: [person2, person3.id]) }.not_to raise_error(Neo4j::ActiveNode::HasN::HasOneValidationError)
+      expect { person1.update(children: [person2, person3.id]) }.not_to raise_error(Neo4j::ActiveNode::HasN::HasOneConstraintError)
     end
   end
 end


### PR DESCRIPTION
Fixes #1566 

This pull introduces/changes:
 * confing flag `enforce_has_one`.  When flag is set, as the relationship is created on reverse object with another object, raises the error.
 * by default flag is not set



