### PR TITLE
fixes #1705 by locking node while Assigning rel

### DIFF
--- a/lib/active_graph/transactions.rb
+++ b/lib/active_graph/transactions.rb
@@ -29,7 +29,7 @@ module ActiveGraph
       alias transaction write_transaction
 
       def lock_node(node)
-        node.as(:n).query.set('n._LOCK_ = null').exec if tx&.open? || explicit_session&.open?
+        node.as(:n).query.remove('n._LOCK_').exec if tx&.open? || explicit_session&.open?
       end
 
       private

--- a/lib/active_graph/transactions.rb
+++ b/lib/active_graph/transactions.rb
@@ -28,6 +28,10 @@ module ActiveGraph
 
       alias transaction write_transaction
 
+      def lock_node(node)
+        node.as(:n).query.set('n._LOCK_ = null').exec if tx&.open? || explicit_session&.open?
+      end
+
       private
 
       def send_transaction(method, **config, &block)

--- a/lib/active_graph/transactions.rb
+++ b/lib/active_graph/transactions.rb
@@ -29,7 +29,7 @@ module ActiveGraph
       alias transaction write_transaction
 
       def lock_node(node)
-        node.as(:n).query.remove('n._AGLOCK_').exec if tx&.open? || explicit_session&.open?
+        node.as(:n).query.remove('n._AGLOCK_').exec if tx&.open?
       end
 
       private

--- a/lib/active_graph/transactions.rb
+++ b/lib/active_graph/transactions.rb
@@ -29,7 +29,7 @@ module ActiveGraph
       alias transaction write_transaction
 
       def lock_node(node)
-        node.as(:n).query.remove('n._LOCK_').exec if tx&.open? || explicit_session&.open?
+        node.as(:n).query.remove('n._AGLOCK_').exec if tx&.open? || explicit_session&.open?
       end
 
       private

--- a/spec/e2e/relationship/persistence/query_factory_spec.rb
+++ b/spec/e2e/relationship/persistence/query_factory_spec.rb
@@ -103,56 +103,55 @@ describe ActiveGraph::Relationship::Persistence::QueryFactory do
         expect(from_node.reload.to_classes).to be_empty
       end
 
-      it 'does not create duplicate has_one relationship' do
-        from_node.save
-        to_node.save
-        begin
-          $concurrency_test = true
-          $concurrency_queue = Queue.new
-          $concurrency_test_wait = true
+      context 'concurrent update' do
+        before do
+          allow(ActiveGraph::Base).to receive(:lock_node).and_wrap_original do |original, *args|
+            $concurrency_queue << 'ready'
+            Thread.stop
+            original.call(*args)
+            $concurrency_queue << Thread.current
+            Thread.stop
+          end
+        end
+        after { $concurrency_queue = nil }
+        let!(:from_node) { FromClass.create(name: 'foo') }
+        let!(:to_node) { ToClass.create(name: 'bar') }
+        let(:from_node_two) { FromClass.create(name: 'foo-2') }
+
+        it 'does not create duplicate has_one relationship' do
+          $concurrency_queue = Thread::Queue.new
           t1 = Thread.new { to_node.update(from_class: from_node) }
           t2 = Thread.new { to_node.update(from_class: from_node) }
-          while $concurrency_queue.size < 2
-            # wait till both thread have complted read query
-            sleep 1
-          end
-          $concurrency_test_wait = false # make threads resume their work
-          [t1, t2].join # wait for the threads to finish
+          sleep(0.1) until $concurrency_queue.size == 2
+          $concurrency_queue.clear
+          [t1, t2].each(&:run)
+          sleep(0.1) until $concurrency_queue.size == 1 && t1.status == 'sleep' && t2.status == 'sleep'
+          $concurrency_queue.pop.run
+          sleep(0.1) until !(t1.status && t2.status)
 
-          # to_node.from_class only returns 1 result but in db there are two rels associated with this node
-          # this assertion fails with with result 2 proving the presence of bug
           expect(ActiveGraph::Base.query("MATCH (node2:`ToClass`)<-[rel1:`HAS_REL`]-(from_class:`FromClass`) return from_class").to_a.size).to eq(1)
-        ensure
-          $concurrency_test = nil
-          $concurrency_test_wait = nil
-          $concurrency_queue = nil
+          (t1.status == 'sleep' ? t1.run : t2.run).join
+          expect(ActiveGraph::Base.query("MATCH (node2:`ToClass`)<-[rel1:`HAS_REL`]-(from_class:`FromClass`) return from_class").to_a.size).to eq(1)
         end
-      end
 
