### PR TITLE
Fix rollback exception propagating

### DIFF
--- a/lib/active_graph/transaction.rb
+++ b/lib/active_graph/transaction.rb
@@ -12,6 +12,10 @@ module ActiveGraph
       after_commit_registry.each(&:call)
     end
 
+    def clear_callbacks
+      after_commit_registry.clear
+    end
+
     private
 
     def after_commit_registry

--- a/lib/active_graph/transactions.rb
+++ b/lib/active_graph/transactions.rb
@@ -40,6 +40,7 @@ module ActiveGraph
 
         yield tx
       rescue ActiveGraph::Rollback
+        tx.clear_callbacks
         false
       end
 

--- a/lib/active_graph/transactions.rb
+++ b/lib/active_graph/transactions.rb
@@ -35,11 +35,12 @@ module ActiveGraph
       private
 
       def send_transaction(method, **config, &block)
-        return yield tx if tx
-        return run_transaction_work(explicit_session, method, **config, &block) if explicit_session&.open?
-        driver.session do |session|
-          run_transaction_work(session, method, **config, &block)
-        end
+        return run_transaction_work(explicit_session, method, **config, &block) if !tx && explicit_session&.open?
+        return driver.session { |session| run_transaction_work(session, method, **config, &block) } unless tx
+
+        yield tx
+      rescue ActiveGraph::Rollback
+        false
       end
 
       def run_transaction_work(session, method, **config, &block)

--- a/spec/active_graph/transactions_spec.rb
+++ b/spec/active_graph/transactions_spec.rb
@@ -122,4 +122,14 @@ describe ActiveGraph::Transactions do
       end
     end
   end
+
+  describe 'rollback in nested transaction' do
+    it 'returns false from the inner transaction when rollback is called' do
+      inner_result = nil
+      ActiveGraph::Base.transaction do
+        inner_result = ActiveGraph::Base.transaction(&:rollback)
+      end
+      expect(inner_result).to eq false
+    end
+  end
 end

--- a/spec/active_graph/transactions_spec.rb
+++ b/spec/active_graph/transactions_spec.rb
@@ -124,12 +124,20 @@ describe ActiveGraph::Transactions do
   end
 
   describe 'rollback in nested transaction' do
-    it 'returns false from the inner transaction when rollback is called' do
-      inner_result = nil
-      ActiveGraph::Base.transaction do
-        inner_result = ActiveGraph::Base.transaction(&:rollback)
+    it 'allows reading model errors after failed update inside an outer transaction' do
+      stub_node_class('ValidatedStudent') do
+        property :name
+        validates :name, presence: true
       end
-      expect(inner_result).to eq false
+
+      student = ValidatedStudent.create!(name: 'Alice')
+
+      errors = ActiveGraph::Base.transaction do
+        student.update(name: nil)
+        student.errors.full_messages
+      end
+
+      expect(errors).to include("Name can't be blank")
     end
   end
 end


### PR DESCRIPTION
Changes in `Transaction#rollback` #1736 lead to the issue with a dependent app's ability to handle failed validation, resulting in HTTP 200 in places where HTTP 422 was before. This PR restores the behavior.