### PR TITLE
Add numeral finder methods

### DIFF
--- a/lib/active_graph/node/query_methods.rb
+++ b/lib/active_graph/node/query_methods.rb
@@ -21,6 +21,36 @@ module ActiveGraph
         self.query_as(:n).limit(1).order(n: {primary_key => :desc}).pluck(:n).first
       end
 
+      # Returns the second node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
+      def second
+        self.query_as(:n).order(n: primary_key).limit(1).skip(1).pluck(:n).first
+      end
+
+      # Returns the third node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
+      def third
+        self.query_as(:n).order(n: primary_key).limit(1).skip(2).pluck(:n).first
+      end
+
+      # Returns the fourth node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
+      def fourth
+        self.query_as(:n).order(n: primary_key).limit(1).skip(3).pluck(:n).first
+      end
+
+      # Returns the fifth node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
+      def fifth
+        self.query_as(:n).order(n: primary_key).limit(1).skip(4).pluck(:n).first
+      end
+
+      # Returns the third to last node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
+      def third_to_last
+        self.query_as(:n).limit(1).order(n: {primary_key => :desc}).skip(2).pluck(:n).first
+      end
+
+      # Returns the second to last node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
+      def second_to_last
+        self.query_as(:n).limit(1).order(n: {primary_key => :desc}).skip(1).pluck(:n).first
+      end
+
       # @return [Integer] number of nodes of this class
       def count(distinct = nil)
         fail(ActiveGraph::InvalidParameterError, ':count accepts the `:distinct` symbol or nil as a parameter') unless distinct.nil? || distinct == :distinct

--- a/lib/active_graph/node/query_methods.rb
+++ b/lib/active_graph/node/query_methods.rb
@@ -96,20 +96,16 @@ module ActiveGraph
         end
       end
 
-      def find_nth(index, limit = 1)
+      def find_nth(index, limit = 1, order = primary_key)
         if limit == 1
-          self.query_as(:n).order(n: primary_key).limit(limit).skip(index).pluck(:n).first
+          self.query_as(:n).order(n: order).limit(limit).skip(index).pluck(:n).first
         else
-          self.query_as(:n).order(n: primary_key).limit(limit).skip(index).pluck(:n).first(limit)
+          self.query_as(:n).order(n: order).limit(limit).skip(index).pluck(:n).first(limit)
         end
       end
 
       def find_nth_from_last(index, limit = 1)
-        if limit == 1
-          self.query_as(:n).order(n: {primary_key => :desc}).limit(limit).skip(index).pluck(:n).first
-        else
-          self.query_as(:n).order(n: {primary_key => :desc}).limit(limit).skip(index).pluck(:n).first(limit)
-        end
+        find_nth(index, limit, {primary_key => :desc})
       end
     end
   end

--- a/lib/active_graph/node/query_methods.rb
+++ b/lib/active_graph/node/query_methods.rb
@@ -18,7 +18,7 @@ module ActiveGraph
 
       # Returns the last node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
       def last
-        self.query_as(:n).limit(1).order(n: {primary_key => :desc}).pluck(:n).first
+        find_nth_from_last(0)
       end
 
       # Returns the second node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
@@ -43,12 +43,12 @@ module ActiveGraph
 
       # Returns the third to last node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
       def third_to_last
-        self.query_as(:n).limit(1).order(n: {primary_key => :desc}).skip(2).pluck(:n).first
+        find_nth_from_last(2)
       end
 
       # Returns the second to last node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
       def second_to_last
-        self.query_as(:n).limit(1).order(n: {primary_key => :desc}).skip(1).pluck(:n).first
+        find_nth_from_last(1)
       end
 
       # @return [Integer] number of nodes of this class
@@ -96,6 +96,10 @@ module ActiveGraph
 
       def find_nth(index)
         self.query_as(:n).order(n: primary_key).limit(1).skip(index).pluck(:n).first
+      end
+
+      def find_nth_from_last(index)
+        self.query_as(:n).order(n: {primary_key => :desc}).limit(1).skip(index).pluck(:n).first
       end
     end
   end

--- a/lib/active_graph/node/query_methods.rb
+++ b/lib/active_graph/node/query_methods.rb
@@ -13,7 +13,7 @@ module ActiveGraph
 
       # Returns the first node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
       def first
-        self.query_as(:n).limit(1).order(n: primary_key).pluck(:n).first
+        find_nth(0)
       end
 
       # Returns the last node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
@@ -23,22 +23,22 @@ module ActiveGraph
 
       # Returns the second node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
       def second
-        self.query_as(:n).order(n: primary_key).limit(1).skip(1).pluck(:n).first
+        find_nth(1)
       end
 
       # Returns the third node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
       def third
