### PR TITLE
Refactored transaction rollback handling

### DIFF
--- a/lib/active_graph/transaction.rb
+++ b/lib/active_graph/transaction.rb
@@ -1,7 +1,11 @@
 module ActiveGraph
   module Transaction
     def rollback
-      fail ActiveGraph::Rollback
+      @rolled_back = true
+    end
+
+    def check_rollback
+      fail ActiveGraph::Rollback if @rolled_back
     end
 
     def after_commit(&block)

--- a/lib/active_graph/transactions.rb
+++ b/lib/active_graph/transactions.rb
@@ -42,23 +42,26 @@ module ActiveGraph
         end
       end
 
-      def run_transaction_work(session, method, **config, &block)
-        implicit = config.delete(:implicit)
+      def run_transaction_work(session, method, implicit: false, **config, &block)
+        result = nil
         session.send(method, **config) do |tx|
           self.tx = tx
-          block.call(tx).tap do |result|
-            if implicit &&
-              [Core::Result, ActiveGraph::Node::Query::QueryProxy, ActiveGraph::Core::Query]
-                .any?(&result.method(:is_a?))
-              result.store
-            end
+          (result = block.call(tx)).tap do
+            store(it) if implicit
+            tx.check_rollback
           end
         end.tap { tx.apply_callbacks }
       rescue ActiveGraph::Rollback
         # rollbacks are silently swallowed
-        false # to satisfy save and update conventions
+        result
       ensure
         self.tx = nil
+      end
+
+      def store(result)
+        if [Core::Result, ActiveGraph::Node::Query::QueryProxy, ActiveGraph::Core::Query].any?(&result.method(:is_a?))
+          result.store
+        end
       end
     end
   end

--- a/spec/active_graph/transactions_spec.rb
+++ b/spec/active_graph/transactions_spec.rb
@@ -122,4 +122,33 @@ describe ActiveGraph::Transactions do
       end
     end
   end
+
+  describe 'rollback in nested transaction' do
+    it 'returns the result from the inner transaction when rollback is called' do
+      inner_result = nil
+      ActiveGraph::Base.transaction do
+        inner_result = ActiveGraph::Base.transaction do |tx|
+          tx.rollback
+          'inner result'
+        end
+      end
+      expect(inner_result).to eq 'inner result'
+    end
+
+    it 'allows reading model errors after failed update inside an outer transaction' do
+      stub_node_class('ValidatedStudent') do
+        property :name
+        validates :name, presence: true
+      end
+
+      student = ValidatedStudent.create!(name: 'Alice')
+
+      errors = ActiveGraph::Base.transaction do
+        student.update(name: nil)
+        student.errors.full_messages
+      end
+
+      expect(errors).to include("Name can't be blank")
+    end
+  end
 end


### PR DESCRIPTION
Let's the transaction block execute completely and rolls back at the end of the execution if marked for rollback. Ensures the transaction block return value is passed to the caller even in case of a rollback for backwards compatibility. But it allows as well modern managed transaction handling by explicitly raising an exception if the block return value is not needed.