-      it 'does not create two rels with different nodes in has_one relationship' do
-        from_node.save
-        to_node.save
-        from_node_two = FromClass.create(name: 'foo-2')
-        begin
-          $concurrency_test = true
-          $concurrency_queue = Queue.new
-          $concurrency_test_wait = true
+        it 'does not create two rels with different nodes in has_one relationship' do
+          $concurrency_queue = Thread::Queue.new
           t1 = Thread.new { to_node.update(from_class: from_node) }
           t2 = Thread.new { to_node.update(from_class: from_node_two) }
-          while $concurrency_queue.size < 2
-            # wait till both thread have complted read query
-            sleep 1
-          end
-          $concurrency_test_wait = false # make threads resume their work
-          [t1, t2].join # wait for the threads to finish
+          sleep(0.1) until $concurrency_queue.size == 2
+          $concurrency_queue.clear
+          [t1, t2].each(&:run)
+          sleep(0.1) until $concurrency_queue.size == 1 && t1.status == 'sleep' && t2.status == 'sleep'
+          $concurrency_queue.pop.run
+          sleep(0.1) until !(t1.status && t2.status)
 
-          # to_node.from_class only returns 1 result but in db there are two rels associated with this node
-          # this assertion fails with with result 2 proving the presence of bug
+          first_assigned_from_class, second_assigned_from_class = t1.status == 'sleep' ? [from_node_two, from_node] : [from_node, from_node_two]
+
+          expect(ToClass.find(to_node.id).from_class.id).to eq(first_assigned_from_class.id)
+          (t1.status == 'sleep' ? t1.run : t2.run).join
+
+          expect(to_node.reload.from_class.id).to eq(second_assigned_from_class.id)
           expect(ActiveGraph::Base.query("MATCH (node2:`ToClass`)<-[rel1:`HAS_REL`]-(from_class:`FromClass`) return from_class").to_a.size).to eq(1)
-        ensure
-          $concurrency_test = nil
-          $concurrency_test_wait = nil
-          $concurrency_queue = nil
         end
       end
 

--- a/spec/e2e/relationship/persistence/query_factory_spec.rb
+++ b/spec/e2e/relationship/persistence/query_factory_spec.rb
@@ -103,6 +103,58 @@ describe ActiveGraph::Relationship::Persistence::QueryFactory do
         expect(from_node.reload.to_classes).to be_empty
       end
 
+      context 'concurrent update' do
+        before do
+          allow(ActiveGraph::Base).to receive(:lock_node).and_wrap_original do |original, *args|
+            $concurrency_queue << 'ready'
+            Thread.stop
+            original.call(*args)
+            $concurrency_queue << Thread.current
+            Thread.stop
+          end
+        end
+        after { $concurrency_queue = nil }
+        let!(:from_node) { FromClass.create(name: 'foo') }
+        let!(:to_node) { ToClass.create(name: 'bar') }
+        let(:from_node_two) { FromClass.create(name: 'foo-2') }
+
+        it 'does not create duplicate has_one relationship' do
+          $concurrency_queue = Thread::Queue.new
+          t1 = Thread.new { to_node.update(from_class: from_node) }
+          t2 = Thread.new { to_node.update(from_class: from_node) }
+          sleep(0.1) until $concurrency_queue.size == 2
+          $concurrency_queue.clear
+          [t1, t2].each(&:run)
+          sleep(0.1) until $concurrency_queue.size == 1 && t1.status == 'sleep' && t2.status == 'sleep'
+          $concurrency_queue.pop.run
+          sleep(0.1) until !(t1.status && t2.status)
+
+          expect(ActiveGraph::Base.query("MATCH (node2:`ToClass`)<-[rel1:`HAS_REL`]-(from_class:`FromClass`) return from_class").to_a.size).to eq(1)
+          (t1.status == 'sleep' ? t1.run : t2.run).join
+          expect(ActiveGraph::Base.query("MATCH (node2:`ToClass`)<-[rel1:`HAS_REL`]-(from_class:`FromClass`) return from_class").to_a.size).to eq(1)
+        end
+
+        it 'does not create two rels with different nodes in has_one relationship' do
+          $concurrency_queue = Thread::Queue.new
+          t1 = Thread.new { to_node.update(from_class: from_node) }
+          t2 = Thread.new { to_node.update(from_class: from_node_two) }
+          sleep(0.1) until $concurrency_queue.size == 2
+          $concurrency_queue.clear
+          [t1, t2].each(&:run)
+          sleep(0.1) until $concurrency_queue.size == 1 && t1.status == 'sleep' && t2.status == 'sleep'
+          $concurrency_queue.pop.run
+          sleep(0.1) until !(t1.status && t2.status)
+
+          first_assigned_from_class, second_assigned_from_class = t1.status == 'sleep' ? [from_node_two, from_node] : [from_node, from_node_two]
+
+          expect(ToClass.find(to_node.id).from_class.id).to eq(first_assigned_from_class.id)
+          (t1.status == 'sleep' ? t1.run : t2.run).join
+
+          expect(to_node.reload.from_class.id).to eq(second_assigned_from_class.id)
+          expect(ActiveGraph::Base.query("MATCH (node2:`ToClass`)<-[rel1:`HAS_REL`]-(from_class:`FromClass`) return from_class").to_a.size).to eq(1)
+        end
+      end
+
       it 'delets has_one rel from from_node when new relation is created' do
         to_node_two = ToClass.new(name: 'bar-2')
         Rel2Class.new(from_node: from_node, to_node: to_node, score: 10).save

