### PR TITLE
Zeitwerk autoload fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,6 @@ source 'http://rubygems.org'
 
 gemspec
 
-# gem 'neo4j-ruby-driver', path: '../neo4j-ruby-driver'
-
-# gem 'listen', '< 3.1'
-
 active_model_version = ENV['ACTIVE_MODEL_VERSION']
 gem 'activemodel', "~> #{active_model_version}" if active_model_version&.length&.positive?
 

--- a/docs/activegraph.rb
+++ b/docs/activegraph.rb
@@ -1,6 +1,6 @@
 # Usage: rails new myapp -m activegraph.rb
 
-gem 'activegraph', '=> 11.1'
+gem 'activegraph', '>= 11.1'
 
 gem_group :development do
   gem 'neo4j-rake_tasks'

--- a/lib/active_graph/railtie.rb
+++ b/lib/active_graph/railtie.rb
@@ -1,3 +1,5 @@
+require 'active_graph'
+
 module ActiveGraph
   class Railtie < ::Rails::Railtie
     def empty_config


### PR DESCRIPTION
Fixes #1702 

Problem:
1) From Rails application (which uses `active_graph` but do not explicitly load(require)it ) the `neo4j-ruby-driver` and other dependacies of `active_graph` are not loaded. So starting rails environment (by `rails s` , `rails c` or any of the rake task) results in uninitialized constant error of that dependancy.

2) generating new rails application using `rails new myapp -m activegraph.rb` was creating incorrect gemfile.

Solution:
1) Updated `railtie.rb` to require `active_graph` gem. The zeitwerk within `active_graph` will take care of loading all depending files and gems.

2) fixed the template which generated gemfile to use correct operator.