-        self.query_as(:n).order(n: primary_key).limit(1).skip(2).pluck(:n).first
+        find_nth(2)
       end
 
       # Returns the fourth node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
       def fourth
-        self.query_as(:n).order(n: primary_key).limit(1).skip(3).pluck(:n).first
+        find_nth(3)
       end
 
       # Returns the fifth node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
       def fifth
-        self.query_as(:n).order(n: primary_key).limit(1).skip(4).pluck(:n).first
+        find_nth(4)
       end
 
       # Returns the third to last node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
@@ -92,6 +92,10 @@ module ActiveGraph
         else
           self.query_as(:n)
         end
+      end
+
+      def find_nth(index)
+        self.query_as(:n).order(n: primary_key).limit(1).skip(index).pluck(:n).first
       end
     end
   end

--- a/lib/active_graph/node/query_methods.rb
+++ b/lib/active_graph/node/query_methods.rb
@@ -11,14 +11,16 @@ module ActiveGraph
         !!result
       end
 
-      # Returns the first node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
-      def first
-        find_nth(0)
+      # Returns the first node (or first N nodes if a parameter is supplied) of this class, sorted by ID.
+      # Note that this may not be the first node created since Neo4j recycles IDs.
+      def first(limit = 1)
+        find_nth(0, limit)
       end
 
-      # Returns the last node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
-      def last
-        find_nth_from_last(0)
+      # Returns the last node (or last N nodes if a parameter is supplied) of this class, sorted by ID.
+      # Note that this may not be the first node created since Neo4j recycles IDs.
+      def last(limit = 1)
+        find_nth_from_last(0, limit)
       end
 
       # Returns the second node of this class, sorted by ID. Note that this may not be the first node created since Neo4j recycles IDs.
@@ -94,12 +96,20 @@ module ActiveGraph
         end
       end
 
-      def find_nth(index)
-        self.query_as(:n).order(n: primary_key).limit(1).skip(index).pluck(:n).first
+      def find_nth(index, limit = 1)
+        if limit == 1
+          self.query_as(:n).order(n: primary_key).limit(limit).skip(index).pluck(:n).first
+        else
+          self.query_as(:n).order(n: primary_key).limit(limit).skip(index).pluck(:n).first(limit)
+        end
       end
 
-      def find_nth_from_last(index)
-        self.query_as(:n).order(n: {primary_key => :desc}).limit(1).skip(index).pluck(:n).first
+      def find_nth_from_last(index, limit = 1)
+        if limit == 1
+          self.query_as(:n).order(n: {primary_key => :desc}).limit(limit).skip(index).pluck(:n).first
+        else
+          self.query_as(:n).order(n: {primary_key => :desc}).limit(limit).skip(index).pluck(:n).first(limit)
+        end
       end
     end
   end

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -177,11 +177,14 @@ describe 'query_proxy_methods' do
     end
   end
 
-  describe 'first and last' do
+  describe 'numeral finder methods (first, last, etc.)' do
     it 'returns different objects' do
-      Student.create
+      5.times { Student.create }
       expect(Student.all.count).to be > 1
       expect(Student.all.first).to_not eq(Student.all.last)
+      expect(Student.all.second).to_not eq(Student.all.second_to_last)
+      expect(Student.all.third).to_not eq(Student.all.third_to_last)
+      expect(Student.all.fourth).to_not eq(Student.all.fifth)
     end
 
     it 'returns objects across multiple associations' do

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -187,6 +187,13 @@ describe 'query_proxy_methods' do
       expect(Student.all.fourth).to_not eq(Student.all.fifth)
     end
 
+    it 'allows to specify limit for first and last methods' do
+      Student.create
+      expect(Student.all.count).to be > 1
+      expect(Student.first(2)).to eq([Student.all.first, Student.all.second])
+      expect(Student.last(2)).to eq([Student.all.last, Student.all.second_to_last])
+    end
+
     it 'returns objects across multiple associations' do
       jimmy.lessons << science
       science.teachers << mr_adams


### PR DESCRIPTION
Hello
I've been using active graph for some time and one thing that bothered me from the start was the absence of finder methods like `second` or `third`. This PR aims to add them. I've taken inspiration from [rails repository](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation/finder_methods.rb#L173)

This pull introduces/changes:
 * Adds `second`, `third`, `fourth` and `fifth` methods to query records 'from the start'
 * Adds `second_to_last` and `third_to_last` methods to query records 'from the end'
 * Adds optional argument `limit` to `first` and `last` methods to return more than one record

In `find_nth`, conditional is necessary. If we have only one branch and always use `limit`, in the case of `limit = 1` it doesn't work. `first(1)` returns one record as an array, not a singular object.



