### PR TITLE
Add ids method as in AR

### DIFF
--- a/lib/active_graph/node/query/query_proxy_methods.rb
+++ b/lib/active_graph/node/query/query_proxy_methods.rb
@@ -270,6 +270,11 @@ module ActiveGraph
           end.first
         end
 
+        # @return [Array] An array of primary key values
+        def ids
+          pluck(association_id_key)
+        end
+
         # @return [String] The primary key of a the current QueryProxy's model or target class
         def association_id_key
           self.association.nil? ? model.primary_key : self.association.target_class.primary_key

--- a/lib/active_graph/node/query/query_proxy_methods.rb
+++ b/lib/active_graph/node/query/query_proxy_methods.rb
@@ -272,7 +272,7 @@ module ActiveGraph
 
         # @return [Array] An array of primary key values
         def ids
-          pluck(association_id_key)
+          query.pluck(identity => association_id_key)
         end
 
         # @return [String] The primary key of a the current QueryProxy's model or target class

--- a/lib/active_graph/node/query_methods.rb
+++ b/lib/active_graph/node/query_methods.rb
@@ -49,6 +49,13 @@ module ActiveGraph
         end
       end
 
+      # Returns an array of all the IDs (primary key values) of the model's nodes.
+      # ActiveRecord-compatible shortcut for `pluck(primary_key)`.
+      # @return [Array] An array of primary key values
+      def ids
+        self.all.ids
+      end
+
       private
 
       def exists_query_start(condition)

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -470,6 +470,34 @@ describe 'query_proxy_methods' do
     it 'returns an empty array when there are no matches' do
       expect(Lesson.where(name: 'nope').ids).to eq([])
     end
+
+    context 'when the association target uses a custom id_property' do
+      before(:each) do
+        stub_node_class('Book') do
+          id_property :book_id, on: :generate_book_id
+          property :title
+          has_many :in, :owners, model_class: 'Reader', origin: :books
+          def generate_book_id
+            "book-#{SecureRandom.hex(4)}"
+          end
+        end
+
+        stub_node_class('Reader') do
+          property :name
+          has_many :out, :books, model_class: 'Book', type: 'OWNS'
+        end
+
+        @reader = Reader.create(name: 'Ada')
+        @b1 = Book.create(title: 'A')
+        @b2 = Book.create(title: 'B')
+        @reader.books << @b1
+        @reader.books << @b2
+      end
+
+      it 'uses the target class primary key when traversing an association' do
+        expect(@reader.books.ids).to match_array([@b1.book_id, @b2.book_id])
+      end
+    end
   end
 
   describe 'distinct' do

--- a/spec/e2e/query_proxy_methods_spec.rb
+++ b/spec/e2e/query_proxy_methods_spec.rb
@@ -444,6 +444,34 @@ describe 'query_proxy_methods' do
     end
   end
 
+  describe 'ids' do
+    before(:each) do
+      [Student, Lesson].each(&:delete_all)
+
+      @john = Student.create(name: 'John')
+      @history = Lesson.create(name: 'history')
+      @math2 = Lesson.create(name: 'math2')
+      @john.lessons << @history
+      @john.lessons << @math2
+    end
+
+    it 'returns the ids of nodes on the class' do
+      expect(Lesson.ids).to match_array([@history.id, @math2.id])
+    end
+
+    it 'returns the ids of nodes on a query proxy association' do
+      expect(@john.lessons.ids).to match_array([@history.id, @math2.id])
+    end
+
+    it 'returns the ids of nodes on a where chain' do
+      expect(Lesson.where(name: 'history').ids).to eq([@history.id])
+    end
+
+    it 'returns an empty array when there are no matches' do
+      expect(Lesson.where(name: 'nope').ids).to eq([])
+    end
+  end
+
   describe 'distinct' do
     let(:frank) { Student.create(name: 'Frank') }
     let(:bill) { Teacher.create(name: 'Bill') }


### PR DESCRIPTION
ActiveRecord has `Model.ids` (and `relation.ids`) as a shortcut for `pluck(primary_key)`. It's a tiny method, but it shows up everywhere.

ActiveGraph tries to feel like ActiveRecord where it can. Right now, people coming from AR can't write `Model.ids` and are forced to fall back to `pluck(:id)` or `pluck(:uuid)`, which means knowing whether the model uses `:id`, `:uuid`, or a custom id_property. The same goes for chains like `user.posts.ids`.

Adding `#ids` on the model and on QueryProxy fixes that:

 - AR habits just work
 - callers don't have to care what the primary key is named
 - automated code quality and analysis tools don't complain about using `pluck(:id)`
