### PR TITLE
Fixes to support compatibility with Rails 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+## Fixed
+
+- supports activemodel and activesupport version 6.0.0
+
 ## [9.5.3] 2019-08-16
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [9.6.0] 2019-09-3
 
-## Fixed
+## Added
 
-- supports activemodel and activesupport version 6.0.0
+- support for activemodel and activesupport version 6
 
 ## [9.5.3] 2019-08-16
 

--- a/lib/neo4j/shared/initialize.rb
+++ b/lib/neo4j/shared/initialize.rb
@@ -27,8 +27,13 @@ module Neo4j::Shared
 
     # We should be using #clear_changes_information
     # but right now we don't use `ActiveModel` attributes correctly and so it doesn't work
+    # Once we set @attribute correctly from using class ActiveModel::Attribute
+    # we will no longer need to explicitly call following method and can safely remove it
     def changed_attributes_clear!
       return if changed_attributes.nil?
+
+      # with ActiveModel 6.0.0 we have to clear attribute changes with clear_attribute_changes
+      clear_attribute_changes(self.attributes.keys)
 
       # changed_attributes is frozen starting with ActiveModel 5.2.0
       # Not a good long term solution
@@ -39,7 +44,12 @@ module Neo4j::Shared
       end
     end
 
+    # Once we set @attribute correctly from using class ActiveModel::Attribute
+    # we will no longer need to explicitly call following method and can safely remove it
     def changed_attributes_selective_clear!(hash_to_clear)
+      # with ActiveModel 6.0.0 we have to clear attribute changes with clear_attribute_change
+      hash_to_clear.each_key { |k| clear_attribute_change(k) } if defined?(ActiveModel::ForcedMutationTracker)
+
       # changed_attributes is frozen starting with ActiveModel 5.2.0
       # Not a good long term solution
       if changed_attributes.frozen?

--- a/lib/neo4j/shared/persistence.rb
+++ b/lib/neo4j/shared/persistence.rb
@@ -242,7 +242,14 @@ module Neo4j::Shared
                                  .pluck("#{element_name}.`#{attribute}`").first
       return false unless new_attribute
       self[attribute] = new_attribute
-      set_attribute_was(attribute, new_attribute)
+
+      if defined? ActiveModel::ForcedMutationTracker
+        # with ActiveModel 6.0.0 set_attribute_was is removed
+        # so we mark attribute's previous value using attr_will_change method
+        clear_attribute_change(attribute)
+      else
+        set_attribute_was(attribute, new_attribute)
+      end
       true
     end
 

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -11,8 +11,11 @@ module Neo4j::Shared
 
     attr_reader :_persisted_obj
 
+    # TODO: Set @attribute correctly using class ActiveModel::Attribute, and after that
+    # remove mutations_from_database and other ActiveModel::Dirty overrided methods
     def mutations_from_database
-      ActiveModel::NullMutationTracker.instance
+      @mutations_from_database ||=
+        defined?(ActiveModel::ForcedMutationTracker) ? ActiveModel::ForcedMutationTracker.new(self) : ActiveModel::NullMutationTracker.instance
     end
 
     def inspect
@@ -210,7 +213,7 @@ module Neo4j::Shared
         attributes[name.to_s] = declared_properties[name]
         define_method("#{name}=") do |value|
           typecast_value = typecast_attribute(_attribute_typecaster(name), value)
-          send("#{name}_will_change!") unless typecast_value == read_attribute(name)
+          send("#{name}_will_change!") if typecast_value != read_attribute(name)
           super(value)
         end
       end

--- a/lib/neo4j/shared/property.rb
+++ b/lib/neo4j/shared/property.rb
@@ -213,7 +213,7 @@ module Neo4j::Shared
         attributes[name.to_s] = declared_properties[name]
         define_method("#{name}=") do |value|
           typecast_value = typecast_attribute(_attribute_typecaster(name), value)
-          send("#{name}_will_change!") if typecast_value != read_attribute(name)
+          send("#{name}_will_change!") unless typecast_value == read_attribute(name)
           super(value)
         end
       end

--- a/neo4j.gemspec
+++ b/neo4j.gemspec
@@ -33,8 +33,8 @@ DESCRIPTION
     'bug_tracker_uri' => 'https://github.com/neo4jrb/neo4j/issues'
   }
 
-  s.add_dependency('activemodel', ['>= 4.0', '< 6'])
-  s.add_dependency('activesupport', ['>= 4.0', '< 6'])
+  s.add_dependency('activemodel', '>= 4.0')
+  s.add_dependency('activesupport', '>= 4.0')
   s.add_dependency('i18n', '!= 1.3.0') # version 1.3.0 introduced a bug with `symbolize_key`
   s.add_dependency('neo4j-core', '>= 9.0.0')
   s.add_dependency('orm_adapter', '~> 0.5.0')


### PR DESCRIPTION
Fixes issue of gem not being compatible with rails 6.

This pull introduces/changes:
 * modified `mutations_from_database` to return `ActiveModel::ForcedMutationTracker` instead of `ActiveModel::NullMutationTracker`, as later was removed in ActiveModel 6.0.0
 * some other methods are replaced with new methods as they got removed in ActiveModel 6.0.0
 * changes in gemspec to allow newer versions of `activemodel` and `activesupport`



