### PR TITLE
Update persistence.rb

### DIFF
--- a/lib/active_graph/shared/persistence.rb
+++ b/lib/active_graph/shared/persistence.rb
@@ -144,7 +144,7 @@ module ActiveGraph::Shared
 
     # @return [Hash] all defined and none nil properties
     def props
-      attributes.reject { |_, v| v.nil? }.symbolize_keys
+      attributes.compact.transform_keys(&:to_sym)
     end
 
     # @return true if the attributes hash has been frozen


### PR DESCRIPTION
Tiny change to `props` method that hopefully speeds it up.

This pull introduces/changes:
 *  Speeds up ActiveGraph::Shared::Persistence#props method by calling `compact` instead of looping through values with `reject`


```
require "benchmark/ips"
require "active_support/core_ext/hash/keys"

h = {"a" => 1, "b" => nil}

def compact_symbol(h)
  h.compact.transform_keys(&:to_sym)
end

def reject_symb(h)
  h.reject { |_, v| v.nil? }.symbolize_keys
end

Benchmark.ips do |x|
  x.report("with compact + transform keys") { compact_symbol(h) }
  x.report("reject + symbolize keys") { reject_symb(h) }
  x.compare!
end


ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin22]
Warming up --------------------------------------
with compact + transform keys
                       531.162k i/100ms
reject + symbolize keys
                       385.490k i/100ms
Calculating -------------------------------------
with compact + transform keys
                          5.238M (± 0.7%) i/s -     26.558M in   5.070284s
reject + symbolize keys
                          3.892M (± 1.0%) i/s -     19.660M in   5.051196s

Comparison:
with compact + transform keys:  5238259.6 i/s
reject + symbolize keys:  3892499.0 i/s - 1.35x  slower
```
