### PR TITLE
Restricting activemodel and activesupport version to < 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Fixed
 
 - Enforces has_one uniqness constraint on relationship with config flag. (#1566)
+- Restricting activemodel and activesupport version to < 6.0.
 
 ## [9.5.2] 2019-08-06
 

--- a/neo4j.gemspec
+++ b/neo4j.gemspec
@@ -33,8 +33,8 @@ DESCRIPTION
     'bug_tracker_uri' => 'https://github.com/neo4jrb/neo4j/issues'
   }
 
-  s.add_dependency('activemodel', '>= 4.0')
-  s.add_dependency('activesupport', '>= 4.0')
+  s.add_dependency('activemodel', ['>= 4.0', '< 6'])
+  s.add_dependency('activesupport', ['>= 4.0', '< 6'])
   s.add_dependency('i18n', '!= 1.3.0') # version 1.3.0 introduced a bug with `symbolize_key`
   s.add_dependency('neo4j-core', '>= 9.0.0')
   s.add_dependency('orm_adapter', '~> 0.5.0')


### PR DESCRIPTION
Restricting activemodel and activesupport version to < 6.0.0 as gem is yet not compatible with rails 6.




