### PR TITLE
Fixed warnings of mentioning specific exceptions in rspec

### DIFF
--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -184,7 +184,7 @@ describe 'Association Proxy' do
     end
 
     it 'Raises error if attempting to deep eager load "past" a polymorphic association' do
-      expect { math.students.with_associations(homework: :lessons) }.to raise_error
+      expect { math.students.with_associations(homework: :lessons) }.to raise_error(RuntimeError, /Cannot eager load "past" a polymorphic association/)
     end
 
     it 'Queries limited times in depth two loops' do
@@ -403,7 +403,7 @@ describe 'Association Proxy' do
       person3 = Person.create(name: '3')
       person2 = Person.create(name: '2', children: [person3])
       person1 = Person.create(name: '1', children: [person2])
-      expect { person1.update(children: [person2, person3.id]) }.not_to raise_error(Neo4j::ActiveNode::HasN::HasOneConstraintError)
+      expect { person1.update(children: [person2, person3.id]) }.not_to raise_error
     end
   end
 end

--- a/spec/e2e/undeclared_properties_spec.rb
+++ b/spec/e2e/undeclared_properties_spec.rb
@@ -32,7 +32,7 @@ describe Neo4j::ActiveNode do
 
   describe 'save' do
     it 'does not raise Neo4j::Shared::UnknownAttributeError if trying to set undeclared property' do
-      expect { Person.new[:foo] = 42 }.not_to raise_error(Neo4j::UnknownAttributeError)
+      expect { Person.new[:foo] = 42 }.not_to raise_error
     end
 
     it 'saves undeclared the properties that has been changed with []= operator' do


### PR DESCRIPTION
Fixes 3 warning related to mentioning specific exception class while running test cases

This pull introduces/changes:

**1. neo4j/spec/e2e/association_proxy_spec.rb:406**
> WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. NoMethodError, NameError and ArgumentError), meaning the code you are intending to test may not even get reached.
> Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`.
> This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`.
> Called from neo4j/spec/e2e/association_proxy_spec.rb:406:in `block (3 levels) in <top (required)>'.
> 

**2. neo4j/spec/e2e/association_proxy_spec.rb:187**
> WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call.
>  Actual error raised was #<RuntimeError: Cannot eager load "past" a polymorphic association.               (Since the association can return multiple models, we don't how to handle the "lessons" association.)>.
> Instead consider providing a specific error class or message.
> This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from neo4j/spec/e2e/association_proxy_spec.rb:187:in `block (3 levels) in <top (required)>'.
> 

**3. neo4j/spec/e2e/undeclared_properties_spec.rb:35**
> WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. NoMethodError, NameError and ArgumentError), meaning the code you are intending to test may not even get reached.
> Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`.
> This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`.
> Called from neo4j/spec/e2e/undeclared_properties_spec.rb:35:in `block (3 levels) in <top (required)>'.

