### PR TITLE
Executing relationship callbacks on relationship deletion and respecting has_one constraint on relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This file should follow the standards specified on [http://keepachangelog.com/]
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [10.0.x] 2020-01-23
+
+- Enforcing has_one constraint on relationships.
+
 ## [9.6.1] 2019-12-18
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [10.0.x] 2020-01-23
 
-- Enforcing has_one constraint on relationships.
+- Executing relationship callbacks on relationship deletion.
+- When assiging relationships, preserving earlier relationships.
+- Enforcing has one constraint on relationships.
 
 ## [9.6.1] 2019-12-18
 

--- a/config/neo4j/config.yml
+++ b/config/neo4j/config.yml
@@ -33,6 +33,3 @@ cache_class_names: true
 # class_name_property:  :_classname
 
 transform_rel_type: :upcase
-
-# Enforce has_one relationship. When same reationship is created on reverse object with another object, raise the error.
-enforce_has_one: false

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -105,10 +105,6 @@ Variables
     **Default:** ``false``
 
     Specifies that queries outputted to the log also get a source file / line outputted to aid debugging.
-  **enforce_has_one**
-    **Default:** ``false``
-
-    If true raises an error if any operation would violate the uniqueness of a `has_one` relationship. Requires that associations are defined from both sides and that one side uses `origin:` in the definition.
 
 Instrumented events
 ~~~~~~~~~~~~~~~~~~~

--- a/lib/neo4j.rb
+++ b/lib/neo4j.rb
@@ -61,6 +61,7 @@ require 'neo4j/active_rel/related_node'
 require 'neo4j/active_rel/types'
 require 'neo4j/active_rel'
 
+require 'neo4j/active_node/dependent_callbacks'
 require 'neo4j/active_node/node_list_formatter'
 require 'neo4j/active_node/dependent'
 require 'neo4j/active_node/dependent/query_proxy_methods'

--- a/lib/neo4j/active_node.rb
+++ b/lib/neo4j/active_node.rb
@@ -45,6 +45,7 @@ module Neo4j
     include Neo4j::ActiveNode::Dependent
     include Neo4j::ActiveNode::Enum
     include Neo4j::Shared::PermittedAttributes
+    include Neo4j::ActiveNode::DependentCallbacks
 
     def initialize(args = nil)
       self.class.ensure_id_property_info! # So that we make sure all objects have an id_property

--- a/lib/neo4j/active_node/dependent/association_methods.rb
+++ b/lib/neo4j/active_node/dependent/association_methods.rb
@@ -14,27 +14,6 @@ module Neo4j
           raise "Unknown dependent option #{dependent}"
         end
 
-        # Callback methods
-        def dependent_delete_callback(object, ids = [])
-          object.association_query_proxy(name).delete_all
-        end
-
-        def dependent_delete_orphans_callback(object, ids = [])
-          unique_query = object.as(:self).unique_nodes(self, :self, :n, :other_rel, ids)
-          unique_query.query.optional_match('(n)-[r]-()').delete(:n, :r).exec if unique_query
-        end
-
-        def dependent_destroy_callback(object, ids = [])
-          unique_query = object.association_query_proxy(name)
-          unique_query.each_for_destruction(object, &:destroy) if unique_query
-        end
-
-        def dependent_destroy_orphans_callback(object, ids = [])
-          unique_query = object.as(:self).unique_nodes(self, :self, :n, :other_rel, ids)
-          unique_query.each_for_destruction(object, &:destroy) if unique_query
-        end
-        # End callback methods
-
         private
 
         def valid_dependent_value?(value)
@@ -42,6 +21,28 @@ module Neo4j
 
           self.respond_to?("dependent_#{value}_callback", true)
         end
+
+        # Callback methods
+        def dependent_delete_callback(object)
+          object.association_query_proxy(name).delete_all
+        end
+
+        def dependent_delete_orphans_callback(object)
+          unique_query = object.as(:self).unique_nodes(self, :self, :n, :other_rel)
+          unique_query.query.optional_match('(n)-[r]-()').delete(:n, :r).exec if unique_query
+        end
+
+        def dependent_destroy_callback(object)
+          unique_query = object.association_query_proxy(name)
+          unique_query.each_for_destruction(object, &:destroy) if unique_query
+        end
+
+        def dependent_destroy_orphans_callback(object)
+          unique_query = object.as(:self).unique_nodes(self, :self, :n, :other_rel)
+          unique_query.each_for_destruction(object, &:destroy) if unique_query
+        end
+
+        # End callback methods
       end
     end
   end

--- a/lib/neo4j/active_node/dependent/association_methods.rb
+++ b/lib/neo4j/active_node/dependent/association_methods.rb
@@ -14,6 +14,27 @@ module Neo4j
           raise "Unknown dependent option #{dependent}"
         end
 
+        # Callback methods
+        def dependent_delete_callback(object, ids = [])
+          object.association_query_proxy(name).delete_all
+        end
+
+        def dependent_delete_orphans_callback(object, ids = [])
+          unique_query = object.as(:self).unique_nodes(self, :self, :n, :other_rel, ids)
+          unique_query.query.optional_match('(n)-[r]-()').delete(:n, :r).exec if unique_query
+        end
+
+        def dependent_destroy_callback(object, ids = [])
+          unique_query = object.association_query_proxy(name)
+          unique_query.each_for_destruction(object, &:destroy) if unique_query
+        end
+
+        def dependent_destroy_orphans_callback(object, ids = [])
+          unique_query = object.as(:self).unique_nodes(self, :self, :n, :other_rel, ids)
+          unique_query.each_for_destruction(object, &:destroy) if unique_query
+        end
+        # End callback methods
+
         private
 
         def valid_dependent_value?(value)
@@ -21,28 +42,6 @@ module Neo4j
 
           self.respond_to?("dependent_#{value}_callback", true)
         end
-
-        # Callback methods
-        def dependent_delete_callback(object)
-          object.association_query_proxy(name).delete_all
-        end
-
-        def dependent_delete_orphans_callback(object)
-          unique_query = object.as(:self).unique_nodes(self, :self, :n, :other_rel)
-          unique_query.query.optional_match('(n)-[r]-()').delete(:n, :r).exec if unique_query
-        end
-
-        def dependent_destroy_callback(object)
-          unique_query = object.association_query_proxy(name)
-          unique_query.each_for_destruction(object, &:destroy) if unique_query
-        end
-
-        def dependent_destroy_orphans_callback(object)
-          unique_query = object.as(:self).unique_nodes(self, :self, :n, :other_rel)
-          unique_query.each_for_destruction(object, &:destroy) if unique_query
-        end
-
-        # End callback methods
       end
     end
   end

--- a/lib/neo4j/active_node/dependent/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/dependent/query_proxy_methods.rb
@@ -26,24 +26,25 @@ module Neo4j
         # @param [String, Symbol] other_node The identifier to use for the other end of the chain.
         # @param [String, Symbol] other_rel The identifier to use for the relationship in the optional match.
         # @return [Neo4j::ActiveNode::Query::QueryProxy]
-        def unique_nodes(association, self_identifer, other_node, other_rel)
+        def unique_nodes(association, self_identifer, other_node, other_rel, ids = [])
           fail 'Only supported by in QueryProxy chains started by an instance' unless source_object
           return false if send(association.name).empty?
-          unique_nodes_query(association, self_identifer, other_node, other_rel)
+          unique_nodes_query(association, self_identifer, other_node, other_rel, ids)
             .proxy_as(association.target_class, other_node)
         end
 
         private
 
-        def unique_nodes_query(association, self_identifer, other_node, other_rel)
-          query.with(identity).proxy_as_optional(source_object.class, self_identifer)
-               .send(association.name, other_node, other_rel)
-               .query
-               .with(other_node)
-               .match("()#{association.arrow_cypher(:orphan_rel)}(#{other_node})")
-               .with(other_node, count: 'count(*)')
-               .where('count = {one}', one: 1)
-               .break
+        def unique_nodes_query(association, self_identifer, other_node, other_rel, ids)
+          base = query.with(identity).proxy_as_optional(source_object.class, self_identifer)
+                      .send(association.name, other_node, other_rel)
+          base = base.where(id: ids) if ids.present?
+          base.query
+              .with(other_node)
+              .match("()#{association.arrow_cypher(:orphan_rel)}(#{other_node})")
+              .with(other_node, count: 'count(*)')
+              .where('count = {one}', one: 1)
+              .break
         end
       end
     end

--- a/lib/neo4j/active_node/dependent/query_proxy_methods.rb
+++ b/lib/neo4j/active_node/dependent/query_proxy_methods.rb
@@ -43,7 +43,7 @@ module Neo4j
               .with(other_node)
               .match("()#{association.arrow_cypher(:orphan_rel)}(#{other_node})")
               .with(other_node, count: 'count(*)')
-              .where('count = {one}', one: 1)
+              .where('count = $one', one: 1)
               .break
         end
       end

--- a/lib/neo4j/active_node/dependent_callbacks.rb
+++ b/lib/neo4j/active_node/dependent_callbacks.rb
@@ -13,7 +13,7 @@ module Neo4j
       end
 
       def dependent_destroy_callback(association, ids)
-        unique_query = association_query_proxy(association.name).where(ids: ids)
+        unique_query = association_query_proxy(association.name).where(id: ids)
         unique_query.each_for_destruction(self, &:destroy) if unique_query
       end
 

--- a/lib/neo4j/active_node/dependent_callbacks.rb
+++ b/lib/neo4j/active_node/dependent_callbacks.rb
@@ -24,7 +24,7 @@ module Neo4j
 
       def callbacks_from_active_rel(active_rel, direction, other_node)
         rel = active_rel_corresponding_rel(active_rel, direction, other_node.class).try(:last)
-        public_send("dependent_#{rel.dependent}_callback", rel, [other_node.id]) if rel.dependent
+        public_send("dependent_#{rel.dependent}_callback", rel, [other_node.id]) if rel && rel.dependent
       end
     end
   end

--- a/lib/neo4j/active_node/dependent_callbacks.rb
+++ b/lib/neo4j/active_node/dependent_callbacks.rb
@@ -1,0 +1,31 @@
+module Neo4j
+  module ActiveNode
+    module DependentCallbacks
+      extend ActiveSupport::Concern
+
+      def dependent_delete_callback(association, ids)
+        association_query_proxy(association.name).where(id: ids).delete_all
+      end
+
+      def dependent_delete_orphans_callback(association, ids)
+        unique_query = as(:self).unique_nodes(association, :self, :n, :other_rel, ids)
+        unique_query.query.optional_match('(n)-[r]-()').delete(:n, :r).exec if unique_query
+      end
+
+      def dependent_destroy_callback(association, ids)
+        unique_query = association_query_proxy(association.name).where(ids: ids)
+        unique_query.each_for_destruction(self, &:destroy) if unique_query
+      end
+
+      def dependent_destroy_orphans_callback(association, ids)
+        unique_query = as(:self).unique_nodes(association, :self, :n, :other_rel, ids)
+        unique_query.each_for_destruction(self, &:destroy) if unique_query
+      end
+
+      def callbacks_from_active_rel(active_rel, direction, other_node)
+        rel = active_rel_corresponding_rel(active_rel, direction, other_node.class).try(:last)
+        public_send("dependent_#{rel.dependent}_callback", rel, [other_node.id]) if rel.dependent
+      end
+    end
+  end
+end

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -229,10 +229,9 @@ module Neo4j::ActiveNode
       end
     end
 
-    def validate_reverse_has_one_core_rel(association, other_node)
-      return unless Neo4j::Config[:enforce_has_one]
+    def delete_reverse_has_one_core_rel(association, other_node)
       reverse_assoc = reverse_association(association)
-      validate_has_one_rel!(reverse_assoc, other_node) if reverse_assoc && reverse_assoc.type == :has_one
+      delete_has_one_rel!(reverse_assoc, other_node) if reverse_assoc && reverse_assoc.type == :has_one
     end
 
     def reverse_association(association)
@@ -242,14 +241,14 @@ module Neo4j::ActiveNode
       reverse_assoc && reverse_assoc.last
     end
 
-    def validate_reverse_has_one_active_rel(active_rel, direction, other_node)
+    def delete_reverse_has_one_active_rel(active_rel, direction, other_node)
       rel = active_rel_corresponding_rel(active_rel, direction, other_node.class)
-      validate_has_one_rel!(rel.last, other_node) if rel && rel.last.type == :has_one
+      delete_has_one_rel!(rel.last, other_node) if rel && rel.last.type == :has_one
     end
 
-    def validate_has_one_rel!(rel, other_node)
-      raise_error = (node = send(rel.name.to_s)) && node != other_node
-      fail(HasOneConstraintError, "node #{self.class}##{neo_id} has a has_one relationship with #{other_node.class}##{other_node.neo_id}") if raise_error
+    def delete_has_one_rel!(rel)
+      send("#{rel.name}=", nil)
+      association_proxy_cache.clear
     end
 
     def active_rel_corresponding_rel(active_rel, direction, target_class)

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -247,7 +247,7 @@ module Neo4j::ActiveNode
     end
 
     def delete_has_one_rel!(rel)
-      send("#{rel.name}=", nil)
+      send("#{rel.name}", :n, :r, chainable: true).query.delete(:r).exec
       association_proxy_cache.clear
     end
 

--- a/lib/neo4j/active_node/has_n.rb
+++ b/lib/neo4j/active_node/has_n.rb
@@ -229,9 +229,9 @@ module Neo4j::ActiveNode
       end
     end
 
-    def delete_reverse_has_one_core_rel(association, other_node)
+    def delete_reverse_has_one_core_rel(association)
       reverse_assoc = reverse_association(association)
-      delete_has_one_rel!(reverse_assoc, other_node) if reverse_assoc && reverse_assoc.type == :has_one
+      delete_has_one_rel!(reverse_assoc) if reverse_assoc && reverse_assoc.type == :has_one
     end
 
     def reverse_association(association)
@@ -243,7 +243,7 @@ module Neo4j::ActiveNode
 
     def delete_reverse_has_one_active_rel(active_rel, direction, other_node)
       rel = active_rel_corresponding_rel(active_rel, direction, other_node.class)
-      delete_has_one_rel!(rel.last, other_node) if rel && rel.last.type == :has_one
+      delete_has_one_rel!(rel.last) if rel && rel.last.type == :has_one
     end
 
     def delete_has_one_rel!(rel)

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -208,7 +208,7 @@ module Neo4j
           Neo4j::ActiveBase.run_transaction do
             other_nodes.each do |other_node|
               if other_node.neo_id
-                other_node.try(:delete_reverse_has_one_core_rel, association, @start_object)
+                other_node.try(:delete_reverse_has_one_core_rel, association)
               else
                 other_node.save
               end

--- a/lib/neo4j/active_node/query/query_proxy.rb
+++ b/lib/neo4j/active_node/query/query_proxy.rb
@@ -208,7 +208,7 @@ module Neo4j
           Neo4j::ActiveBase.run_transaction do
             other_nodes.each do |other_node|
               if other_node.neo_id
-                other_node.try(:validate_reverse_has_one_core_rel, association, @start_object)
+                other_node.try(:delete_reverse_has_one_core_rel, association, @start_object)
               else
                 other_node.save
               end

--- a/lib/neo4j/active_node/query/query_proxy_methods_of_mass_updating.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods_of_mass_updating.rb
@@ -49,13 +49,37 @@ module Neo4j
         # Deletes the relationships between all nodes for the last step in the QueryProxy chain and replaces them with relationships to the given nodes.
         # Executed in the database, callbacks will not be run.
         def replace_with(node_or_nodes)
-          nodes = Array(node_or_nodes)
+          node_hash = idify_hash(node_or_nodes)
+          original_ids = self.pluck(:id)
+          new_nodes = add_rels(node_hash, original_ids)
+          delete_rels_for_nodes(original_ids - node_hash.keys)
+          new_nodes | node_hash.values
+        end
 
-          self.delete_all_rels
-          nodes.map do |node|
-            node if _create_relation_or_defer(node)
+        def idify_hash(args)
+          [args].compact.flatten.each_with_object({}).with_index do |(arg, hash), inx|
+            if arg.is_a?(Integer) || arg.is_a?(String)
+              hash[arg.to_i] = @model.find(arg)
+            else
+              key = arg.persisted? ? arg.id : "tmp_#{inx}"
+              hash[key] = arg
+            end
+          end
+        end
+
+        def add_rels(node_hash, original_ids)
+          (node_hash.keys - original_ids).map do |id|
+            node_hash[id] if _create_relation_or_defer(node_hash[id])
           end.compact
-          # nodes.each { |node| self << node }
+        end
+
+        def delete_rels_for_nodes(ids)
+          return unless ids.present?
+          if association.dependent
+            association.public_send("dependent_#{association.dependent}_callback", start_object, ids)
+          else
+            self.where(id: ids).delete_all_rels
+          end
         end
 
         # Returns all relationships between a node and its last link in the QueryProxy chain, destroys them in Ruby. Callbacks will be run.

--- a/lib/neo4j/active_node/query/query_proxy_methods_of_mass_updating.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods_of_mass_updating.rb
@@ -57,7 +57,7 @@ module Neo4j
         end
 
         def idify_hash(args)
-          [args].compact.flatten.each_with_object({}).with_index do |(arg, hash), inx|
+          Array(args).reject(&:blank?).flatten.each_with_object({}).with_index do |(arg, hash), inx|
             if arg.is_a?(Integer) || arg.is_a?(String)
               hash[arg.to_i] = @model.find(arg)
             else

--- a/lib/neo4j/active_node/query/query_proxy_methods_of_mass_updating.rb
+++ b/lib/neo4j/active_node/query/query_proxy_methods_of_mass_updating.rb
@@ -76,7 +76,7 @@ module Neo4j
         def delete_rels_for_nodes(ids)
           return unless ids.present?
           if association.dependent
-            association.public_send("dependent_#{association.dependent}_callback", start_object, ids)
+            start_object.public_send("dependent_#{association.dependent}_callback", association, ids)
           else
             self.where(id: ids).delete_all_rels
           end

--- a/lib/neo4j/active_rel/callbacks.rb
+++ b/lib/neo4j/active_rel/callbacks.rb
@@ -10,6 +10,12 @@ module Neo4j
         end
         super(*args)
       end
+
+      def destroy
+        to_node.callbacks_from_active_rel(self, :in, from_node).try(:last)
+        from_node.callbacks_from_active_rel(self, :out, to_node).try(:last)
+        super
+      end
     end
   end
 end

--- a/lib/neo4j/active_rel/persistence.rb
+++ b/lib/neo4j/active_rel/persistence.rb
@@ -45,17 +45,16 @@ module Neo4j::ActiveRel
 
     def create_model
       validate_node_classes!
-      validate_has_one_rel
+      delete_has_one_rel
       rel = _create_rel
       return self unless rel.respond_to?(:props)
       init_on_load(rel, from_node, to_node, @rel_type)
       true
     end
 
-    def validate_has_one_rel
-      return unless Neo4j::Config[:enforce_has_one]
-      to_node.validate_reverse_has_one_active_rel(self, :in, from_node) if to_node.persisted?
-      from_node.validate_reverse_has_one_active_rel(self, :out, to_node) if from_node.persisted?
+    def delete_has_one_rel
+      to_node.delete_reverse_has_one_active_rel(self, :in, from_node) if to_node.persisted?
+      from_node.delete_reverse_has_one_active_rel(self, :out, to_node) if from_node.persisted?
     end
 
     def query_as(var)

--- a/spec/e2e/association_dependency_spec.rb
+++ b/spec/e2e/association_dependency_spec.rb
@@ -39,7 +39,7 @@ describe 'association dependent delete/destroy' do
       has_many :out, :comments, model_class: 'Comment', type: 'HAS_COMMENT', dependent: :delete_orphans
       has_one :out, :poorly_modeled_thing, model_class: 'BadModel', type: 'HAS_TERRIBLE_MODEL', dependent: :delete
       has_many :out, :poorly_modeled_things, model_class: 'BadModel', type: 'HAS_TERRIBLE_MODELS', dependent: :delete
-      has_many :out, :poorly_modeled_things_2, rel_class: 'MyRelClass'#, dependent: :destroy
+      has_many :out, :poorly_modeled_things_2, rel_class: 'MyRelClass', dependent: :destroy
     end
 
     stub_active_node_class('Band') do

--- a/spec/e2e/association_dependency_spec.rb
+++ b/spec/e2e/association_dependency_spec.rb
@@ -39,7 +39,10 @@ describe 'association dependent delete/destroy' do
       has_many :out, :comments, model_class: 'Comment', type: 'HAS_COMMENT', dependent: :delete_orphans
       has_one :out, :poorly_modeled_thing, model_class: 'BadModel', type: 'HAS_TERRIBLE_MODEL', dependent: :delete
       has_many :out, :poorly_modeled_things, model_class: 'BadModel', type: 'HAS_TERRIBLE_MODELS', dependent: :delete
-      has_many :out, :poorly_modeled_things_2, rel_class: 'MyRelClass', dependent: :destroy
+      has_many :out, :things, rel_class: 'MyRelClass', dependent: :destroy
+      has_many :out, :things_2, rel_class: 'MyRelClass2', dependent: :destroy_orphans
+      has_many :out, :things_3, rel_class: 'MyRelClass3', dependent: :delete
+      has_many :out, :things_4, rel_class: 'MyRelClass4', dependent: :delete_orphans
     end
 
     stub_active_node_class('Band') do
@@ -55,6 +58,9 @@ describe 'association dependent delete/destroy' do
       has_one :out, :user, model_class: 'User', type: 'HAS_A_USER', dependent: :destroy
       has_many :out, :users, model_class: 'User', type: 'HAS_USERS', dependent: :destroy
       has_many :in, :stops, rel_class: 'MyRelClass', dependent: :destroy
+      has_many :in, :stops_2, rel_class: 'MyRelClass2'
+      has_many :in, :stops_3, rel_class: 'MyRelClass3'
+      has_many :in, :stops_4, rel_class: 'MyRelClass4'
     end
 
     stub_active_node_class('Comment') do
@@ -69,6 +75,24 @@ describe 'association dependent delete/destroy' do
       from_class :Stop
       to_class :BadModel
       type 'rel_class_type'
+    end
+
+    stub_active_rel_class('MyRelClass2') do
+      from_class :Stop
+      to_class :BadModel
+      type 'rel_class_type_2'
+    end
+
+    stub_active_rel_class('MyRelClass3') do
+      from_class :Stop
+      to_class :BadModel
+      type 'rel_class_type_3'
+    end
+
+    stub_active_rel_class('MyRelClass4') do
+      from_class :Stop
+      to_class :BadModel
+      type 'rel_class_type_4'
     end
   end
 
@@ -114,25 +138,112 @@ describe 'association dependent delete/destroy' do
     end
 
     context 'delete relationships' do
-      let(:band) { Band.create }
-      let(:other_band) { Band.create }
-      before { node.bands << band }
+      context 'dependent destroy_orphans' do
+        let(:orphan_band) { Band.create }
+        let(:non_orphan_band) { Band.create }
+        let(:other_band) { Band.create }
+        let(:user_2) { User.create(bands: [non_orphan_band]) }
+        before do
+          node.bands = [orphan_band, non_orphan_band]
+          user_2
+        end
 
-      it 'deletes orphans' do
-        node.bands = [other_band]
-        expect{Band.find(band.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+        it 'deletes only orphans' do
+          node.bands = [other_band]
+          expect{Band.find(orphan_band.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect{Band.find(non_orphan_band.id)}.not_to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+        end
+      end
+
+      context 'dependent destroy' do
+        let(:comment) { Comment.create }
+        let(:route) { Route.create(comments: [comment]) }
+        let(:tour) { Tour.create(routes: [route]) }
+        let(:route_2) { Route.create }
+        it 'cascades dependent destroy' do
+          tour.routes = [route_2]
+          expect{Route.find(route.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect{Comment.find(comment.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+        end
+      end
+
+      context 'dependent delete' do
+        let(:bad_model) { BadModel.create }
+        let(:bad_model_2) { BadModel.create }
+        let(:stop) { Stop.create(poorly_modeled_things: [bad_model]) }
+        let(:stop_2) { Stop.create(poorly_modeled_things: [bad_model]) }
+        it 'deletes dependent model node without cascade' do
+          stop.poorly_modeled_things = [bad_model_2]
+          expect{BadModel.find(bad_model.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect{Stop.find(stop_2.id)}.not_to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+        end
+      end
+
+      context 'dependent delete_orphans' do
+        let(:comment_1) { Comment.create }
+        let(:comment_2) { Comment.create }
+        let(:comment_3) { Comment.create }
+        let(:stop) { Stop.create(comments: [comment_1, comment_2]) }
+        let!(:stop_2) { Stop.create(comments: [comment_2]) }
+        it 'deletes only orphans' do
+          stop.comments = [comment_3]
+          expect{Comment.find(comment_1.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect{Comment.find(comment_2.id)}.not_to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+        end
       end
     end
 
-    context 'ActiveRel with dependent destroy' do
-      let(:bad_model) { BadModel.create }
-      let(:city) { Stop.create(city: 'AMB') }
-      let(:rel) { MyRelClass.create(from_node: city, to_node: bad_model) }
+    context 'destroy ActiveRel relationship' do
+      context 'dependent destroy' do
+        let(:bad_model) { BadModel.create }
+        let(:city) { Stop.create(city: 'AMB') }
+        let(:rel) { MyRelClass.create(from_node: city, to_node: bad_model) }
 
-      it 'destroys the BadModel and Stop on deletion of ActiveRel' do
-        rel.destroy
-        expect{Stop.find(city.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
-        expect{BadModel.find(bad_model.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+        it 'destroys the BadModel and Stop on deletion of ActiveRel' do
+          rel.destroy
+          expect{Stop.find(city.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect{BadModel.find(bad_model.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+        end
+      end
+
+      context 'dependent destroy orphans' do
+        let(:bad_model_1) { BadModel.create }
+        let(:city_1) { Stop.create(city: 'AMB') }
+        let(:bad_model_2) { BadModel.create }
+        let(:city_2) { Stop.create(city: 'UNR') }
+        let(:rel_1) { MyRelClass2.create(from_node: city_1, to_node: bad_model_1) }
+        let!(:rel_2) { MyRelClass2.create(from_node: city_1, to_node: bad_model_2) }
+        let!(:rel_3) { MyRelClass2.create(from_node: city_2, to_node: bad_model_2) }
+        it 'deletes only orphans' do
+          rel_1.destroy
+          expect{BadModel.find(bad_model_1.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect{BadModel.find(bad_model_2.id)}.not_to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+        end
+      end
+
+      context 'dependent delete' do
+        let(:bad_model) { BadModel.create }
+        let(:city) { Stop.create(city: 'AMB') }
+        let(:rel) { MyRelClass3.create(from_node: city, to_node: bad_model) }
+        it 'deletes relationship object' do
+          rel.destroy
+          expect{BadModel.find(bad_model.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+        end
+      end
+
+      context 'dependent delete orphans' do
+        let(:bad_model_1) { BadModel.create }
+        let(:city_1) { Stop.create(city: 'AMB') }
+        let(:bad_model_2) { BadModel.create }
+        let(:city_2) { Stop.create(city: 'UNR') }
+        let(:rel_1) { MyRelClass4.create(from_node: city_1, to_node: bad_model_1) }
+        let!(:rel_2) { MyRelClass4.create(from_node: city_1, to_node: bad_model_2) }
+        let!(:rel_3) { MyRelClass4.create(from_node: city_2, to_node: bad_model_2) }
+        it 'deletes only orphans' do
+          rel_1.destroy
+          expect{BadModel.find(bad_model_1.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect{BadModel.find(bad_model_2.id)}.not_to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+        end
       end
     end
   end

--- a/spec/e2e/association_dependency_spec.rb
+++ b/spec/e2e/association_dependency_spec.rb
@@ -113,7 +113,6 @@ describe 'association dependent delete/destroy' do
       it 'deletes orphans' do
         node.bands = [other_band]
         expect{Band.find(band.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
-        expect(User.find(node).bands.to_a).to contain_exactly(other_band)
       end
     end
   end

--- a/spec/e2e/association_dependency_spec.rb
+++ b/spec/e2e/association_dependency_spec.rb
@@ -150,8 +150,8 @@ describe 'association dependent delete/destroy' do
 
         it 'deletes only orphans' do
           node.bands = [other_band]
-          expect{Band.find(orphan_band.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
-          expect{Band.find(non_orphan_band.id)}.not_to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect { Band.find(orphan_band.id) }.to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
+          expect { Band.find(non_orphan_band.id) }.not_to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
         end
       end
 
@@ -162,8 +162,8 @@ describe 'association dependent delete/destroy' do
         let(:route_2) { Route.create }
         it 'cascades dependent destroy' do
           tour.routes = [route_2]
-          expect{Route.find(route.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
-          expect{Comment.find(comment.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect { Route.find(route.id) }.to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
+          expect { Comment.find(comment.id) }.to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
         end
       end
 
@@ -174,8 +174,8 @@ describe 'association dependent delete/destroy' do
         let(:stop_2) { Stop.create(poorly_modeled_things: [bad_model]) }
         it 'deletes dependent model node without cascade' do
           stop.poorly_modeled_things = [bad_model_2]
-          expect{BadModel.find(bad_model.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
-          expect{Stop.find(stop_2.id)}.not_to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect { BadModel.find(bad_model.id) }.to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
+          expect { Stop.find(stop_2.id) }.not_to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
         end
       end
 
@@ -187,8 +187,8 @@ describe 'association dependent delete/destroy' do
         let!(:stop_2) { Stop.create(comments: [comment_2]) }
         it 'deletes only orphans' do
           stop.comments = [comment_3]
-          expect{Comment.find(comment_1.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
-          expect{Comment.find(comment_2.id)}.not_to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect { Comment.find(comment_1.id) }.to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
+          expect { Comment.find(comment_2.id) }.not_to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
         end
       end
     end
@@ -201,8 +201,8 @@ describe 'association dependent delete/destroy' do
 
         it 'destroys the BadModel and Stop on deletion of ActiveRel' do
           rel.destroy
-          expect{Stop.find(city.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
-          expect{BadModel.find(bad_model.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect { Stop.find(city.id) }.to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
+          expect { BadModel.find(bad_model.id) }.to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
         end
       end
 
@@ -216,8 +216,8 @@ describe 'association dependent delete/destroy' do
         let!(:rel_3) { MyRelClass2.create(from_node: city_2, to_node: bad_model_2) }
         it 'deletes only orphans' do
           rel_1.destroy
-          expect{BadModel.find(bad_model_1.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
-          expect{BadModel.find(bad_model_2.id)}.not_to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect { BadModel.find(bad_model_1.id) }.to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
+           expect { BadModel.find(bad_model_2.id) }.not_to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
         end
       end
 
@@ -227,7 +227,7 @@ describe 'association dependent delete/destroy' do
         let(:rel) { MyRelClass3.create(from_node: city, to_node: bad_model) }
         it 'deletes relationship object' do
           rel.destroy
-          expect{BadModel.find(bad_model.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect { BadModel.find(bad_model.id) }.to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
         end
       end
 
@@ -241,8 +241,8 @@ describe 'association dependent delete/destroy' do
         let!(:rel_3) { MyRelClass4.create(from_node: city_2, to_node: bad_model_2) }
         it 'deletes only orphans' do
           rel_1.destroy
-          expect{BadModel.find(bad_model_1.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
-          expect{BadModel.find(bad_model_2.id)}.not_to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+          expect { BadModel.find(bad_model_1.id) }.to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
+          expect { BadModel.find(bad_model_2.id) }.not_to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
         end
       end
     end

--- a/spec/e2e/association_dependency_spec.rb
+++ b/spec/e2e/association_dependency_spec.rb
@@ -104,6 +104,18 @@ describe 'association dependent delete/destroy' do
         node.destroy
       end
     end
+
+    context 'delete relationships' do
+      let(:band) { Band.create }
+      let(:other_band) { Band.create }
+      before { node.bands << band }
+
+      it 'deletes orphans' do
+        node.bands = [other_band]
+        expect{Band.find(band.id)}.to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+        expect(User.find(node).bands.to_a).to contain_exactly(other_band)
+      end
+    end
   end
 
   describe 'Grzesiek is booking a tour for his bands' do

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -398,16 +398,17 @@ describe 'Association Proxy' do
       end
     end
 
-    it 'raises error in case of inverse has_one rel is enforced' do
+    it 'deletes inverse has_one rel and does not call callbacks in inverse rel' do
       person3 = Person.create(name: '3')
       person2 = Person.create(name: '2', children: [person3])
       person1 = Person.create(name: '1', children: [person2])
       person1.update(children: [person2, person3.id])
 
       expect(person3.as(:p).parent.count).to eq(1)
+      expect{Person.find(person2.id)}.not_to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
     end
 
-    it 'raises error in case of inverse has_one rel is enforced and two relationships with same type' do
+    it 'deletes rel in case of inverse has_one rel and two relationships with same type' do
       person1 = Person.create(name: 'person-1')
       person2 = Person.create(name: 'person-2')
       comment = Comment.create(text: 'test-comment-2', comment_owner: person1)

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -399,27 +399,20 @@ describe 'Association Proxy' do
     end
 
     it 'raises error in case of inverse has_one rel is enforced' do
-      Neo4j::Config[:enforce_has_one] = true
       person3 = Person.create(name: '3')
       person2 = Person.create(name: '2', children: [person3])
       person1 = Person.create(name: '1', children: [person2])
-      expect { person1.update(children: [person2, person3.id]) }.to raise_error(Neo4j::ActiveNode::HasN::HasOneConstraintError)
+      person1.update(children: [person2, person3.id])
+
+      expect(person3.as(:p).parent.count).to eq(1)
     end
 
     it 'raises error in case of inverse has_one rel is enforced and two relationships with same type' do
-      Neo4j::Config[:enforce_has_one] = true
       person1 = Person.create(name: 'person-1')
       person2 = Person.create(name: 'person-2')
       comment = Comment.create(text: 'test-comment-2', comment_owner: person1)
-      expect { person2.owner_comments = [comment] }.to raise_error(Neo4j::ActiveNode::HasN::HasOneConstraintError)
-    end
-
-    it 'does not raises error in case of inverse has_one rel is not enforced' do
-      Neo4j::Config[:enforce_has_one] = false
-      person3 = Person.create(name: '3')
-      person2 = Person.create(name: '2', children: [person3])
-      person1 = Person.create(name: '1', children: [person2])
-      expect { person1.update(children: [person2, person3.id]) }.not_to raise_error
+      person2.owner_comments = [comment]
+      expect(comment.as(:c).comment_owner.count).to eq(1)
     end
   end
 end

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -405,7 +405,7 @@ describe 'Association Proxy' do
       person1.update(children: [person2, person3.id])
 
       expect(person3.as(:p).parent.count).to eq(1)
-      expect{Person.find(person2.id)}.not_to raise_error Neo4j::ActiveNode::Labels::RecordNotFound
+      expect { Person.find(person2.id) }.not_to raise_error(Neo4j::ActiveNode::Labels::RecordNotFound)
     end
 
     it 'deletes rel in case of inverse has_one rel and two relationships with same type' do

--- a/spec/e2e/association_proxy_spec.rb
+++ b/spec/e2e/association_proxy_spec.rb
@@ -57,6 +57,12 @@ describe 'Association Proxy' do
       expect(billy.lessons.exams_given).to respond_to(:to_ary)
     end
 
+    it 'does not recreate relatioship for existing relationships' do
+      rel_id = science.exams_given.where(id: science_exam.id).rel.id
+      science.exams_given = [science_exam]
+      expect(science.exams_given.rel.id).to eq(rel_id)
+    end
+
     it 'Should only make one query per association' do
       expect(billy.lessons.exams_given).to match_array([math_exam, science_exam, science_exam2])
 


### PR DESCRIPTION
Fixes :
 - Respecting has_one constraint on relationships.

Introduces :  
- Only deleting relationships that needs to be deleted.
- Executing relationship callbacks on deletion of relationship

This pull introduces/changes:
 * Respecting has_one constraint on relationships
 `User.has_many :snaps` and `Snap.has_one :user` `user_1.snaps = [snap]` and now if we do `user_2.snaps = [snap]` then the relationship between `user_1` and `snap` will be deleted, earlier this relationship would be preserved and we would end up with two relationships from snap to user, which would violate  `Snap.has_one :user`

 * Only deleting relationships that needs to be deleted. 
Given `User.has_many :snaps` and `user.snaps = [snap_1]`. Now if we do `user.snaps = [snap_1, snap_2]` then the relationship between `user` and `snap_1` would not be deleted. Earlier this would delete relationship between `user` and `snap_1` and create again.

 * Executing relationship callbacks on deletion of relationship
`User.has_many :snaps, dependent: :delete` and `user.snaps = [snap_1]`. This dependent callback would be only executed when `user` is deleted. Now this callback would be executed when the relationship between `user` and `snap_1` is also deleted. eg. `user.snaps = [snap_2]` would also delete `snap_1`.