--- a/spec/e2e/relationship/persistence/query_factory_spec.rb
+++ b/spec/e2e/relationship/persistence/query_factory_spec.rb
@@ -105,52 +105,24 @@ describe ActiveGraph::Relationship::Persistence::QueryFactory do
 
       context 'concurrent update' do
         before do
-          allow(ActiveGraph::Base).to receive(:lock_node).and_wrap_original do |original, *args|
+          allow_any_instance_of(ActiveGraph::Node::Query::QueryProxy).to receive(:replace_with).and_wrap_original do |original, *args|
             $concurrency_queue << 'ready'
             Thread.stop
             original.call(*args)
-            $concurrency_queue << Thread.current
-            Thread.stop
           end
         end
         after { $concurrency_queue = nil }
         let!(:from_node) { FromClass.create(name: 'foo') }
         let!(:to_node) { ToClass.create(name: 'bar') }
-        let(:from_node_two) { FromClass.create(name: 'foo-2') }
 
         it 'does not create duplicate has_one relationship' do
+          count = 100
           $concurrency_queue = Thread::Queue.new
-          t1 = Thread.new { to_node.update(from_class: from_node) }
-          t2 = Thread.new { to_node.update(from_class: from_node) }
-          sleep(0.1) until $concurrency_queue.size == 2
+          threads = count.times.map { Thread.new { to_node.update(from_class: from_node) } }
+          sleep(0.1) until $concurrency_queue.size == count
           $concurrency_queue.clear
-          [t1, t2].each(&:run)
-          sleep(0.1) until $concurrency_queue.size == 1 && t1.status == 'sleep' && t2.status == 'sleep'
-          $concurrency_queue.pop.run
-          sleep(0.1) until !(t1.status && t2.status)
-
-          expect(ActiveGraph::Base.query("MATCH (node2:`ToClass`)<-[rel1:`HAS_REL`]-(from_class:`FromClass`) return from_class").to_a.size).to eq(1)
-          (t1.status == 'sleep' ? t1.run : t2.run).join
-          expect(ActiveGraph::Base.query("MATCH (node2:`ToClass`)<-[rel1:`HAS_REL`]-(from_class:`FromClass`) return from_class").to_a.size).to eq(1)
-        end
-
-        it 'does not create two rels with different nodes in has_one relationship' do
-          $concurrency_queue = Thread::Queue.new
-          t1 = Thread.new { to_node.update(from_class: from_node) }
-          t2 = Thread.new { to_node.update(from_class: from_node_two) }
-          sleep(0.1) until $concurrency_queue.size == 2
-          $concurrency_queue.clear
-          [t1, t2].each(&:run)
-          sleep(0.1) until $concurrency_queue.size == 1 && t1.status == 'sleep' && t2.status == 'sleep'
-          $concurrency_queue.pop.run
-          sleep(0.1) until !(t1.status && t2.status)
-
-          first_assigned_from_class, second_assigned_from_class = t1.status == 'sleep' ? [from_node_two, from_node] : [from_node, from_node_two]
-
-          expect(ToClass.find(to_node.id).from_class.id).to eq(first_assigned_from_class.id)
-          (t1.status == 'sleep' ? t1.run : t2.run).join
-
-          expect(to_node.reload.from_class.id).to eq(second_assigned_from_class.id)
+          threads.each(&:run)
+          threads.each(&:join)
           expect(ActiveGraph::Base.query("MATCH (node2:`ToClass`)<-[rel1:`HAS_REL`]-(from_class:`FromClass`) return from_class").to_a.size).to eq(1)
         end
       end


### PR DESCRIPTION
Fixes #1705 

This pull introduces/changes:
 * makes #replace_with method safe for concurrent use by locking node before read/update




