### PR TITLE
Update rollback syntax in Testing doc

### DIFF
--- a/docs/Testing.rst
+++ b/docs/Testing.rst
@@ -86,7 +86,7 @@ If you are using RSpec you can perform tests in a transaction as you would using
   config.around do |example|
     ActiveGraph::Base.transaction do |tx|
       example.run
-      tx.failure
+      tx.rollback if tx.open?
     end
   end
 


### PR DESCRIPTION
When using the suggested code from [the documentation](https://neo4jrb.readthedocs.io/en/stable/Testing.html):

```ruby
# For the `neo4j` gem
config.around do |example|
  ActiveGraph::Base.transaction do |tx|
    example.run
    tx.failure
  end
end
```

We get this error:

```ruby
NoMethodError:
       undefined method `failure' for an instance of Neo4j::Driver::Internal::InternalTransaction
```

The syntax is apparently now `tx.rollback`, however when the transaction has already been rolled back we get this error

```ruby
     Neo4j::Driver::Exceptions::ClientException:
       Can't rollback, transaction has been rolled back
```

This pull request changes the documention to recommend:
 * Usage of the new syntax for rollback
 * A check to see if the transaction is open before rolling it back