### PR TITLE
CI: Drop unused Travis sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ script:
   - "travis_retry bin/rake default --trace"
 language: ruby
 cache: bundler
-sudo: false
 jdk: openjdk8
 rvm:
   - 2


### PR DESCRIPTION

This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).



